### PR TITLE
Provide info on our KEDA dashboard

### DIFF
--- a/content/_index/features/dashboard.md
+++ b/content/_index/features/dashboard.md
@@ -1,0 +1,9 @@
++++
+title = "Dashboard"
+weight = 60
+
+[asset]
+  icon = "fas fa-chart-area"
++++
+
+Dashboard to view details of your deployments & jobs ([opt-in](https://github.com/kedacore/dashboard))

--- a/content/deploy.md
+++ b/content/deploy.md
@@ -5,16 +5,22 @@ fragment = "content"
 weight = 100
 +++
 
-We provide a few approaches to deploy KEDA in your Kubernetes clusters:
+KEDA consists of two components - [Runtime](#runtime) & [Dashboard](#dashboard).
+
+You'll find steps how to deploy them in this article.
+
+## Runtime
+
+We provide a few approaches to deploy KEDA runtime in your Kubernetes clusters:
 
 - Operator framework
 - Helm charts
 - Azure Function Core Tool
 - YAML declarations
 
-Don't see what you need? Feel free to [create an issue]() on our GitHub repo.
+Don't see what you need? Feel free to [create an issue](https://github.com/kedacore/keda/issues/new) on our GitHub repo.
 
-## Deploying with a Helm chart
+### Deploying with a Helm chart
 
 Deploying KEDA with Helm is very simple:
 
@@ -37,7 +43,7 @@ helm install kedacore/keda-edge --devel --set logLevel=debug --namespace keda --
 
 You can use our ARM image instead by adding `--set image.tag=arm` to your helm install command.
 
-## Deploying with the Azure Functions Core Tools
+### Deploying with the Azure Functions Core Tools
 KEDA supports autoscaling a variety of workloads which include Azure Functions and is included in their [Azure Functions Core Tools](https://github.com/Azure/azure-functions-core-tools).
 
 Here is how you can easily install KEDA with their CLI:
@@ -45,7 +51,7 @@ Here is how you can easily install KEDA with their CLI:
 func kubernetes install --namespace keda
 ```
 
-## Deploying using the deploy yaml
+### Deploying using the deploy yaml
 If you want to try KEDA on minikube or a different Kubernetes deployment without using Helm you can still deploy it with `kubectl`.
 
 We provide sample YAML declarations which includes our CRD - You can find them in our `/deploy` directory on our [GitHub repo](https://github.com/kedacore/keda).
@@ -54,4 +60,14 @@ We provide sample YAML declarations which includes our CRD - You can find them i
 kubectl apply -f deploy/crds/keda.k8s.io_scaledobjects_crd.yaml
 kubectl apply -f deploy/crds/keda.k8s.io_triggerauthentications_crd.yaml
 kubectl apply -f deploy/
+```
+
+## Dashboard
+
+You can install the KEDA dashboard by using the deployment YAML in the repo:
+
+```
+git clone https://github.com/kedacore/dashboard
+cd dashboard
+kubectl apply -f deploy/keda-dashboard.yaml
 ```


### PR DESCRIPTION
Provide info on our KEDA dashboard as a feature and how to deploy it.

Deployment is minimal for now until we have a Helm chart which should be our recommended approach. Once we have that, we can update the docs or provide a dedicated deployment page for that.

Relates to https://github.com/kedacore/keda/issues/167