### PR TITLE
removing references to dashboard

### DIFF
--- a/content/_index/features/dashboard.md
+++ b/content/_index/features/dashboard.md
@@ -1,9 +1,0 @@
-+++
-title = "Dashboard"
-weight = 60
-
-[asset]
-  icon = "fas fa-chart-area"
-+++
-
-Dashboard to view details of your deployments & jobs ([opt-in](https://github.com/kedacore/dashboard))

--- a/content/deploy.md
+++ b/content/deploy.md
@@ -5,15 +5,8 @@ fragment = "content"
 weight = 100
 +++
 
-KEDA consists of two components - [Runtime](#runtime) & [Dashboard](#dashboard).
-
-You'll find steps how to deploy them in this article.
-
-## Runtime
-
 We provide a few approaches to deploy KEDA runtime in your Kubernetes clusters:
 
-- Operator framework
 - Helm charts
 - Azure Function Core Tools
 - YAML declarations
@@ -67,16 +60,6 @@ kubectl create namespace keda
 kubectl apply -f deploy/crds/keda.k8s.io_scaledobjects_crd.yaml
 kubectl apply -f deploy/crds/keda.k8s.io_triggerauthentications_crd.yaml
 kubectl apply -f deploy/
-```
-
-## Dashboard
-
-You can install the KEDA dashboard by using the deployment YAML in the repo:
-
-```
-git clone https://github.com/kedacore/dashboard
-cd dashboard
-kubectl apply -f deploy/keda-dashboard.yaml
 ```
 
 <br/><br/>


### PR DESCRIPTION
I'm fairly confident with the latest changes of v1.0 and operator SDK the dashboard is non-functional.  Created an issue to track with help wanted flag

https://github.com/kedacore/dashboard/issues/14

@Aarthisk in case she can confirm or not if that makes sense