### PR TITLE
Provide capability to subscribe for standup

### DIFF
--- a/content/_index/community.md
+++ b/content/_index/community.md
@@ -10,7 +10,7 @@ particles = true
 ### Community
 If interested in contributing or participating in the direction of KEDA, you can join our community meetings.
 
-* **Meeting time:** Weekly Thurs 18:00 UTC. *([Subscribe to Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*.
+* **Meeting time:** Bi-weekly Thurs 18:00 UTC. *([Subscribe to Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*.
 * **Zoom link:** [https://zoom.us/j/150360492 ](https://zoom.us/j/150360492 )
 * **Meeting agenda:** [https://hackmd.io/s/r127ErYiN](https://hackmd.io/s/r127ErYiN)
 

--- a/content/_index/community.md
+++ b/content/_index/community.md
@@ -10,7 +10,7 @@ particles = true
 ### Community
 If interested in contributing or participating in the direction of KEDA, you can join our community meetings.
 
-* **Meeting time:** Bi-weekly Thurs 18:00 UTC. *([Subscribe to Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*.
+* **Meeting time:** Weekly Thurs 18:00 UTC. *([Subscribe to Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*.
 * **Zoom link:** [https://zoom.us/j/150360492 ](https://zoom.us/j/150360492 )
 * **Meeting agenda:** [https://hackmd.io/s/r127ErYiN](https://hackmd.io/s/r127ErYiN)
 

--- a/content/_index/standup.md
+++ b/content/_index/standup.md
@@ -1,6 +1,5 @@
 +++
 fragment = "content"
-#disabled = true
 date = "2016-09-07"
 weight = 300
 background = "light" # can influence the text color
@@ -10,6 +9,6 @@ particles = true
 ### Community Standup
 If interested in contributing or participating in the direction of KEDA, you can join our community meetings.
 
-* Meeting time: Weekly Thurs 18:00 UTC. [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC).
-* Zoom link: [https://zoom.us/j/150360492 ](https://zoom.us/j/150360492 )
-* Meeting agenda: [https://hackmd.io/s/r127ErYiN](https://hackmd.io/s/r127ErYiN)
+* **Meeting time:** Weekly Thurs 18:00 UTC. *([Subscribe to Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*.
+* **Zoom link:** [https://zoom.us/j/150360492 ](https://zoom.us/j/150360492 )
+* **Meeting agenda:** [https://hackmd.io/s/r127ErYiN](https://hackmd.io/s/r127ErYiN)


### PR DESCRIPTION
Provide capability to subscribe for standup meetings via Google Calendar.

This allows folks to just pull in the agenda in their calendar client and see if there is a meeting or not, for example when it's cancelled due to Thanksgiving.

Relates to https://github.com/kedacore/keda/issues/472
Relates to https://github.com/kedacore/keda/issues/502