### PR TITLE
Added default value for lag on Kafka scaler

### DIFF
--- a/content/scalers/apache-kafka-topic.md
+++ b/content/scalers/apache-kafka-topic.md
@@ -27,7 +27,7 @@ This specification describes the `kafka` trigger for Apache Kafka Topic.
 
 **Parameter list:**
 
-- `lagThreshold` Optional. How much the stream is lagging on the current consumer group
+- `lagThreshold` Optional. How much the stream is lagging on the current consumer group. Default is 10.
 
 ### Authentication Parameters
 


### PR DESCRIPTION
This PR adds the default value (10) for the `lagThreshold` parameter in the Kafka scaler.