### PR TITLE
Changed from brokerList to bootstrapServers

### DIFF
--- a/content/scalers/apache-kafka-topic.md
+++ b/content/scalers/apache-kafka-topic.md
@@ -19,6 +19,7 @@ This specification describes the `kafka` trigger for Apache Kafka Topic.
   triggers:
   - type: kafka
     metadata:
+      # brokerList: kafka.svc:9092 - deprecated
       bootstrapServers: kafka.svc:9092
       consumerGroup: my-group
       topic: test-topic
@@ -63,6 +64,7 @@ spec:
   - type: kafka
     metadata:
       # Required
+      # brokerList: kafka.svc:9092 - deprecated
       bootstrapServers: localhost:9092
       consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
       topic: test-topic
@@ -127,6 +129,7 @@ spec:
   - type: kafka
     metadata:
       # Required
+      # brokerList: kafka.svc:9092 - deprecated
       bootstrapServers: localhost:9092
       consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
       topic: test-topic

--- a/content/scalers/apache-kafka-topic.md
+++ b/content/scalers/apache-kafka-topic.md
@@ -19,7 +19,7 @@ This specification describes the `kafka` trigger for Apache Kafka Topic.
   triggers:
   - type: kafka
     metadata:
-      brokerList: kafka.svc:9092
+      bootstrapServers: kafka.svc:9092
       consumerGroup: my-group
       topic: test-topic
       lagThreshold: '5'
@@ -63,9 +63,10 @@ spec:
   - type: kafka
     metadata:
       # Required
-      brokerList: localhost:9092
+      bootstrapServers: localhost:9092
       consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
       topic: test-topic
+      # Optional
       lagThreshold: "50"
 ```
 
@@ -126,9 +127,10 @@ spec:
   - type: kafka
     metadata:
       # Required
-      brokerList: localhost:9092
+      bootstrapServers: localhost:9092
       consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
       topic: test-topic
+      # Optional
       lagThreshold: "50"
     authenticationRef:
       name: keda-trigger-auth-kafka-credential

--- a/content/scalers/apache-kafka-topic.md
+++ b/content/scalers/apache-kafka-topic.md
@@ -28,6 +28,7 @@ This specification describes the `kafka` trigger for Apache Kafka Topic.
 
 **Parameter list:**
 
+- `brokerList`: comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap (DEPRECATED).
 - `bootstrapServers`: comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup`: consumer group used for checking the offset on the topic and processing the related lag.
 - `topic`: topic on which processing the offset lag.

--- a/content/scalers/apache-kafka-topic.md
+++ b/content/scalers/apache-kafka-topic.md
@@ -28,7 +28,10 @@ This specification describes the `kafka` trigger for Apache Kafka Topic.
 
 **Parameter list:**
 
-- `lagThreshold` Optional. How much the stream is lagging on the current consumer group. Default is 10.
+- `bootstrapServers`: comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
+- `consumerGroup`: consumer group used for checking the offset on the topic and processing the related lag.
+- `topic`: topic on which processing the offset lag.
+- `lagThreshold` How much the stream is lagging on the current consumer group. Default is 10. Optional.
 
 ### Authentication Parameters
 
@@ -63,8 +66,6 @@ spec:
   triggers:
   - type: kafka
     metadata:
-      # Required
-      # brokerList: kafka.svc:9092 - deprecated
       bootstrapServers: localhost:9092
       consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
       topic: test-topic
@@ -128,8 +129,6 @@ spec:
   triggers:
   - type: kafka
     metadata:
-      # Required
-      # brokerList: kafka.svc:9092 - deprecated
       bootstrapServers: localhost:9092
       consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
       topic: test-topic


### PR DESCRIPTION
This is the documentation PR related to the https://github.com/kedacore/keda/pull/621
It changes the declaration of the bootstrap servers list from `brokerList` (deprecated) to `bootstrapServers`.