### PR TITLE
Revert "Add documenation for AWS pod identity providers"

### DIFF
--- a/content/concepts/authentication/content.md
+++ b/content/concepts/authentication/content.md
@@ -158,7 +158,7 @@ Currently we support the following:
 
 ```yaml
 podIdentity:
-  provider: none | azure | kiam | eks # Optional. Default: none
+  provider: none | azure # Optional. Default: none
 ```
 
 #### Azure Pod Identity
@@ -173,25 +173,3 @@ podIdentity:
 ```
 
 Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set aadPodIdentity={your-label-name}`.
-
-#### EKS Pod Identity Webhook for AWS
-
-[**EKS Pod Identity Webhook**](https://github.com/aws/amazon-eks-pod-identity-webhook), which is described more in depth [here](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/), allows you to provide the role name using an annotation on a service account associated with your pod.
-
-You can tell KEDA to use EKS Pod Identity Webhook via `podIdentity.provider`.
-
-```yaml
-podIdentity:
-  provider: aws-eks # Optional. Default: false
-```
-
-#### Kiam Pod Identity for AWS
-
-[**Kiam**](https://github.com/uswitch/kiam/) lets you bind an AWS IAM Role to a pod using an annotation on the pod.
-
-You can tell KEDA to use Kiam via `podIdentity.provider`.
-
-```yaml
-podIdentity:
-  provider: aws-kiam # Optional. Default: false
-```

--- a/content/scalers/aws-cloudwatch.md
+++ b/content/scalers/aws-cloudwatch.md
@@ -39,10 +39,6 @@ triggers:
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
-**Pod identity based authentication:**
-
-- `podIdentity.provider` needs to be set to either `aws-kiam` or `aws-eks` on the `TriggerAuthentication` and the pod/service account must be configured correctly for your pod identity provider.
-
 **Role based authentication:**
 
 - `awsRoleArn` - Amazon Resource Names (ARNs) uniquely identify AWS resource

--- a/content/scalers/aws-sqs.md
+++ b/content/scalers/aws-sqs.md
@@ -35,10 +35,6 @@ triggers:
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
-**Pod identity based authentication:**
-
-- `podIdentity.provider` needs to be set to either `aws-kiam` or `aws-eks` on the `TriggerAuthentication` and the pod/service account must be configured correctly for your pod identity provider.
-
 **Role based authentication:**
 
 - `awsRoleArn` - Amazon Resource Names (ARNs) uniquely identify AWS resource
@@ -48,7 +44,7 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by providi
 - `awsAccessKeyID` - Id of the user
 - `awsSecretAccessKey` - Access key for the user to authenticate with
 
-The user will need access to read properties from the specified AWS SQS queue.
+The user will need access to read data from AWS Cloudwatch.
 
 ### Example
 


### PR DESCRIPTION
Reverts kedacore/keda-docs#56 since https://github.com/kedacore/keda/pull/499 is not merged yet.