### PR TITLE
Fixing Apache Kafka topic naming

### DIFF
--- a/content/docs/concepts/scaling-deployments.md
+++ b/content/docs/concepts/scaling-deployments.md
@@ -11,7 +11,7 @@ It allows you to define the Kubernetes Deployment that you want KEDA to scale ba
 
 Behind the scenes, KEDA acts to monitor the event source and feed that data to Kubernetes and the HPA (Horizontal Pod Autoscaler) to drive rapid scale of a deployment.  Each replica of a deployment is actively pulling items from the event source.  With KEDA and scaling deployments you can scale based on events while also preserving rich connection and processing semantics with the event source (e.g. in-order processing, retries, deadletter, checkpointing).
 
-For example, if you wanted to use KEDA with an Apache Kafka Topic event source, the flow of information would be:
+For example, if you wanted to use KEDA with an Apache Kafka topic as event source, the flow of information would be:
 
 * When no messages are pending processing, KEDA can scale the deployment to zero.
 * When a message arrives, KEDA detects this event and activates the deployment.

--- a/content/scalers/apache-kafka.md
+++ b/content/scalers/apache-kafka.md
@@ -1,15 +1,15 @@
 +++
-title = "Apache Kafka Topic"
+title = "Apache Kafka"
 layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
-description = "Scale applications based on Apache Kafka Topic or other services that support Kafka protocol."
+description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
 go_file = "kafka_scaler"
 +++
 
 ### Trigger Specification
 
-This specification describes the `kafka` trigger for Apache Kafka Topic.
+This specification describes the `kafka` trigger for an Apache Kafka topic.
 
 ```yaml
 triggers:


### PR DESCRIPTION
This PR is mostly a cosmetic change about how using the Apache Kafka naming.
The doc talks about Apache Kafka Topic in the scalers menu as if it was the "project" name, which is not true. It's like saying that instead of having Azure Service Bus on the menu, we had Azure Service Bus Queue/Topic.
This PR highlight the scaler as an Apache Kafka based scaler also renaming the corresponding markdown file.