### PR TITLE
Clarify `cooldownPeriod` for Deployments.

### DIFF
--- a/content/docs/concepts/scaling-deployments.md
+++ b/content/docs/concepts/scaling-deployments.md
@@ -71,7 +71,9 @@ This is the interval to check each trigger on. By default KEDA will check each t
   cooldownPeriod:  300 # Optional. Default: 300 seconds
 ```
 
-The period to wait after the last trigger reported active before scaling the deployment back to 0. By default it's 5 minutes (300 seconds)
+The period to wait after the last trigger reported active before scaling the deployment back to 0. By default it's 5 minutes (300 seconds).
+
+The `cooldownPeriod` only applies after a trigger occurs; when you first create your `Deployment`, KEDA will immediately scale it to `minReplicaCount`.  Additionally, the KEDA `cooldownPeriod` only applies when scaling to 0; scaling from 1 to N replicas is handled by the [Kubernetes Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-cooldown-delay).
 
 **Example:** wait 5 minutes after the last time KEDA checked the queue and it was empty. (this is obviously dependent on `pollingInterval`)
 


### PR DESCRIPTION
Signed-off-by: Will Simpson <wsimpson@email.arizona.edu>

I was a little confused by the fact that KEDA will scale your Deployment to minReplicatCount immediately after it's created. I thought that it would wait for the cooldownPeriod to elapse before doing this. I realize the docs specify that cooldownPeriod is the period to wait after the last trigger and that when you first create a Deployment, nothing has triggered, but I think it would be helpful to tell say that explicitly.