### PR TITLE
Rename `Schedulers` to `Scalers`

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -22,8 +22,8 @@
       <br />
       <br />
 
-      <h2 id="available-schedulers">
-        Currently available schedulers for KEDA
+      <h2 id="available-scalers">
+        Currently available scalers for KEDA
       </h2>
       {{ partial "scalers.html" . }}
       {{ end }}


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>