### PR TITLE
Update the list of podIdentity.provider to match keda source

### DIFF
--- a/content/docs/1.4/concepts/authentication.md
+++ b/content/docs/1.4/concepts/authentication.md
@@ -93,7 +93,7 @@ metadata:
   namespace: default # must be same namespace as the ScaledObject
 spec:
   podIdentity:
-      provider: none | azure | gcp | spiffe # Optional. Default: none
+      provider: none | azure | gcp | spiffe | aws-eks | aws-kiam # Optional. Default: none
   secretTargetRef: # Optional.
   - parameter: {scaledObject-parameter-name} # Required.
     name: {secret-name} # Required.
@@ -153,7 +153,7 @@ Currently we support the following:
 
 ```yaml
 podIdentity:
-  provider: none | azure | kiam | eks # Optional. Default: none
+  provider: none | azure | gcp | spiffe | aws-eks | aws-kiam # Optional. Default: none
 ```
 
 #### Azure Pod Identity

--- a/content/docs/1.5/concepts/authentication.md
+++ b/content/docs/1.5/concepts/authentication.md
@@ -93,7 +93,7 @@ metadata:
   namespace: default # must be same namespace as the ScaledObject
 spec:
   podIdentity:
-      provider: none | azure | gcp | spiffe # Optional. Default: none
+      provider: none | azure | gcp | spiffe | aws-eks | aws-kiam # Optional. Default: none
   secretTargetRef: # Optional.
   - parameter: {scaledObject-parameter-name} # Required.
     name: {secret-name} # Required.
@@ -153,7 +153,7 @@ Currently we support the following:
 
 ```yaml
 podIdentity:
-  provider: none | azure | kiam | eks # Optional. Default: none
+  provider: none | azure | gcp | spiffe | aws-eks | aws-kiam # Optional. Default: none
 ```
 
 #### Azure Pod Identity

--- a/content/docs/2.0/concepts/authentication.md
+++ b/content/docs/2.0/concepts/authentication.md
@@ -93,7 +93,7 @@ metadata:
   namespace: default # must be same namespace as the ScaledObject
 spec:
   podIdentity:
-      provider: none | azure | gcp | spiffe # Optional. Default: none
+      provider: none | azure | gcp | spiffe | aws-eks | aws-kiam # Optional. Default: none
   secretTargetRef: # Optional.
   - parameter: {scaledObject-parameter-name} # Required.
     name: {secret-name} # Required.
@@ -153,7 +153,7 @@ Currently we support the following:
 
 ```yaml
 podIdentity:
-  provider: none | azure | kiam | eks # Optional. Default: none
+  provider: none | azure | gcp | spiffe | aws-eks | aws-kiam # Optional. Default: none
 ```
 
 #### Azure Pod Identity


### PR DESCRIPTION
While reading the authentication docs, I noticed that the supported podIdentity.provider values were inconsistent both in membership, and in spelling (of eks and kiam).

I sourced the revised list from here: https://github.com/kedacore/keda/blob/master/pkg/apis/keda/v1alpha1/triggerauthentication_types.go#L46

Also checked the version of that file in the v2 branch and it had the same provider list.