### PR TITLE
Correcting incorrect property reference for the mySQL scaler example

### DIFF
--- a/content/docs/1.4/scalers/mysql.md
+++ b/content/docs/1.4/scalers/mysql.md
@@ -79,5 +79,5 @@ spec:
       queryValue: "4"
       query: "SELECT CEIL(COUNT(*) / 6) FROM task_instance WHERE state='running' OR state='queued'"
     authenticationRef:
-      connectionString: keda-trigger-auth-mysql-secret
+      name: keda-trigger-auth-mysql-secret
 ```

--- a/content/docs/1.5/scalers/mysql.md
+++ b/content/docs/1.5/scalers/mysql.md
@@ -79,5 +79,5 @@ spec:
       queryValue: "4"
       query: "SELECT CEIL(COUNT(*) / 6) FROM task_instance WHERE state='running' OR state='queued'"
     authenticationRef:
-      connectionString: keda-trigger-auth-mysql-secret
+      name: keda-trigger-auth-mysql-secret
 ```

--- a/content/docs/2.0/scalers/mysql.md
+++ b/content/docs/2.0/scalers/mysql.md
@@ -79,5 +79,5 @@ spec:
       queryValue: "4"
       query: "SELECT CEIL(COUNT(*) / 6) FROM task_instance WHERE state='running' OR state='queued'"
     authenticationRef:
-      connectionString: keda-trigger-auth-mysql-secret
+      name: keda-trigger-auth-mysql-secret
 ```


### PR DESCRIPTION
The mySQL AuthenticationRef should use `name` (https://github.com/kedacore/keda/blob/1b38a7fe1fc7c05535c96955fd043a99e9fb22f1/deploy/crds/keda.k8s.io_scaledobjects_crd.yaml#L4506) instead of `connectionString`