### PR TITLE
[v2] adds doc for consumer offset reset policy option to keda kafka scaler

### DIFF
--- a/content/docs/2.0/scalers/apache-kafka.md
+++ b/content/docs/2.0/scalers/apache-kafka.md
@@ -20,7 +20,7 @@ triggers:
     consumerGroup: my-group
     topic: test-topic
     lagThreshold: '5'
-    consumerOffsetReset: earliest
+    offsetResetPolicy: latest
 ```
 
 **Parameter list:**
@@ -30,7 +30,7 @@ triggers:
 - `consumerGroup`: consumer group used for checking the offset on the topic and processing the related lag.
 - `topic`: topic on which processing the offset lag.
 - `lagThreshold` How much the stream is lagging on the current consumer group. Default is 10. Optional.
-- `consumerOffsetReset` the offset reset policy for the consumer. Can be other "earliest" or "latest". Default is "earliest".
+- `offsetResetPolicy` the offset reset policy for the consumer. Can be other "latest" or "latest". Default is "latest" as in Kafka Consumer defaults.
 
 ### Authentication Parameters
 
@@ -68,7 +68,7 @@ spec:
       topic: test-topic
       # Optional
       lagThreshold: "50"
-      consumerOffsetReset: earliest
+      offsetResetPolicy: latest
 ```
 
 Your kafka cluster turn on sasl auth
@@ -130,7 +130,7 @@ spec:
       topic: test-topic
       # Optional
       lagThreshold: "50"
-      consumerOffsetReset: earliest
+      offsetResetPolicy: latest
     authenticationRef:
       name: keda-trigger-auth-kafka-credential
 ```

--- a/content/docs/2.0/scalers/apache-kafka.md
+++ b/content/docs/2.0/scalers/apache-kafka.md
@@ -30,7 +30,7 @@ triggers:
 - `consumerGroup`: consumer group used for checking the offset on the topic and processing the related lag.
 - `topic`: topic on which processing the offset lag.
 - `lagThreshold` How much the stream is lagging on the current consumer group. Default is 10. Optional.
-- `offsetResetPolicy` the offset reset policy for the consumer. Can be other "latest" or "latest". Default is "latest" as in Kafka Consumer defaults.
+- `offsetResetPolicy` the offset reset policy for the consumer. Can be either "latest" or "earliest". Default is "latest" as in Kafka Consumer defaults.
 
 ### Authentication Parameters
 

--- a/content/docs/2.0/scalers/apache-kafka.md
+++ b/content/docs/2.0/scalers/apache-kafka.md
@@ -20,6 +20,7 @@ triggers:
     consumerGroup: my-group
     topic: test-topic
     lagThreshold: '5'
+    consumerOffsetReset: earliest
 ```
 
 **Parameter list:**
@@ -29,6 +30,7 @@ triggers:
 - `consumerGroup`: consumer group used for checking the offset on the topic and processing the related lag.
 - `topic`: topic on which processing the offset lag.
 - `lagThreshold` How much the stream is lagging on the current consumer group. Default is 10. Optional.
+- `consumerOffsetReset` the offset reset policy for the consumer. Can be other "earliest" or "latest". Default is "earliest".
 
 ### Authentication Parameters
 
@@ -66,6 +68,7 @@ spec:
       topic: test-topic
       # Optional
       lagThreshold: "50"
+      consumerOffsetReset: earliest
 ```
 
 Your kafka cluster turn on sasl auth
@@ -127,6 +130,7 @@ spec:
       topic: test-topic
       # Optional
       lagThreshold: "50"
+      consumerOffsetReset: earliest
     authenticationRef:
       name: keda-trigger-auth-kafka-credential
 ```


### PR DESCRIPTION
Signed-off-by: grassiale <alessandro.grassi01@gmail.com>

This is related to pr: https://github.com/kedacore/keda/pull/925