### PR TITLE
Remove localhost that is not used on ScaledJob

### DIFF
--- a/content/docs/2.0/concepts/scaling-jobs.md
+++ b/content/docs/2.0/concepts/scaling-jobs.md
@@ -104,7 +104,6 @@ metadata:
   name: rabbitmq-consumer
 data:
   RabbitMqHost: <omitted>
-  LocalHost: <omitted>
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
@@ -134,6 +133,5 @@ spec:
     metadata:
       queueName: hello
       host: RabbitMqHost
-      localhost: LocalHost
       queueLength  : '5'
 ```


### PR DESCRIPTION
I forget to remove `localhost` on the ScaledJob sample. 