### PR TITLE
Update ScaledJob migration page

### DIFF
--- a/content/docs/2.0/migration.md
+++ b/content/docs/2.0/migration.md
@@ -63,7 +63,6 @@ In order to scale `Jobs` with KEDA v2, you need to do only a few modifications t
 - Change the value of `kind` property from `ScaledObject` to `ScaledJob`
 - Remove property `spec.scaleType`
 - Remove properties `spec.cooldownPeriod` and `spec.minReplicaCount`   
-- Rename property `spec.scaleTargetRef.deploymentName` to `spec.scaleTargetRef.name`
 
 You can configure `successfulJobsHistoryLimit` and `failedJobsHistoryLimit`. They will remove the old job histories automatically.
 
@@ -95,11 +94,11 @@ spec:
 **Example of v2 ScaledJob**
 
 ```yaml
-apiVersion: keda.sh/v1alpha1
-kind: ScaledJob
+apiVersion: keda.sh/v1alpha1              #  <--- Property value was changed
+kind: ScaledJob                           #  <--- Property value was changed
 metadata:
   name: {scaled-job-name}
-spec:
+spec:                                     #  <--- spec.scaleType are not needed
   jobTargetRef:
     parallelism: 1 
     completions: 1 
@@ -107,9 +106,9 @@ spec:
     backoffLimit: 6
     template:
       # {job template}
-  pollingInterval: 30 
-  successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 5
+  pollingInterval: 30                     #  <--- spec.cooldownPeriod and spec.minReplicaCount are not needed
+  successfulJobsHistoryLimit: 5           #  <--- property is added
+  failedJobsHistoryLimit: 5               #  <--- Property is added
   maxReplicaCount: 100
   triggers:
   # {list of triggers to create jobs}

--- a/content/docs/2.0/migration.md
+++ b/content/docs/2.0/migration.md
@@ -38,6 +38,7 @@ spec:
 ```
 
 **Example of v2 ScaledObject**
+
 ```yaml
 apiVersion: keda.sh/v1alpha1                  #  <--- Property value was changed
 kind: ScaledObject
@@ -55,10 +56,16 @@ spec:
   # {list of triggers to activate the deployment}
 ```
 
-
 ### Scaling of Jobs
 
-TODO description
+In order to scale `Jobs` with KEDA v2, you need to do only a few modifications to existing v1 `ScaledObjects` definitions, so they comply with v2:
+- Change the value of `apiVersion` property from `keda.k8s.io/v1alpha1` to `keda.sh/v1alpha1`
+- Change the value of `kind` property from `ScaledObject` to `ScaledJob`
+- Remove property `spec.scaleType`
+- Remove properties `spec.cooldownPeriod` and `spec.minReplicaCount`   
+- Rename property `spec.scaleTargetRef.deploymentName` to `spec.scaleTargetRef.name`
+
+You can configure `successfulJobsHistoryLimit` and `failedJobsHistoryLimit`. They will remove the old job histories automatically.
 
 Please see the examples below or refer to the full [v2 ScaledJob Specification](../concepts/scaling-jobs/#scaledjob-spec)
 
@@ -87,8 +94,26 @@ spec:
 
 **Example of v2 ScaledJob**
 
-TODO
-
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: {scaled-job-name}
+spec:
+  jobTargetRef:
+    parallelism: 1 
+    completions: 1 
+    activeDeadlineSeconds: 600
+    backoffLimit: 6
+    template:
+      # {job template}
+  pollingInterval: 30 
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  maxReplicaCount: 100
+  triggers:
+  # {list of triggers to create jobs}
+```
 
 ### Scalers
  


### PR DESCRIPTION
I updated the ScaledJob documentation for v2 release. 

# What I've done 
- Add sample of V2 ScaledJob
- Add migration guide for V2