### PR TITLE
Fix formatting in KEDA 2.0 blog

### DIFF
--- a/content/blog/keda-2.0-beta.md
+++ b/content/blog/keda-2.0-beta.md
@@ -58,7 +58,7 @@ With our official release we will provide [migration scripts](https://github.com
 > 
 > KEDA comes with a metrics server and Kubernetes only allows you to run one of them in a cluster.
 > 
->_Learn more about how KEDA is architected in [our docs](http://keda.sh/docs/latest/concepts/#architecture)._
+>__Learn more about how KEDA is architected in [our docs](http://keda.sh/docs/latest/concepts/#architecture).__
 
 # Conclusion
 

--- a/content/blog/keda-2.0-beta.md
+++ b/content/blog/keda-2.0-beta.md
@@ -58,7 +58,7 @@ With our official release we will provide [migration scripts](https://github.com
 > 
 > KEDA comes with a metrics server and Kubernetes only allows you to run one of them in a cluster.
 > 
->__Learn more about how KEDA is architected in [our docs](http://keda.sh/docs/latest/concepts/#architecture).__
+>*Learn more about how KEDA is architected in [our docs](http://keda.sh/docs/latest/concepts/#architecture).*
 
 # Conclusion
 


### PR DESCRIPTION
Not sure if those `_` were expected to be there:
<img width="919" alt="Screenshot 2020-09-11 at 19 38 43" src="https://user-images.githubusercontent.com/9528307/92956034-79787380-f466-11ea-943b-d1c114387b94.png">
