### PR TITLE
feature[v2]: adding documentation regarding authentication in metric scalers

### DIFF
--- a/content/docs/2.0/scalers/metrics-api.md
+++ b/content/docs/2.0/scalers/metrics-api.md
@@ -33,25 +33,27 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication. API Key based authentication, basic authentication and TLS 
-authentication. You can use `TriggerAuthentication` CRD to configure the authentication by providing `authMode` along 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
+authentication. 
+
+You can use `TriggerAuthentication` CRD to configure the authentication by providing `authMode` along 
 with other necessary parameters as mentioned:
 
 **API Key based authentication:**
-- `authMode`: It must be set to `apiKeyAuth` in case of Basic Authentication.
+- `authMode`: It must be set to `apiKey` in case of API key Authentication.
 - `apiKey`: API Key needed for authentication.
 - `method`: This specifies the possible methods API Key based authentication supports. Possible values are `header` and `query`. `header` is the default method.
 - `keyParamName`: This is either header key or query param used for passing apikey. Default header is `X-API-KEY` and default query param is `api_key`. 
 If your implementation has different key, please specify it here.
 
 **Basic authentication:**
-- `authMode`: It must be set to `basicAuth` in case of Basic Authentication.
+- `authMode`: It must be set to `basic` in case of Basic Authentication.
 - `username`: This is a required field. Provide the username to be used for basic authentication.
 - `password`: Provide the password to be used for authentication. For convenience, this has been marked optional, 
 because many application implements basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must be set to `tlsAuth` in case of TLS Authentication.
+- `authMode`: It must be set to `tls` in case of TLS Authentication.
 - `ca`: Certificate authority file for TLS client authentication. This is a required field.
 - `cert`: Certificate for client authentication. This is a required field.
 - `key`: Key for client authentication. Optional. This is a required field.
@@ -103,7 +105,6 @@ Assuming such response, Metrics API trigger will figure out that current metric 
 For metric scaler with API Key based authentication,
 
 ```yaml
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -160,7 +161,6 @@ spec:
 For metric scaler with Basic Authentication, define the `Secret` and `TriggerAuthentication` as follows
 
 ```yaml
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -194,7 +194,6 @@ spec:
 For metric scaler with TLS Authentication, define the `Secret` and `TriggerAuthentication` as follows
 
 ```yaml
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -225,5 +224,4 @@ spec:
     - parameter: ca
       name: keda-metric-api-secret
       key: ca
-   
 ```

--- a/content/docs/2.0/scalers/metrics-api.md
+++ b/content/docs/2.0/scalers/metrics-api.md
@@ -33,7 +33,28 @@ triggers:
 
 ### Authentication Parameters
 
-Not supported yet.
+Metrics Scaler API supported three types of authentication. API Key based authentication, basic authentication and TLS 
+authentication. You can use `TriggerAuthentication` CRD to configure the authentication by providing `authMode` along 
+with other necessary parameters as mentioned:
+
+**API Key based authentication:**
+- `authMode`: It must be set to `apiKeyAuth` in case of Basic Authentication.
+- `apiKey`: API Key needed for authentication.
+- `method`: This specifies the possible methods API Key based authentication supports. Possible values are `header` and `query`. `header` is the default method.
+- `keyParamName`: This is either header key or query param used for passing apikey. Default header is `X-API-KEY` and default query param is `api_key`. 
+If your implementation has different key, please specify it here.
+
+**Basic authentication:**
+- `authMode`: It must be set to `basicAuth` in case of Basic Authentication.
+- `username`: This is a required field. Provide the username to be used for basic authentication.
+- `password`: Provide the password to be used for authentication. For convenience, this has been marked optional, 
+because many application implements basic auth with a username as apikey and password as empty.
+
+**TLS authentication:**
+- `authMode`: It must be set to `tlsAuth` in case of TLS Authentication.
+- `ca`: Certificate authority file for TLS client authentication. This is a required field.
+- `cert`: Certificate for client authentication. This is a required field.
+- `key`: Key for client authentication. Optional. This is a required field.
 
 ### Example
 
@@ -78,3 +99,131 @@ The above example expects that the API endpoint will return response similar to 
 Assuming such response, Metrics API trigger will figure out that current metric value is 12.
 
 > 💡 **NOTE:**The value of the metric must be json number type. The value is casted to **integer**.
+
+For metric scaler with API Key based authentication,
+
+```yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-metric-api-secret
+  namespace: default
+data:
+  authMode: "apiKeyAuth"
+  apiKey: "APIKEY" 
+  method: "query"
+  keyParamName: "QUERY_KEY"
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-metric-api-creds
+  namespace: default
+spec:
+  secretTargetRef:
+    - parameter: authMode
+      name: keda-metric-api-secret
+      key: authMode
+    - parameter: apiKey
+      name: keda-metric-api-secret
+      key: apiKey
+    - parameter: method
+      name: keda-metric-api-secret
+      key: method
+    - parameter: keyParamName
+      name: keda-metric-api-secret
+      key: keyParamName
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: http-scaledobject
+  namespace: keda
+  labels:
+    deploymentName: dummy
+spec:
+  maxReplicaCount: 12
+  scaleTargetRef:
+    name: dummy
+  triggers:
+    - type: metrics-api
+      metadata:
+        targetValue: "7"
+        url: "http://api:3232/components/stats"
+        valueLocation: 'components.worker.tasks'
+      authenticationRef:
+        name: keda-metric-api-creds
+
+```
+
+For metric scaler with Basic Authentication, define the `Secret` and `TriggerAuthentication` as follows
+
+```yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-metric-api-secret
+  namespace: default
+data:
+  authMode: "basicAuth" 
+  username: "username" 
+  password: "password"
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-metric-api-creds
+  namespace: default
+spec:
+  secretTargetRef:
+    - parameter: authMode
+      name: keda-metric-api-secret
+      key: authMode
+    - parameter: username
+      name: keda-metric-api-secret
+      key: username
+    - parameter: password
+      name: keda-metric-api-secret
+      key: password
+   
+```
+
+
+For metric scaler with TLS Authentication, define the `Secret` and `TriggerAuthentication` as follows
+
+```yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-metric-api-secret
+  namespace: default
+data:
+  authMode: "tlsAuth" 
+  cert: "cert" 
+  key: "key"
+  ca: "ca"
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-metric-api-creds
+  namespace: default
+spec:
+  secretTargetRef:
+    - parameter: authMode
+      name: keda-metric-api-secret
+      key: authMode
+    - parameter: cert
+      name: keda-metric-api-secret
+      key: cert
+    - parameter: key
+      name: keda-metric-api-secret
+      key: key
+    - parameter: ca
+      name: keda-metric-api-secret
+      key: ca
+   
+```


### PR DESCRIPTION
This is related to https://github.com/kedacore/keda/pull/1137 . Authentication methods for metric scaler api has been added. Currently supported authModes are API key-based authentication, Basic Authentication and TLS authentication.

Relates to https://github.com/kedacore/keda/issues/1082
Relates to https://github.com/kedacore/keda/issues/1083
Relates to https://github.com/kedacore/keda/issues/1084

Signed-off-by: aman-bansal <bansalaman2905@gmail.com>