### PR TITLE
Pod identity for Azure is now set through podIdentity.activeDirectory.identity

### DIFF
--- a/content/docs/2.0/concepts/authentication.md
+++ b/content/docs/2.0/concepts/authentication.md
@@ -200,7 +200,7 @@ podIdentity:
   provider: azure # Optional. Default: false
 ```
 
-Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set aadPodIdentity={your-label-name}`.
+Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set podIdentity.activeDirectory.identity={your-label-name}`.
 
 #### EKS Pod Identity Webhook for AWS
 


### PR DESCRIPTION
Pod identity for Azure is now set through podIdentity.activeDirectory.identity