### PR TITLE
Move community standup to bi-weekly Tues 17:00 UTC

### DIFF
--- a/content/resources.md
+++ b/content/resources.md
@@ -7,7 +7,6 @@ description = "Materials for learning more about KEDA"
 
 [KubeCon North America 2019](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019) presentation by [Jeff Hollan](https://twitter.com/jeffhollan).
 
-
 {{< youtube "ZK2SS_GXF-g" >}}
 
 ## Application Autoscaling Made Easy with Kubernetes Event-driven Autoscaling (KEDA)

--- a/includes/get-involved.md
+++ b/includes/get-involved.md
@@ -1,6 +1,6 @@
 If you're interested in contributing to or participating in the direction of KEDA, you can join our community meetings.
 
-* Meeting time: Bi-weekly Thurs 16:00 UTC (does follow US daylight savings). (Subscribe to [Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=04%3A00%20pm&tz=UTC))
+* Meeting time: Bi-weekly Tues 17:00 UTC (does follow US daylight savings). (Subscribe to [Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=04%3A00%20pm&tz=UTC))
 * Zoom link: https://us02web.zoom.us/j/150360492?pwd=eUVtQzBPMzFoQUR2K1dqUWhENjJJdz09 (Password: keda)
 * Meeting agenda: https://hackmd.io/s/r127ErYiN
 


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Move community standup to bi-weekly Tues 17:00 UTC which takes affect as of Nov 9th with our first standup on Nov 10th.

Relates to https://github.com/kedacore/keda/issues/1269