### PR TITLE
Fix RabbitMQ documentation

### DIFF
--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -35,7 +35,7 @@ triggers:
 - `queueLength`: Queue length target for HPA. Default is 20. Optional.
 - `protocol`: Protocol to be used for communication. Either `http` or `amqp`. It should correspond with the `host` value. 
 
-> **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
+> 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 
 > **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 

--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -30,23 +30,27 @@ triggers:
 - `hostFromEnv`: Value is the name of the environment variable your deployment uses to get the connection string. 
     This is usually resolved from a `Secret V1` or a `ConfigMap V1` collections. `env` and `envFrom` are both supported.  
     The resolved host should follow a format like `amqp://guest:password@localhost:5672/vhost` or 
-    `https://guest:password@localhost:443/vhostname`
+    `http://guest:password@localhost:15672/vhostname`
 - `queueName`: Name of the queue to read message from. Required.
 - `queueLength`: Queue length target for HPA. Default is 20. Optional.
 - `protocol`: Protocol to be used for communication. Either `http` or `amqp`. It should correspond with the `host` value. 
 
-Note `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
+> **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
+
+> **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 
 ### Authentication Parameters
 
 TriggerAuthentication CRD is used to connect and authenticate to RabbitMQ:
 
 - For AMQP, the URI should look similar to `amqp://guest:password@localhost:5672/vhost`
-- For HTTP, the URI should look similar to `https://guest:password@localhost:443/vhostname`
+- For HTTP, the URI should look similar to `http://guest:password@localhost:15672/vhostname`
+
+> See the [RabbitMQ Ports](https://www.rabbitmq.com/networking.html#ports) section for more details on how to configure the ports.
 
 ### Example
 
-AMQP protocol:
+#### AMQP protocol:
 
 ```yaml
 apiVersion: v1
@@ -85,7 +89,7 @@ spec:
       name: keda-trigger-auth-rabbitmq-conn
 ```
 
-HTTP protocol:
+#### HTTP protocol:
 
 ```yaml
 apiVersion: v1
@@ -93,7 +97,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format https://guest:password@localhost:443/vhostname
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhostname
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -37,7 +37,7 @@ triggers:
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 
-> **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
+> ⚠ **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 
 ### Authentication Parameters
 


### PR DESCRIPTION
The RabbitMQ documentation was lacking when RabbitMQ was used but messages arrived in the "Unacked" state rather than the "Ready" state, which can happens in frameworks such as Dapr.

This commit clarifies that this can be resolved through the HTTP interface and also points to the correct endpoint to utilize.