### PR TITLE
resolve broken link to community standup section in contributing.md and FAQs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Our documentation is versioned so it's important to make the changes for the cor
 
 ## Getting Help
 
-If you have a question about KEDA or how best to contribute, the [#KEDA](https://kubernetes.slack.com/archives/CKZJ36A5D) channel on the Kubernetes slack channel ([get an invite if you don't have one already](https://slack.k8s.io/)) is a good place to start.  We also have regular [community stand-ups](https://github.com/kedacore/keda#community-standup) to track ongoing work and discuss areas of contribution.  For any issues with the product you can [create an issue](https://github.com/kedacore/keda/issues/new) in this repo.
+If you have a question about KEDA or how best to contribute, the [#KEDA](https://kubernetes.slack.com/archives/CKZJ36A5D) channel on the Kubernetes slack channel ([get an invite if you don't have one already](https://slack.k8s.io/)) is a good place to start.  We also have regular [community stand-ups](https://github.com/kedacore/keda#community) to track ongoing work and discuss areas of contribution.  For any issues with the product you can [create an issue](https://github.com/kedacore/keda/issues/new) in this repo.
 
 ## Contributing New Documentation
 

--- a/data/faq.toml
+++ b/data/faq.toml
@@ -49,7 +49,7 @@ There are several ways to get involved.
 * Pick up an issue to work on. A good place to start might be issues which are marked as [Good First Issue](https://github.com/kedacore/keda/labels/good%20first%20issue) or [Help Wanted](https://github.com/kedacore/keda/labels/help%20wanted)
 * We are always looking to add more scalers.
 * We are always looking for more samples, documentation, etc.
-* Please join us in our [weekly standup](https://github.com/kedacore/keda#community-standup).
+* Please join us in our [weekly standup](https://github.com/kedacore/keda#community).
 """
 
 [[qna]]

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -49,7 +49,7 @@ There are several ways to get involved.
 * Pick up an issue to work on. A good place to start might be issues which are marked as [Good First Issue](https://github.com/kedacore/keda/labels/good%20first%20issue) or [Help Wanted](https://github.com/kedacore/keda/labels/help%20wanted)
 * We are always looking to add more scalers.
 * We are always looking for more samples, documentation, etc.
-* Please join us in our [weekly standup](https://github.com/kedacore/keda#community-standup).
+* Please join us in our [weekly standup](https://github.com/kedacore/keda#community).
 """
 
 [[qna]]


### PR DESCRIPTION
Signed-off-by: Girish Ramnani <girishramnani95@gmail.com>

The current link to community standup in contributing.md and FAQ seems to be pointing to a non-existent section in README.md, so changed that.

related PR in keda https://github.com/kedacore/keda/pull/1335