### PR TITLE
Fix amqp rabbitmq-queue documentation

### DIFF
--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -84,7 +84,7 @@ spec:
   triggers:
   - type: rabbitmq
     metadata:
-      protocol: aqmp
+      protocol: amqp
       queueName: testqueue
       queueLength: "20"
     authenticationRef:


### PR DESCRIPTION
The protocol for amqp was misspelled causing Keda to error on copied config.