### PR TITLE
Modify the value of name in ScaledObject metadata.

### DIFF
--- a/content/docs/1.4/concepts/authentication.md
+++ b/content/docs/1.4/concepts/authentication.md
@@ -54,7 +54,7 @@ spec:
 apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {deployment-name}
+  name: {scaled-object-name}
   namespace: default
 spec:
   scaleTargetRef:

--- a/content/docs/1.5/concepts/authentication.md
+++ b/content/docs/1.5/concepts/authentication.md
@@ -54,7 +54,7 @@ spec:
 apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {deployment-name}
+  name: {scaled-object-name}
   namespace: default
 spec:
   scaleTargetRef:

--- a/content/docs/2.0/concepts/authentication.md
+++ b/content/docs/2.0/concepts/authentication.md
@@ -54,7 +54,7 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {deployment-name}
+  name: {scaled-object-name}
   namespace: default
 spec:
   scaleTargetRef:

--- a/content/docs/2.1/concepts/authentication.md
+++ b/content/docs/2.1/concepts/authentication.md
@@ -54,7 +54,7 @@ spec:
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {deployment-name}
+  name: {scaled-object-name}
   namespace: default
 spec:
   scaleTargetRef:


### PR DESCRIPTION
Signed-off-by: Shubham82 <shubham.kuchhal@india.nec.com>

The term used for value of name in scaledobject metadata is {deployment-name} which is incorrect. instead it should be {scaled-object-name}. i have changed in 1.4, 1.5, 2.0, 2.1 documents.