### PR TITLE
Fix the links in scaling-deployments.md and scaling-jobs.md

### DIFF
--- a/content/docs/1.4/concepts/scaling-deployments.md
+++ b/content/docs/1.4/concepts/scaling-deployments.md
@@ -23,7 +23,7 @@ For example, if you wanted to use KEDA with an Apache Kafka topic as event sourc
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1.4.0/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.4/concepts/scaling-deployments.md
+++ b/content/docs/1.4/concepts/scaling-deployments.md
@@ -23,7 +23,7 @@ For example, if you wanted to use KEDA with an Apache Kafka topic as event sourc
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/master/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.4/concepts/scaling-jobs.md
+++ b/content/docs/1.4/concepts/scaling-jobs.md
@@ -19,7 +19,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/master/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.4/concepts/scaling-jobs.md
+++ b/content/docs/1.4/concepts/scaling-jobs.md
@@ -19,7 +19,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1.4.0/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.5/concepts/scaling-deployments.md
+++ b/content/docs/1.5/concepts/scaling-deployments.md
@@ -23,7 +23,7 @@ For example, if you wanted to use KEDA with an Apache Kafka topic as event sourc
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1.5.0/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.5/concepts/scaling-deployments.md
+++ b/content/docs/1.5/concepts/scaling-deployments.md
@@ -23,7 +23,7 @@ For example, if you wanted to use KEDA with an Apache Kafka topic as event sourc
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/master/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.5/concepts/scaling-jobs.md
+++ b/content/docs/1.5/concepts/scaling-jobs.md
@@ -19,7 +19,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1.5.0/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/1.5/concepts/scaling-jobs.md
+++ b/content/docs/1.5/concepts/scaling-jobs.md
@@ -19,7 +19,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledObject` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/master/pkg/apis/keda/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v1/pkg/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.k8s.io/v1alpha1

--- a/content/docs/2.0/concepts/scaling-deployments.md
+++ b/content/docs/2.0/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/master/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.0/concepts/scaling-deployments.md
+++ b/content/docs/2.0/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v2.0.0/api/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.0/concepts/scaling-jobs.md
+++ b/content/docs/2.0/concepts/scaling-jobs.md
@@ -20,7 +20,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledJob` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/master/api/v1alpha1/scaledjob_types.go)
+[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledjob_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.0/concepts/scaling-jobs.md
+++ b/content/docs/2.0/concepts/scaling-jobs.md
@@ -20,7 +20,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledJob` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledjob_types.go)
+[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/v2.0.0/api/v1alpha1/scaledjob_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.1/concepts/scaling-deployments.md
+++ b/content/docs/2.1/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/master/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.1/concepts/scaling-deployments.md
+++ b/content/docs/2.1/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v2.1.0/api/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.1/concepts/scaling-deployments.md
+++ b/content/docs/2.1/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/v2.1.0/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.1/concepts/scaling-jobs.md
+++ b/content/docs/2.1/concepts/scaling-jobs.md
@@ -20,7 +20,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledJob` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/v2.1.0/api/v1alpha1/scaledjob_types.go)
+[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledjob_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.1/concepts/scaling-jobs.md
+++ b/content/docs/2.1/concepts/scaling-jobs.md
@@ -20,7 +20,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledJob` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/master/api/v1alpha1/scaledjob_types.go)
+[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledjob_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.1/concepts/scaling-jobs.md
+++ b/content/docs/2.1/concepts/scaling-jobs.md
@@ -20,7 +20,7 @@ For example, if you wanted to use KEDA to run a job for each message that lands 
 
 This specification describes the `ScaledJob` custom resource definition which is used to define how KEDA should scale your application and what the triggers are.
 
-[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledjob_types.go)
+[`scaledjob_types.go`](https://github.com/kedacore/keda/blob/v2.1.0/api/v1alpha1/scaledjob_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1


### PR DESCRIPTION
Signed-off-by: Shubham82 <shubham.kuchhal@india.nec.com>

Updated the links  for  scaledobject_types.go and scaledjob_types.go in  scaling-deployments.md and scaling-jobs.md in  keda 1.4, 1.5, 2.0 and 2.1