### PR TITLE
Clarify queueLength parameter of queue-based scalers

### DIFF
--- a/content/docs/2.0/scalers/artemis.md
+++ b/content/docs/2.0/scalers/artemis.md
@@ -31,7 +31,7 @@ triggers:
 - `queueName` - Name of the queue to check for the number of messages available.
 - `brokerName` - Name of the broker as defined in Artemis.
 - `brokerAddress` - Address of the broker.
-- `queueLength` - Average target value to trigger scaling actions. (default: 10)
+- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size.
   - Default - `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`. In this example, `<<managementEndpoint>>`, `<<brokerName>>`, `<<brokerAddress>>` and `<<queueName>>` will be replaced automatically during runtime by values from metadata of YAML definition: `managementEndpoint`, `brokerName`, `brokerAddress`, `queueName`.
   

--- a/content/docs/2.0/scalers/artemis.md
+++ b/content/docs/2.0/scalers/artemis.md
@@ -31,7 +31,7 @@ triggers:
 - `queueName` - Name of the queue to check for the number of messages available.
 - `brokerName` - Name of the broker as defined in Artemis.
 - `brokerAddress` - Address of the broker.
-- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 10)
+- `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size.
   - Default - `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`. In this example, `<<managementEndpoint>>`, `<<brokerName>>`, `<<brokerAddress>>` and `<<queueName>>` will be replaced automatically during runtime by values from metadata of YAML definition: `managementEndpoint`, `brokerName`, `brokerAddress`, `queueName`.
   

--- a/content/docs/2.0/scalers/aws-sqs.md
+++ b/content/docs/2.0/scalers/aws-sqs.md
@@ -26,7 +26,7 @@ triggers:
 **Parameter list:**
 
 - `queueURL` - Full URL for the SQS Queue
-- `queueLength` - Target value for `ApproximateNumberOfMessages` in the SQS Queue
+- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual `ApproximateNumberOfMessages` in the SQS Queue is 30, HPA scales to 3 pods. (default: 5)
 - `awsRegion` - AWS Region for the SQS Queue
 - `identityOwner` - Receive permissions on the SQS Queue via Pod Identity or from the KEDA operator itself (see below).
 

--- a/content/docs/2.0/scalers/aws-sqs.md
+++ b/content/docs/2.0/scalers/aws-sqs.md
@@ -26,7 +26,7 @@ triggers:
 **Parameter list:**
 
 - `queueURL` - Full URL for the SQS Queue
-- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual `ApproximateNumberOfMessages` in the SQS Queue is 30, HPA scales to 3 pods. (default: 5)
+- `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual `ApproximateNumberOfMessages` in the SQS Queue is 30, the scaler scales to 3 pods. (default: 5)
 - `awsRegion` - AWS Region for the SQS Queue
 - `identityOwner` - Receive permissions on the SQS Queue via Pod Identity or from the KEDA operator itself (see below).
 

--- a/content/docs/2.0/scalers/azure-storage-queue.md
+++ b/content/docs/2.0/scalers/azure-storage-queue.md
@@ -23,7 +23,7 @@ triggers:
 **Parameter list:**
 
 - `queueName` - Name of the queue.
-- `queueLength` - Average target value to trigger scaling actions. (default: 5)
+- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 5)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
 
 ### Authentication Parameters

--- a/content/docs/2.0/scalers/azure-storage-queue.md
+++ b/content/docs/2.0/scalers/azure-storage-queue.md
@@ -23,7 +23,7 @@ triggers:
 **Parameter list:**
 
 - `queueName` - Name of the queue.
-- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 5)
+- `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 5)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
 
 ### Authentication Parameters

--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -30,12 +30,12 @@ triggers:
     `http://guest:password@localhost:15672/vhostname`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 
 - `queueName`: Name of the queue to read message from. Required.
-- `queueLength`: Queue length target for HPA. Default is 20. Optional.
+- `queueLength`: Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. Default is 20. Optional.
 - `protocol`: Protocol to be used for communication. Either `http` or `amqp`. It should correspond with the `host` value.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 
-- `hostFromEnv`: The connection string of the RabbitMQ server, similar to `host`, but reads it from an environment variable on the scale target.`
+- `hostFromEnv`: The connection string of the RabbitMQ server, similar to `host`, but reads it from an environment variable on the scale target.
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 

--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -30,7 +30,7 @@ triggers:
     `http://guest:password@localhost:15672/vhostname`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 
 - `queueName`: Name of the queue to read message from. Required.
-- `queueLength`: Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. Default is 20. Optional.
+- `queueLength`: Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. Default is 20. Optional.
 - `protocol`: Protocol to be used for communication. Either `http` or `amqp`. It should correspond with the `host` value.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:

--- a/content/docs/2.1/scalers/artemis.md
+++ b/content/docs/2.1/scalers/artemis.md
@@ -31,7 +31,7 @@ triggers:
 - `queueName` - Name of the queue to check for the number of messages available.
 - `brokerName` - Name of the broker as defined in Artemis.
 - `brokerAddress` - Address of the broker.
-- `queueLength` - Average target value to trigger scaling actions. (default: 10)
+- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size.
   - Default - `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`. In this example, `<<managementEndpoint>>`, `<<brokerName>>`, `<<brokerAddress>>` and `<<queueName>>` will be replaced automatically during runtime by values from metadata of YAML definition: `managementEndpoint`, `brokerName`, `brokerAddress`, `queueName`.
   

--- a/content/docs/2.1/scalers/artemis.md
+++ b/content/docs/2.1/scalers/artemis.md
@@ -31,7 +31,7 @@ triggers:
 - `queueName` - Name of the queue to check for the number of messages available.
 - `brokerName` - Name of the broker as defined in Artemis.
 - `brokerAddress` - Address of the broker.
-- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 10)
+- `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size.
   - Default - `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`. In this example, `<<managementEndpoint>>`, `<<brokerName>>`, `<<brokerAddress>>` and `<<queueName>>` will be replaced automatically during runtime by values from metadata of YAML definition: `managementEndpoint`, `brokerName`, `brokerAddress`, `queueName`.
   

--- a/content/docs/2.1/scalers/aws-sqs.md
+++ b/content/docs/2.1/scalers/aws-sqs.md
@@ -26,7 +26,7 @@ triggers:
 **Parameter list:**
 
 - `queueURL` - Full URL for the SQS Queue
-- `queueLength` - Target value for `ApproximateNumberOfMessages` in the SQS Queue
+- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual `ApproximateNumberOfMessages` in the SQS Queue is 30, HPA scales to 3 pods. (default: 5)
 - `awsRegion` - AWS Region for the SQS Queue
 - `identityOwner` - Receive permissions on the SQS Queue via Pod Identity or from the KEDA operator itself (see below).
 

--- a/content/docs/2.1/scalers/aws-sqs.md
+++ b/content/docs/2.1/scalers/aws-sqs.md
@@ -26,7 +26,7 @@ triggers:
 **Parameter list:**
 
 - `queueURL` - Full URL for the SQS Queue
-- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual `ApproximateNumberOfMessages` in the SQS Queue is 30, HPA scales to 3 pods. (default: 5)
+- `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual `ApproximateNumberOfMessages` in the SQS Queue is 30, the scaler scales to 3 pods. (default: 5)
 - `awsRegion` - AWS Region for the SQS Queue
 - `identityOwner` - Receive permissions on the SQS Queue via Pod Identity or from the KEDA operator itself (see below).
 

--- a/content/docs/2.1/scalers/azure-storage-queue.md
+++ b/content/docs/2.1/scalers/azure-storage-queue.md
@@ -23,7 +23,7 @@ triggers:
 **Parameter list:**
 
 - `queueName` - Name of the queue.
-- `queueLength` - Average target value to trigger scaling actions. (default: 5)
+- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 5)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
 
 ### Authentication Parameters

--- a/content/docs/2.1/scalers/azure-storage-queue.md
+++ b/content/docs/2.1/scalers/azure-storage-queue.md
@@ -23,7 +23,7 @@ triggers:
 **Parameter list:**
 
 - `queueName` - Name of the queue.
-- `queueLength` - Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. (default: 5)
+- `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 5)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
 
 ### Authentication Parameters

--- a/content/docs/2.1/scalers/rabbitmq-queue.md
+++ b/content/docs/2.1/scalers/rabbitmq-queue.md
@@ -31,14 +31,14 @@ triggers:
     `http://guest:password@localhost:15672/vhostname`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 
 - `queueName`: Name of the queue to read message from. Required.
-- `queueLength`: Queue length target for HPA. Default is 20. Optional.
+- `queueLength`: Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. Default is 20. Optional.
 - `protocol`: Protocol to be used for communication. Either `auto`, `http`, or `amqp`. It should correspond with the `host` value. Optional, will autodetect based on the `host` URL if possible.
 - `vhostName`: Vhost to use for the connection, overrides any vhost set in the connection string from `host`/`hostFromEnv`.
 
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 
-- `hostFromEnv`: The host and port of the Redis server, similar to `host`, but reads it from an environment variable on the scale target.`
+- `hostFromEnv`: The host and port of the Redis server, similar to `host`, but reads it from an environment variable on the scale target.
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 

--- a/content/docs/2.1/scalers/rabbitmq-queue.md
+++ b/content/docs/2.1/scalers/rabbitmq-queue.md
@@ -31,7 +31,7 @@ triggers:
     `http://guest:password@localhost:15672/vhostname`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 
 - `queueName`: Name of the queue to read message from. Required.
-- `queueLength`: Target value for queue length passed to Horizontal Pod Autoscaler (HPA). Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, HPA scales to 3 pods. Default is 20. Optional.
+- `queueLength`: Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. Default is 20. Optional.
 - `protocol`: Protocol to be used for communication. Either `auto`, `http`, or `amqp`. It should correspond with the `host` value. Optional, will autodetect based on the `host` URL if possible.
 - `vhostName`: Vhost to use for the connection, overrides any vhost set in the connection string from `host`/`hostFromEnv`.
 


### PR DESCRIPTION
Per discussion https://github.com/kedacore/keda/discussions/1395. The description of the queueLength parameter of queue-based scalers is short and quite technical. The practical implication that it should be set to the number of queue messages one pod processes was not clear to me until I got a working configuration using trial and error. This PR is intended to clarify that.