### PR TITLE
Added double quotes to value.

### DIFF
--- a/content/docs/2.0/scalers/cpu.md
+++ b/content/docs/2.0/scalers/cpu.md
@@ -21,7 +21,7 @@ triggers:
   metadata:
     # Required
     type: Value/ Utilization/ AverageValue
-    value: 60
+    value: "60"
 ```
 
 **Parameter list:**

--- a/content/docs/2.0/scalers/memory.md
+++ b/content/docs/2.0/scalers/memory.md
@@ -21,7 +21,7 @@ triggers:
   metadata:
     # Required
     type: Value/ Utilization/ AverageValue
-    value: 60
+    value: "60"
 ```
 
 **Parameter list:**

--- a/content/docs/2.1/scalers/cpu.md
+++ b/content/docs/2.1/scalers/cpu.md
@@ -21,7 +21,7 @@ triggers:
   metadata:
     # Required
     type: Value/ Utilization/ AverageValue
-    value: 60
+    value: "60"
 ```
 
 **Parameter list:**

--- a/content/docs/2.1/scalers/memory.md
+++ b/content/docs/2.1/scalers/memory.md
@@ -21,7 +21,7 @@ triggers:
   metadata:
     # Required
     type: Value/ Utilization/ AverageValue
-    value: 60
+    value: "60"
 ```
 
 **Parameter list:**


### PR DESCRIPTION
Added the double quotes to the value as it is of string type not integer. if not mentioned then it would give this on creation of scaledobject:
`The ScaledObject "cpu-scaledobject" is invalid: spec.triggers.metadata.value: Invalid value: "integer": spec.triggers.metadata.value in body must be of type string: "integer"`

Signed-off-by: Shubham Kuchhal <shubham.kuchhal@india.nec.com>