### PR TITLE
Correcting links in faqs

### DIFF
--- a/data/faq.toml
+++ b/data/faq.toml
@@ -35,7 +35,7 @@ We recommend using the [Prometheus scaler](/scalers/prometheus/) to create scale
 
 [[qna]]
 q = "Where can I get to the code for the Scalers?"
-a = "All scalers have their code [here](https://github.com/kedacore/keda/tree/master/pkg/scalers)."
+a = "All scalers have their code [here](https://github.com/kedacore/keda/tree/main/pkg/scalers)."
 
 [[qna]]
 q = "Is short polling intervals a problem?"

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -35,7 +35,7 @@ We recommend using the [Prometheus scaler](/scalers/prometheus/) to create scale
 
 [[qna]]
 q = "Where can I get to the code for the Scalers?"
-a = "All scalers have their code [here](https://github.com/kedacore/keda/tree/master/pkg/scalers)."
+a = "All scalers have their code [here](https://github.com/kedacore/keda/tree/main/pkg/scalers)."
 
 [[qna]]
 q = "Is short polling intervals a problem?"


### PR DESCRIPTION
Changed the links with master -> main.
So that "Branch not found, redirected to default branch." does do not show up on clicking.

Signed-off-by: Ritikaa96 <ritika@india.nec.com>
