### PR TITLE
docs: Provide overview of required ports to be accessible

### DIFF
--- a/content/docs/2.0/operate/cluster.md
+++ b/content/docs/2.0/operate/cluster.md
@@ -27,3 +27,14 @@ Here is an overview of all KEDA deployments and the supported replicas:
 |----------------|-------------------------|-------------------------------|
 | Operator       | 1                       |                               |
 | Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
+
+## Firewall requirements
+
+KEDA requires to be accessible inside the cluster to be able to autoscale.
+
+Here is an overview of the required ports that need to be accessible for KEDA to work:
+
+| Port   | Why?                                         | Remarks                                              |
+| ------ | -------------------------------------------- | ---------------------------------------------------- |
+| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms, except for Google Cloud. |
+| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud                       |

--- a/content/docs/2.1/operate/cluster.md
+++ b/content/docs/2.1/operate/cluster.md
@@ -4,17 +4,6 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## High Availability
-
-KEDA does not provide support for high-availability due to upstream limitations.
-
-Here is an overview of all KEDA deployments and the supported replicas:
-
-| Deployment     | Support Replicas        | Reasoning                     |
-|----------------|-------------------------|-------------------------------|
-| Operator       | 1                       |                               |
-| Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-
 ## Cluster capacity requirements
 
 The KEDA runtime require the following resources in a production-ready setup:
@@ -27,6 +16,28 @@ The KEDA runtime require the following resources in a production-ready setup:
 These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
+
+## Firewall requirements
+
+KEDA requires to be accessible inside the cluster to be able to autoscale.
+
+Here is an overview of the required ports that need to be accessible for KEDA to work:
+
+| Port   | Why?                                         | Remarks                                              |
+| ------ | -------------------------------------------- | ---------------------------------------------------- |
+| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms, except for Google Cloud. |
+| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud                       |
+
+## High Availability
+
+KEDA does not provide support for high-availability due to upstream limitations.
+
+Here is an overview of all KEDA deployments and the supported replicas:
+
+| Deployment     | Support Replicas        | Reasoning                     |
+|----------------|-------------------------|-------------------------------|
+| Operator       | 1                       |                               |
+| Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
 
 ## HTTP Timeouts
 

--- a/content/docs/2.2/operate/cluster.md
+++ b/content/docs/2.2/operate/cluster.md
@@ -23,10 +23,12 @@ KEDA requires to be accessible inside the cluster to be able to autoscale.
 
 Here is an overview of the required ports that need to be accessible for KEDA to work:
 
-| Port   | Why?                                         | Remarks                                              |
-| ------ | -------------------------------------------- | ---------------------------------------------------- |
-| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms, except for Google Cloud. |
-| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud                       |
+<!-- markdownlint-disable no-inline-html -->
+| Port   | Why?                                         | Remarks                                                                                                                                                   |
+| ------ | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms because it uses Control Plane &#8594; port 443 on the Service IP range communication.<br /><br /> This is not applicable for Google Cloud. |
+| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud because it uses Control Plane &#8594; port 6443 on the Pod IP range for communication                                      |
+<!-- markdownlint-enable no-inline-html -->
 
 ## High Availability
 

--- a/content/docs/2.2/operate/cluster.md
+++ b/content/docs/2.2/operate/cluster.md
@@ -4,29 +4,29 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## High Availability
-
-KEDA does not provide support for high-availability due to upstream limitations.
-
-Here is an overview of all KEDA deployments and the supported replicas:
-
-| Deployment     | Support Replicas        | Reasoning                     |
-|----------------|-------------------------|-------------------------------|
-| Operator       | 1                       |                               |
-| Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-
 ## Cluster capacity requirements
 
 The KEDA runtime require the following resources in a production-ready setup:
 
 | Deployment     | CPU                     | Memory                        |
-|----------------|-------------------------|-------------------------------|
-| Operator       | Limit: 1, Request: 100m | Limit: 1000Mi, Request: 100Mi |
+| -------------- | ----------------------- | ----------------------------- |
 | Metrics Server | Limit: 1, Request: 100m | Limit: 1000Mi, Request: 100Mi |
+| Operator       | Limit: 1, Request: 100m | Limit: 1000Mi, Request: 100Mi |
 
 These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
+
+## Firewall requirements
+
+KEDA requires to be accessible inside the cluster to be able to autoscale.
+
+Here is an overview of the required ports that need to be accessible for KEDA to work:
+
+| Port   | Why?                                         | Remarks                                              |
+| ------ | -------------------------------------------- | ---------------------------------------------------- |
+| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms, except for Google Cloud. |
+| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud                       |
 
 ## High Availability
 
@@ -34,10 +34,10 @@ KEDA does not provide support for high-availability due to upstream limitations.
 
 Here is an overview of all KEDA deployments and the supported replicas:
 
-| Deployment     | Support Replicas        | Reasoning                     |
-|----------------|-------------------------|-------------------------------|
-| Operator       | 1                       |                               |
-| Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
+| Deployment     | Support Replicas | Reasoning                                                                                                        |
+| -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
+| Operator       | 1                |                                                                                                                  |
 
 ## HTTP Timeouts
 


### PR DESCRIPTION
Provide overview of required ports to be accessible for KEDA to work and restructured the ordering to show the most important guidance first, followed by more advanced topics.

Relates to https://github.com/kedacore/keda-docs/discussions/389
Closes https://github.com/kedacore/keda-docs/issues/384

Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>