### PR TITLE
Provide documentation for `accountName` for Azure Storage Queues (v2.2)

### DIFF
--- a/content/docs/2.2/scalers/azure-storage-queue.md
+++ b/content/docs/2.2/scalers/azure-storage-queue.md
@@ -18,6 +18,7 @@ triggers:
     queueName: orders
     queueLength: '5'
     connectionFromEnv: STORAGE_CONNECTIONSTRING_ENV_NAME
+    accountName: storage-account-name
 ```
 
 **Parameter list:**
@@ -25,6 +26,7 @@ triggers:
 - `queueName` - Name of the queue.
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 5)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
+- `accountName` - Name of the storage account where that the queue belongs to.
 
 ### Authentication Parameters
 
@@ -58,7 +60,9 @@ spec:
     metadata:
       # Required
       queueName: functionsqueue
-      # Required: connection OR authenticationRef that defines connection
+      # Optional, required when pod identity is used
+      accountName: storage-account-name
+      # Optional: connection OR authenticationRef that defines connection
       connectionFromEnv: STORAGE_CONNECTIONSTRING_ENV_NAME # Default: AzureWebJobsStorage. Reference to a connection string in deployment
       # or authenticationRef as defined below
       #

--- a/content/docs/2.2/scalers/azure-storage-queue.md
+++ b/content/docs/2.2/scalers/azure-storage-queue.md
@@ -26,7 +26,7 @@ triggers:
 - `queueName` - Name of the queue.
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 5)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
-- `accountName` - Name of the storage account where that the queue belongs to.
+- `accountName` - Name of the storage account that the queue belongs to.
 
 ### Authentication Parameters
 


### PR DESCRIPTION
It appears that the code supports passing in the accountName metadata but the docs do not currently reflect this.