### PR TITLE
Changed Azure Service Bus scaler namespace trigger parameter to be required

### DIFF
--- a/content/docs/2.3/scalers/azure-service-bus.md
+++ b/content/docs/2.3/scalers/azure-service-bus.md
@@ -20,7 +20,7 @@ triggers:
     # or
     topicName: functions-sbtopic
     subscriptionName: sbtopic-sub1
-    # Optional, required when pod identity is used
+    # Required
     namespace: service-bus-namespace
     # Optional, can use TriggerAuthentication as well
     connectionFromEnv: SERVICEBUS_CONNECTIONSTRING_ENV_NAME # This must be a connection string for a queue itself, and not a namespace level (e.g. RootAccessPolicy) connection string [#215](https://github.com/kedacore/keda/issues/215)
@@ -34,7 +34,7 @@ triggers:
 - `queueName` - Name of the Azure Service Bus queue to scale on. (optional)
 - `topicName` - Name of the Azure Service Bus topic to scale on. (optional)
 - `subscriptionName` - Name of the Azure Service Bus queue to scale on. (optional, required when `topicName` is specified)
-- `namespace` - Name of the Azure Service Bus namespace that contains your queue or topic. (optional, required when pod identity is used)
+- `namespace` - Name of the Azure Service Bus namespace that contains your queue or topic. (required)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string of the Azure Service Bus namespace. (optional, can use TriggerAuthentication as well)
 
 > 💡 **NOTE:** Service Bus Shared Access Policy needs to be of type `Manage`. Manage access is required for KEDA to be able to get metrics from Service Bus.


### PR DESCRIPTION
Signed-off-by: Damian Trojanowski <damian.trojanowski@unit4.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Changed Azure Service Bus scaler `namespace` trigger parameter to be required. While having two or more namespaces with the same queue name, there is an error with KEDA described in [#1755](https://github.com/kedacore/keda/pull/1755). This way we will have unique metric names even having multiple namespaces.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
