### PR TITLE
docs: Fix server name for RabbitMQ hostFromEnv

### DIFF
--- a/content/docs/2.1/scalers/rabbitmq-queue.md
+++ b/content/docs/2.1/scalers/rabbitmq-queue.md
@@ -38,7 +38,7 @@ triggers:
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 
-- `hostFromEnv`: The host and port of the Redis server, similar to `host`, but reads it from an environment variable on the scale target.
+- `hostFromEnv`: The host and port of the RabbitMQ server, similar to `host`, but reads it from an environment variable on the scale target.
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 

--- a/content/docs/2.2/scalers/rabbitmq-queue.md
+++ b/content/docs/2.2/scalers/rabbitmq-queue.md
@@ -40,7 +40,7 @@ triggers:
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 
-- `hostFromEnv`: The host and port of the Redis server, similar to `host`, but reads it from an environment variable on the scale target.
+- `hostFromEnv`: The host and port of the RabbitMQ server, similar to `host`, but reads it from an environment variable on the scale target.
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 

--- a/content/docs/2.3/scalers/rabbitmq-queue.md
+++ b/content/docs/2.3/scalers/rabbitmq-queue.md
@@ -40,7 +40,7 @@ triggers:
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 
-- `hostFromEnv`: The host and port of the Redis server, similar to `host`, but reads it from an environment variable on the scale target.
+- `hostFromEnv`: The host and port of the RabbitMQ server, similar to `host`, but reads it from an environment variable on the scale target.
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 


### PR DESCRIPTION
Looks like copypasta.
