### PR TITLE
docs: Document network policies in FAQ

### DIFF
--- a/content/troubleshooting/proxy-network.md
+++ b/content/troubleshooting/proxy-network.md
@@ -1,11 +1,15 @@
 +++
-title = "How can I use KEDA in a proxy network?"
+title = "Why is Kubernetes unable to get metrics from KEDA?"
 weight = 1
 +++
 
 If while setting up KEDA, you get an error: `(v1beta1.external.metrics.k8s.io) status FailedDiscoveryCheck` with a message: `no response from https://ip:443: Get https://ip:443: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)`.
 
  One of the reason for this can be that you are behind a proxy network.
+
+### Before you start
+
+- Make sure no network policies are blocking traffic
 
 ### Check the status:
 


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Document that network policies can interfere with KEDA.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/keda/discussions/1835
