### PR TITLE
Remove duplicated prometheus metric

### DIFF
--- a/content/docs/2.1/operate/prometheus.md
+++ b/content/docs/2.1/operate/prometheus.md
@@ -14,4 +14,3 @@ The following metrics are being gathered:
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.
-- `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.2/operate/prometheus.md
+++ b/content/docs/2.2/operate/prometheus.md
@@ -14,4 +14,3 @@ The following metrics are being gathered:
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.
-- `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.3/operate/prometheus.md
+++ b/content/docs/2.3/operate/prometheus.md
@@ -14,4 +14,3 @@ The following metrics are being gathered:
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.
-- `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.4/operate/prometheus.md
+++ b/content/docs/2.4/operate/prometheus.md
@@ -14,4 +14,3 @@ The following metrics are being gathered:
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.
-- `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.


### PR DESCRIPTION
Signed-off-by: amirschw <24677563+amirschw@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Going over the documentation I came across this. The duplication was first introduced in the v2.1 docs.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
