### PR TITLE
feat: adding version metadata to be able to specify kafka version

### DIFF
--- a/content/docs/2.4/scalers/apache-kafka.md
+++ b/content/docs/2.4/scalers/apache-kafka.md
@@ -27,6 +27,7 @@ triggers:
     lagThreshold: '5'
     offsetResetPolicy: latest
     allowIdleConsumers: false
+    version: 1.0.0
 ```
 
 **Parameter list:**
@@ -38,6 +39,7 @@ triggers:
 - `offsetResetPolicy` - The offset reset policy for the consumer. Options are `latest` or `earliest` (default: `latest`)
 - `allowIdleConsumers` - Optional. When set to `true`, the number of replicas can exceed the number of
 partitions on a topic, allowing for idle consumers. (default: `false`)
+- `version` - Optional. Version of your Kafka brokers. See [samara](https://github.com/Shopify/sarama) version (default: `1.0.0`)
 
 ### Authentication Parameters
 


### PR DESCRIPTION
Signed-off-by: Flavien Chantelot <contact@flavien.dev>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Add a new metadata `version` to let the user specify his kafka version. The default option is setted to 1.0.0 to avoid any breaking changes. 
### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [X] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Related to https://github.com/kedacore/keda/pull/1866