### PR TITLE
fix: Architecture overview in KEDA HTTP blog post

### DIFF
--- a/content/blog/2021-06-24-announcing-http-add-on.md
+++ b/content/blog/2021-06-24-announcing-http-add-on.md
@@ -40,7 +40,7 @@ The system is made up of 3 components:
 - **External scaler**: This is an [external push scaler](https://keda.sh/docs/2.1/scalers/external-push/) that constantly pings the interceptor to get pending HTTP queue metrics. It transforms these data and sends them directly down to KEDA, which then makes a scaling decision
 - **Operator**:  This is an [Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) that runs for the convenience of the user. It listens for new [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) resources, called `HTTPScaledObject`s, and creates and configures interceptors and scalers so that your existing [`Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) will begin autoscaling according to incoming HTTP traffic.
 
-![architecture diagram](/static/img/blog/http-add-on/arch.png)
+![architecture diagram](/img/blog/http-add-on/arch.png)
 
 ## Seeing it in action
 


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Fix architecture overview in KEDA HTTP blog post

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
