### PR TITLE
Update meaning of KEDA acronym in FAQ

### DIFF
--- a/data/faq.toml
+++ b/data/faq.toml
@@ -1,6 +1,6 @@
 [[qna]]
 q = "What is KEDA and why is it useful?"
-a = "KEDA stands for Kubernetes-based Event Driven Auto-Scaler. It is built to be able to activate a Kubernetes deployment (i.e. no pods to a single pod) and subsequently to more pods based on events from various event sources."
+a = "KEDA stands for Kubernetes Event-driven Autoscaler. It is built to be able to activate a Kubernetes deployment (i.e. no pods to a single pod) and subsequently to more pods based on events from various event sources."
 
 [[qna]]
 q = "What are the prerequisites for using KEDA?"

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -1,6 +1,6 @@
 [[qna]]
 q = "What is KEDA and why is it useful?"
-a = "KEDA stands for Kubernetes-based Event Driven Auto-Scaler. It is built to be able to activate a Kubernetes deployment (i.e. no pods to a single pod) and subsequently to more pods based on events from various event sources."
+a = "KEDA stands for Kubernetes Event-driven Autoscaler. It is built to be able to activate a Kubernetes deployment (i.e. no pods to a single pod) and subsequently to more pods based on events from various event sources."
 type = "General"
 
 [[qna]]


### PR DESCRIPTION
As discussed in #475, the meaning of the KEDA acronym should be used
consistently.
KEDA stands for `Kubernetes Event-driven Autoscaler`.

Fixes #475

Signed-off-by: Jack Henschel <jackdev@mailbox.org>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)
