### PR TITLE
Fix documentation stretching off screen

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -4,7 +4,7 @@
       {{ partial "nav.html" . }}
     </div>
 
-    <div class="column is-content-column">
+    <div class="column is-three-quarters is-content-column">
       {{ partial "docs/hero.html" . }}
       {{ partial "content.html" . }}
     </div>

--- a/layouts/scalers/list.html
+++ b/layouts/scalers/list.html
@@ -9,7 +9,7 @@ KEDA Scalers
       {{ partial "nav.html" . }}
     </div>
 
-    <div class="column is-content-column">
+    <div class="column is-three-quarters is-content-column">
       {{ partial "docs/hero.html" . }}
       {{ partial "content.html" . }}
     </div>


### PR DESCRIPTION
On some browsers, the right hand side of the documentation was stretching off screen, with no way to scroll and see that. This has been fixed by adding the `.is-three-quarters` class the column adjacent to the nav on the article view and list view.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #470 
