### PR TITLE
add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- Thank you for contributing!
+
+     Read more about how you can contribute in our contribution guide:
+     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
+-->
+
+_Provide a description of what has been changed_
+
+### Checklist
+
+- [ ] Commits are signed with Developer Certificate of Origin (DCO)
+
+Fixes #


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The current tempate inherited from https://github.com/kedacore/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md  has Checklist item, that doesn't make sense for docs repo:
```
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


Fixes #
