### PR TITLE
fixing broken link for authentication methods in aws-kinesis

### DIFF
--- a/content/docs/1.4/scalers/aws-kinesis.md
+++ b/content/docs/1.4/scalers/aws-kinesis.md
@@ -38,7 +38,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`. 
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/1.4/concepts/authentication/).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/1.5/scalers/aws-kinesis.md
+++ b/content/docs/1.5/scalers/aws-kinesis.md
@@ -38,7 +38,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`. 
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/1.5/concepts/authentication/).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.0/scalers/aws-kinesis.md
+++ b/content/docs/2.0/scalers/aws-kinesis.md
@@ -37,7 +37,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`. 
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.0/concepts/authentication/).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.1/scalers/aws-kinesis.md
+++ b/content/docs/2.1/scalers/aws-kinesis.md
@@ -37,7 +37,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`. 
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.1/concepts/authentication/).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.2/scalers/aws-kinesis.md
+++ b/content/docs/2.2/scalers/aws-kinesis.md
@@ -37,7 +37,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`. 
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.2/concepts/authentication/).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.3/scalers/aws-kinesis.md
+++ b/content/docs/2.3/scalers/aws-kinesis.md
@@ -37,7 +37,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`. 
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.3/concepts/authentication/).
 
 #### Delegate auth with TriggerAuthentication
 


### PR DESCRIPTION
Signed-off-by: Ritikaa96 <ritika@india.nec.com>

_Provide a description of what has been changed_

The link address for Authentication [here](https://keda.sh/concepts/authentication) concepts has not been working. Changing it to a working link in all versions.
Changed files includes content/docs/scalers/aws-kinesis.md for KEDA v1.4 to KEDA v2.3

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

