### PR TITLE
Change StreamingIsActive to StreamIsActive for external scaler docs

### DIFF
--- a/content/docs/2.0/concepts/external-scalers.md
+++ b/content/docs/2.0/concepts/external-scalers.md
@@ -60,7 +60,7 @@ service ExternalScaler {
 
 - `GetMetrics` and `GetMetricsSpec` mirror their counterparts in the `Scaler` interface for creating HPA definition
 - `IsActive` maps to the `IsActive` method on the `Scaler` interface
-- `StreamingIsActive` maps to the `Run` method on the `PushScaler` interface.
+- `StreamIsActive` maps to the `Run` method on the `PushScaler` interface.
 
 Few things to notice:
 - Lack of `Close` method as the GRPC connection defines the lifetime of the scaler
@@ -99,7 +99,7 @@ KEDA will attempt a connection to `service-address.svc.local:9090` and calls `Is
 }
 ```
 
-For `StreamingIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
+For `StreamIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
 
 ## Implementing KEDA external scaler GRPC interface
 
@@ -346,9 +346,9 @@ server.start()
 
 <br />
 
-#### 4. Implementing `StreamingIsActive`
+#### 4. Implementing `StreamIsActive`
 
-Unlike `IsActive`, `StreamingIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
+Unlike `IsActive`, `StreamIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
 
 This implementation creates a timer and queries USGS APIs on that timer, effectively ignoring `pollingInterval` set in the scaledObject. Alternatively any other asynchronous event can be used instead of a timer, like an HTTP request, or a network connection.
 

--- a/content/docs/2.1/concepts/external-scalers.md
+++ b/content/docs/2.1/concepts/external-scalers.md
@@ -60,7 +60,7 @@ service ExternalScaler {
 
 - `GetMetrics` and `GetMetricsSpec` mirror their counterparts in the `Scaler` interface for creating HPA definition
 - `IsActive` maps to the `IsActive` method on the `Scaler` interface
-- `StreamingIsActive` maps to the `Run` method on the `PushScaler` interface.
+- `StreamIsActive` maps to the `Run` method on the `PushScaler` interface.
 
 Few things to notice:
 - Lack of `Close` method as the GRPC connection defines the lifetime of the scaler
@@ -99,7 +99,7 @@ KEDA will attempt a connection to `service-address.svc.local:9090` and calls `Is
 }
 ```
 
-For `StreamingIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
+For `StreamIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
 
 ## Implementing KEDA external scaler GRPC interface
 
@@ -346,9 +346,9 @@ server.start()
 
 <br />
 
-#### 4. Implementing `StreamingIsActive`
+#### 4. Implementing `StreamIsActive`
 
-Unlike `IsActive`, `StreamingIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
+Unlike `IsActive`, `StreamIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
 
 This implementation creates a timer and queries USGS APIs on that timer, effectively ignoring `pollingInterval` set in the scaledObject. Alternatively any other asynchronous event can be used instead of a timer, like an HTTP request, or a network connection.
 

--- a/content/docs/2.2/concepts/external-scalers.md
+++ b/content/docs/2.2/concepts/external-scalers.md
@@ -60,7 +60,7 @@ service ExternalScaler {
 
 - `GetMetrics` and `GetMetricsSpec` mirror their counterparts in the `Scaler` interface for creating HPA definition
 - `IsActive` maps to the `IsActive` method on the `Scaler` interface
-- `StreamingIsActive` maps to the `Run` method on the `PushScaler` interface.
+- `StreamIsActive` maps to the `Run` method on the `PushScaler` interface.
 
 Few things to notice:
 - Lack of `Close` method as the GRPC connection defines the lifetime of the scaler
@@ -99,7 +99,7 @@ KEDA will attempt a connection to `service-address.svc.local:9090` and calls `Is
 }
 ```
 
-For `StreamingIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
+For `StreamIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
 
 ## Implementing KEDA external scaler GRPC interface
 
@@ -346,9 +346,9 @@ server.start()
 
 <br />
 
-#### 4. Implementing `StreamingIsActive`
+#### 4. Implementing `StreamIsActive`
 
-Unlike `IsActive`, `StreamingIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
+Unlike `IsActive`, `StreamIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
 
 This implementation creates a timer and queries USGS APIs on that timer, effectively ignoring `pollingInterval` set in the scaledObject. Alternatively any other asynchronous event can be used instead of a timer, like an HTTP request, or a network connection.
 

--- a/content/docs/2.3/concepts/external-scalers.md
+++ b/content/docs/2.3/concepts/external-scalers.md
@@ -60,7 +60,7 @@ service ExternalScaler {
 
 - `GetMetrics` and `GetMetricsSpec` mirror their counterparts in the `Scaler` interface for creating HPA definition
 - `IsActive` maps to the `IsActive` method on the `Scaler` interface
-- `StreamingIsActive` maps to the `Run` method on the `PushScaler` interface.
+- `StreamIsActive` maps to the `Run` method on the `PushScaler` interface.
 
 Few things to notice:
 - Lack of `Close` method as the GRPC connection defines the lifetime of the scaler
@@ -99,7 +99,7 @@ KEDA will attempt a connection to `service-address.svc.local:9090` and calls `Is
 }
 ```
 
-For `StreamingIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
+For `StreamIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
 
 ## Implementing KEDA external scaler GRPC interface
 
@@ -346,9 +346,9 @@ server.start()
 
 <br />
 
-#### 4. Implementing `StreamingIsActive`
+#### 4. Implementing `StreamIsActive`
 
-Unlike `IsActive`, `StreamingIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
+Unlike `IsActive`, `StreamIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
 
 This implementation creates a timer and queries USGS APIs on that timer, effectively ignoring `pollingInterval` set in the scaledObject. Alternatively any other asynchronous event can be used instead of a timer, like an HTTP request, or a network connection.
 

--- a/content/docs/2.4/concepts/external-scalers.md
+++ b/content/docs/2.4/concepts/external-scalers.md
@@ -60,7 +60,7 @@ service ExternalScaler {
 
 - `GetMetrics` and `GetMetricsSpec` mirror their counterparts in the `Scaler` interface for creating HPA definition
 - `IsActive` maps to the `IsActive` method on the `Scaler` interface
-- `StreamingIsActive` maps to the `Run` method on the `PushScaler` interface.
+- `StreamIsActive` maps to the `Run` method on the `PushScaler` interface.
 
 Few things to notice:
 - Lack of `Close` method as the GRPC connection defines the lifetime of the scaler
@@ -99,7 +99,7 @@ KEDA will attempt a connection to `service-address.svc.local:9090` and calls `Is
 }
 ```
 
-For `StreamingIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
+For `StreamIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
 
 ## Implementing KEDA external scaler GRPC interface
 
@@ -346,9 +346,9 @@ server.start()
 
 <br />
 
-#### 4. Implementing `StreamingIsActive`
+#### 4. Implementing `StreamIsActive`
 
-Unlike `IsActive`, `StreamingIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
+Unlike `IsActive`, `StreamIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
 
 This implementation creates a timer and queries USGS APIs on that timer, effectively ignoring `pollingInterval` set in the scaledObject. Alternatively any other asynchronous event can be used instead of a timer, like an HTTP request, or a network connection.
 

--- a/content/docs/2.5/concepts/external-scalers.md
+++ b/content/docs/2.5/concepts/external-scalers.md
@@ -60,7 +60,7 @@ service ExternalScaler {
 
 - `GetMetrics` and `GetMetricsSpec` mirror their counterparts in the `Scaler` interface for creating HPA definition
 - `IsActive` maps to the `IsActive` method on the `Scaler` interface
-- `StreamingIsActive` maps to the `Run` method on the `PushScaler` interface.
+- `StreamIsActive` maps to the `Run` method on the `PushScaler` interface.
 
 Few things to notice:
 - Lack of `Close` method as the GRPC connection defines the lifetime of the scaler
@@ -99,7 +99,7 @@ KEDA will attempt a connection to `service-address.svc.local:9090` and calls `Is
 }
 ```
 
-For `StreamingIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
+For `StreamIsActive` KEDA establishes the connection to the GRPC server and expects `IsActive` events to be streamed as a response.
 
 ## Implementing KEDA external scaler GRPC interface
 
@@ -346,9 +346,9 @@ server.start()
 
 <br />
 
-#### 4. Implementing `StreamingIsActive`
+#### 4. Implementing `StreamIsActive`
 
-Unlike `IsActive`, `StreamingIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
+Unlike `IsActive`, `StreamIsActive` is called once when KEDA reconciles the `ScaledObject`, and expects the external scaler to push `IsActiveResponse` whenever the scaler needs KEDA to activate the deployment.
 
 This implementation creates a timer and queries USGS APIs on that timer, effectively ignoring `pollingInterval` set in the scaledObject. Alternatively any other asynchronous event can be used instead of a timer, like an HTTP request, or a network connection.
 


### PR DESCRIPTION
Signed-off-by: Benjamin <benjamin@yunify.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The ExternalScaler interface contains method StreamIsActive, not StreamingIsActive:
```proto
service ExternalScaler {
    rpc IsActive(ScaledObjectRef) returns (IsActiveResponse) {}
    rpc StreamIsActive(ScaledObjectRef) returns (stream IsActiveResponse) {}
    rpc GetMetricSpec(ScaledObjectRef) returns (GetMetricSpecResponse) {}
    rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse) {}
}
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)