### PR TITLE
docs: Change Helm Pod Identity flag name for Azure Log Analytics scaler

### DIFF
--- a/content/docs/2.0/scalers/azure-log-analytics.md
+++ b/content/docs/2.0/scalers/azure-log-analytics.md
@@ -343,7 +343,6 @@ EOF
 
 # APPLY LABELS: OPTION 1
 #deploy Keda using helm chart and specify aadPodIdentity label.
-#WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}

--- a/content/docs/2.0/scalers/azure-log-analytics.md
+++ b/content/docs/2.0/scalers/azure-log-analytics.md
@@ -346,7 +346,7 @@ EOF
 #WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
-helm install keda kedacore/keda --namespace keda --create-namespace --set aadPodIdentity=${IDENTITY_NAME}
+helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}
 
 # APPLY LABELS: OPTION 2
 #Instead of redeploying Keda, you can update existing deployment:

--- a/content/docs/2.1/scalers/azure-log-analytics.md
+++ b/content/docs/2.1/scalers/azure-log-analytics.md
@@ -343,7 +343,6 @@ EOF
 
 # APPLY LABELS: OPTION 1
 #deploy Keda using helm chart and specify aadPodIdentity label.
-#WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}

--- a/content/docs/2.1/scalers/azure-log-analytics.md
+++ b/content/docs/2.1/scalers/azure-log-analytics.md
@@ -346,7 +346,7 @@ EOF
 #WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
-helm install keda kedacore/keda --namespace keda --create-namespace --set aadPodIdentity=${IDENTITY_NAME}
+helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}
 
 # APPLY LABELS: OPTION 2
 #Instead of redeploying Keda, you can update existing deployment:

--- a/content/docs/2.2/scalers/azure-log-analytics.md
+++ b/content/docs/2.2/scalers/azure-log-analytics.md
@@ -343,7 +343,6 @@ EOF
 
 # APPLY LABELS: OPTION 1
 #deploy Keda using helm chart and specify aadPodIdentity label.
-#WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}

--- a/content/docs/2.2/scalers/azure-log-analytics.md
+++ b/content/docs/2.2/scalers/azure-log-analytics.md
@@ -346,7 +346,7 @@ EOF
 #WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
-helm install keda kedacore/keda --namespace keda --create-namespace --set aadPodIdentity=${IDENTITY_NAME}
+helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}
 
 # APPLY LABELS: OPTION 2
 #Instead of redeploying Keda, you can update existing deployment:

--- a/content/docs/2.3/scalers/azure-log-analytics.md
+++ b/content/docs/2.3/scalers/azure-log-analytics.md
@@ -343,7 +343,6 @@ EOF
 
 # APPLY LABELS: OPTION 1
 #deploy Keda using helm chart and specify aadPodIdentity label.
-#WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}

--- a/content/docs/2.3/scalers/azure-log-analytics.md
+++ b/content/docs/2.3/scalers/azure-log-analytics.md
@@ -346,7 +346,7 @@ EOF
 #WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
-helm install keda kedacore/keda --namespace keda --create-namespace --set aadPodIdentity=${IDENTITY_NAME}
+helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}
 
 # APPLY LABELS: OPTION 2
 #Instead of redeploying Keda, you can update existing deployment:

--- a/content/docs/2.4/scalers/azure-log-analytics.md
+++ b/content/docs/2.4/scalers/azure-log-analytics.md
@@ -343,7 +343,6 @@ EOF
 
 # APPLY LABELS: OPTION 1
 #deploy Keda using helm chart and specify aadPodIdentity label.
-#WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}

--- a/content/docs/2.4/scalers/azure-log-analytics.md
+++ b/content/docs/2.4/scalers/azure-log-analytics.md
@@ -346,7 +346,7 @@ EOF
 #WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
-helm install keda kedacore/keda --namespace keda --create-namespace --set aadPodIdentity=${IDENTITY_NAME}
+helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}
 
 # APPLY LABELS: OPTION 2
 #Instead of redeploying Keda, you can update existing deployment:

--- a/content/docs/2.5/scalers/azure-log-analytics.md
+++ b/content/docs/2.5/scalers/azure-log-analytics.md
@@ -343,7 +343,6 @@ EOF
 
 # APPLY LABELS: OPTION 1
 #deploy Keda using helm chart and specify aadPodIdentity label.
-#WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}

--- a/content/docs/2.5/scalers/azure-log-analytics.md
+++ b/content/docs/2.5/scalers/azure-log-analytics.md
@@ -346,7 +346,7 @@ EOF
 #WARNING: You can run this command once keda v.2.0.0 will be released and helm chart for v2 will be available in official repo
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
-helm install keda kedacore/keda --namespace keda --create-namespace --set aadPodIdentity=${IDENTITY_NAME}
+helm install keda kedacore/keda --namespace keda --create-namespace --set podIdentity.activeDirectory.identity=${IDENTITY_NAME}
 
 # APPLY LABELS: OPTION 2
 #Instead of redeploying Keda, you can update existing deployment:


### PR DESCRIPTION
The flag used to set the Pod Identity labels on the KEDA Operator and
KEDA Metric API provider have changed in the newer versions of the KEDA
Helm Chart.

This was wrong in the current Log Analytics Scaler docs and this changes
it to the new Flag Name! 👍🏼

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)