### PR TITLE
Fixing typo in kubernetes workload scaler documentation

### DIFF
--- a/content/docs/2.4/scalers/kubernetes-workload.md
+++ b/content/docs/2.4/scalers/kubernetes-workload.md
@@ -19,7 +19,7 @@ triggers:
 
 **Parameter list:**
 
-- `podSelector` - [Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) that will be used to get the pod count. It supports multiple selectors split by coma (`,`). It also supports [set-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) and a mix of them.
+- `podSelector` - [Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) that will be used to get the pod count. It supports multiple selectors split by a comma character (`,`). It also supports [set-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) and a mix of them.
 - `value` - Target relation between the scaled workload and the amount of pods which matches the selector. It will be calculated following this formula: `relation = (pods which match selector) / (scaled workload pods)`
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.


### PR DESCRIPTION
This patch fixes a typo in the Kubernetes workload scaler documentation

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
