### PR TITLE
docs: fix invalid ScaledObject CR example

### DIFF
--- a/content/docs/1.4/scalers/apache-kafka.md
+++ b/content/docs/1.4/scalers/apache-kafka.md
@@ -53,14 +53,14 @@ triggers:
 Your kafka cluster no sasl auth:
 
 ```yaml
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: kafka-scaledobject
   namespace: default
 spec:
   scaleTargetRef:
-    deploymentName: azure-functions-deployment
+    name: azure-functions-deployment
   pollingInterval: 30
   triggers:
   - type: kafka
@@ -88,7 +88,7 @@ data:
   cert: <your cert>
   key: <your key>
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: keda-trigger-auth-kafka-credential
@@ -114,14 +114,14 @@ spec:
     name: keda-kafka-secrets
     key: key
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: kafka-scaledobject
   namespace: default
 spec:
   scaleTargetRef:
-    deploymentName: azure-functions-deployment
+    name: azure-functions-deployment
   pollingInterval: 30
   triggers:
   - type: kafka


### PR DESCRIPTION
I was getting the following errors when trying to run these examples:

```shell
error: unable to recognize "STDIN": no matches for kind "ScaledObject" in version "keda.k8s.io/v1alpha1"
```

```shell
error: error validating "STDIN": error validating data: [ValidationError(ScaledObject.spec.scaleTargetRef): unknown field "deploymentName" in sh.keda.v1alpha1.ScaledObject.spec.scaleTargetRef, ValidationError(ScaledObject.spec.scaleTargetRef): missing required field "name" in sh.keda.v1alpha1.ScaledObject.spec.scaleTargetRef]; if you choose to ignore these errors, turn validation off with --validate=false
```

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
