### PR TITLE
chore: Change `feature` as allowed label for stale issues, instead of `feature-request`

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - cant-touch-this
-  - feature-request
+  - feature
   - security
 
 # Label to use when marking an issue as stale


### PR DESCRIPTION
Change `feature` as allowed label for stale issues, instead of `feature-request` as our intention was to mark issues as features if we want to keep them around.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/governance/issues/33
