### PR TITLE
Delete Value metricType from the CPU and Memory Scalers

### DIFF
--- a/content/docs/2.0/scalers/cpu.md
+++ b/content/docs/2.0/scalers/cpu.md
@@ -20,15 +20,14 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.0/scalers/memory.md
+++ b/content/docs/2.0/scalers/memory.md
@@ -20,15 +20,14 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.1/scalers/cpu.md
+++ b/content/docs/2.1/scalers/cpu.md
@@ -20,15 +20,14 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.1/scalers/memory.md
+++ b/content/docs/2.1/scalers/memory.md
@@ -20,15 +20,14 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.2/scalers/cpu.md
+++ b/content/docs/2.2/scalers/cpu.md
@@ -20,15 +20,14 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.2/scalers/memory.md
+++ b/content/docs/2.2/scalers/memory.md
@@ -20,15 +20,14 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.3/scalers/cpu.md
+++ b/content/docs/2.3/scalers/cpu.md
@@ -20,15 +20,14 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.3/scalers/memory.md
+++ b/content/docs/2.3/scalers/memory.md
@@ -20,15 +20,14 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.4/scalers/cpu.md
+++ b/content/docs/2.4/scalers/cpu.md
@@ -20,15 +20,14 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.4/scalers/memory.md
+++ b/content/docs/2.4/scalers/memory.md
@@ -20,15 +20,14 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.5/scalers/cpu.md
+++ b/content/docs/2.5/scalers/cpu.md
@@ -20,15 +20,14 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 

--- a/content/docs/2.5/scalers/memory.md
+++ b/content/docs/2.5/scalers/memory.md
@@ -20,15 +20,14 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Value/ Utilization/ AverageValue
+    type: Utilization/ AverageValue
     value: "60"
 ```
 
 **Parameter list:**
 
-- `type` - Type of metric to use. Options are `Utilization`, `Value`, or `AverageValue`.
+- `type` - Type of metric to use. Options are `Utilization`, or `AverageValue`.
 - `value` - Value to trigger scaling actions for:
-	- When using `Value`, the target value is the value of the metric itself (as a quantity).
 	- When using `Utilization`, the target value is the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 	- When using `AverageValue`, the target value is the target value of the average of the metric across all relevant pods (quantity).
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

This PR removes the support to `Value` metricType in CPU and Memory scalers. HPA doesn't support that metricType in these cases, so it doesn't make sense to maintain in as part of the scaler
https://github.com/kedacore/keda/issues/2200#issuecomment-952124464

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda/pull/2218
Related https://github.com/kedacore/keda/pull/2218
