### PR TITLE
Add note about password restrictions on RabbitMQ scaler

### DIFF
--- a/content/docs/2.5/scalers/rabbitmq-queue.md
+++ b/content/docs/2.5/scalers/rabbitmq-queue.md
@@ -47,6 +47,8 @@ Some parameters could be provided using environmental variables, instead of sett
 
 > 💡 **Note:** `host`/`hostFromEnv` has an optional vhost name after the host slash which will be used to scope API request.
 
+> 💡 **Note:** When using `host`/`hostFromEnv` or TriggerAuthentication, the supplied password cannot contain special characters.
+
 > 💡 **Note:** `mode: MessageRate` requires protocol `http`.
 
 > 💡 **Note:** `useRegex: "true"` requires protocol `http` and ignores unacknowledged messages.


### PR DESCRIPTION
Signed-off-by: Michael Bendtsen <michael@bendtsen.info>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Add note about password restrictions/limitations on RabbitMQ scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes kedacore/keda#2287
