### PR TITLE
No longer list scaler subentries in top- or side- navs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
-public/
+package-lock.json
+/public
 .idea
 resources/
 .DS_Store

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -49,19 +49,20 @@
   {{ with .Sections }}
   {{ range . }}
   {{ $isThisSection := eq .CurrentSection.Title $currentSection.Title }}
+  {{ $regularPages := cond (eq .CurrentSection.Title "Scalers") "" .RegularPages -}}
   <div class="nav-subsection" x-data="{ open: {{ $isThisSection }} }">
     <div class="nav-section-title is-size-5 is-size-6-mobile{{ if $isHere }} is-active{{ end }}" href="{{ .RelPermalink }}">
       <a href="{{ .RelPermalink }}">
         {{ .Title }}
       </a>
-      {{ if .RegularPages }}
+      {{ if $regularPages }}
       <span @click="open = !open">
         <i class="fas fa-md has-text-secondary" :class="{ 'fa-caret-down': !open, 'fa-caret-up': open }"></i>
       </span>
       {{ end }}
     </div>
 
-    {{ with .RegularPages }}
+    {{ with $regularPages }}
     <ul class="nav-section-links" x-show="open">
       {{ range . }}
       {{ $isHere := eq $here .RelPermalink }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -35,25 +35,7 @@
         </div>
 
         <div class="navbar-item is-size-5-desktop has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless" href="/docs/{{ $latest }}/scalers">
-            <span>
-              Scalers
-            </span>
-            <span class="icon has-text-secondary">
-              <i class="fas fa-md fa-caret-down"></i>
-            </span>
-          </a>
-
-          <div class="navbar-dropdown is-radiusless">
-            {{ range $scalers }}
-            {{ $version := index (split .File.Path "/") 1 }}
-            {{ if eq $version $latest }}
-            <a class="navbar-item" href="{{ .RelPermalink }}">
-              {{ .Title }}
-            </a>
-            {{ end }}
-            {{ end }}
-          </div>
+          <a class="navbar-link is-arrowless" href="/docs/{{ $latest }}/scalers">Scalers</a>
         </div>
 
         {{ range $docs }}


### PR DESCRIPTION
- Removes scaler subentries from the top nav
  - Closes #581
- Removes scaler subentries from the left side-nav
- Commits are signed with Developer Certificate of Origin (DCO)

Preview: https://deploy-preview-593--keda.netlify.app/docs/latest/scalers/

### Screenshot

This illustrates how the scaler subentries are gone from the navs, but that the scalers are still listed on the Scalers-section pages.

> <img width="1409" alt="Screen Shot 2021-11-23 at 9 45 26 AM" src="https://user-images.githubusercontent.com/4140793/143045802-2aa0b065-7c2b-43c9-89ff-9a2acabc4dd3.png">

/cc @celestehorgan @nate-double-u

