### PR TITLE
add note about `idleReplicaCount` limitation

### DIFF
--- a/content/docs/2.4/concepts/scaling-deployments.md
+++ b/content/docs/2.4/concepts/scaling-deployments.md
@@ -113,6 +113,8 @@ The `cooldownPeriod` only applies after a trigger occurs; when you first create 
   idleReplicaCount: 0   # Optional. Must be less than minReplicaCount
 ```
 
+> 💡 **NOTE:** Due to limitations in HPA controller the only supported value for this property is 0, it will not work corrently otherwise. See this [issue](https://github.com/kedacore/keda/issues/2314) for more details.
+
 If this property is set, KEDA will scale the resource down to this number of replicas. If there's some activity on target triggers KEDA will scale the target resource immediately to `minReplicaCount` and then will be scaling handled by HPA. When there is no activity, the target resource is again scaled down to `idleReplicaCount`. This seting must be less than `minReplicaCount`.
 
 **Example:** If there's no activity on triggers the target resource is scaled down to `idleReplicaCount` (0), once there is an activity the target resource is immediately scaled to `minReplicaCount` (10) and then up to `maxReplicaCount` (100) as needed. If there's no activity on triggers the resource is again scaled down to `idleReplicaCount` (0).

--- a/content/docs/2.5/concepts/scaling-deployments.md
+++ b/content/docs/2.5/concepts/scaling-deployments.md
@@ -113,6 +113,8 @@ The `cooldownPeriod` only applies after a trigger occurs; when you first create 
   idleReplicaCount: 0   # Optional. Must be less than minReplicaCount
 ```
 
+> 💡 **NOTE:** Due to limitations in HPA controller the only supported value for this property is 0, it will not work corrently otherwise. See this [issue](https://github.com/kedacore/keda/issues/2314) for more details.
+
 If this property is set, KEDA will scale the resource down to this number of replicas. If there's some activity on target triggers KEDA will scale the target resource immediately to `minReplicaCount` and then will be scaling handled by HPA. When there is no activity, the target resource is again scaled down to `idleReplicaCount`. This seting must be less than `minReplicaCount`.
 
 **Example:** If there's no activity on triggers the target resource is scaled down to `idleReplicaCount` (0), once there is an activity the target resource is immediately scaled to `minReplicaCount` (10) and then up to `maxReplicaCount` (100) as needed. If there's no activity on triggers the resource is again scaled down to `idleReplicaCount` (0).


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Adding a note about current limitation of our implementation of `idleReplicaCount`, see the related issue for more details.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates https://github.com/kedacore/keda/issues/2314
