### PR TITLE
Use `latest`  instead specific version in canonical urls

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,11 +1,12 @@
-{{ $url     := .Permalink }}
-{{ $title   := cond .IsHome site.Title (printf "%s | %s" site.Title .Title) }}
-{{ $type    := cond .IsHome "website" "article" }}
-{{ $desc    := cond .IsHome site.Params.description .Description }}
-{{ $twitter := site.Params.twitter_handle }}
-{{ $img     := "img/logos/keda-icon-color.png" | absURL }}
-{{ $imgAlt  := printf "%s color logo" site.Title }}
-{{ $locale  := site.Params.locale }}
+{{ $url         := .Permalink }}
+{{ $canonical   := replaceRE "/docs/\\d.\\d" "/docs/latest" $url }}
+{{ $title       := cond .IsHome site.Title (printf "%s | %s" site.Title .Title) }}
+{{ $type        := cond .IsHome "website" "article" }}
+{{ $desc        := cond .IsHome site.Params.description .Description }}
+{{ $twitter     := site.Params.twitter_handle }}
+{{ $img         := "img/logos/keda-icon-color.png" | absURL }}
+{{ $imgAlt      := printf "%s color logo" site.Title }}
+{{ $locale      := site.Params.locale }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
@@ -13,7 +14,7 @@
 {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type $url site.Title | safeHTML }}
 {{ end -}}
 
-<link rel="canonical" href="{{ $url }}">
+<link rel="canonical" href="{{ $canonical }}">
 
 {{/* Twitter Card metadata */}}
 <meta name="twitter:card" content="summary">


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Now all pages declare their self as canonical in `head` section. This makes that google doesn't list correctly the really canonical page. With this PR we replace the canonical to enforce `latest` (only) under `docs` sub path

![image](https://user-images.githubusercontent.com/36899226/145430508-90ee7eda-0ac0-4d56-821f-e461429f0258.png)
![image](https://user-images.githubusercontent.com/36899226/145430858-b71c4f9e-a426-4738-a130-9652e9524429.png)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
