### PR TITLE
Document running multiple operator instances

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "markdownlint.config": {
-        "MD028": false,
-        "MD025": {
-            "front_matter_title": ""
-        }
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
+}

--- a/content/docs/2.1/operate/cluster.md
+++ b/content/docs/2.1/operate/cluster.md
@@ -36,7 +36,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 
 | Deployment     | Support Replicas        | Reasoning                     |
 |----------------|-------------------------|-------------------------------|
-| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be active. The rest will be standing by, which may reduce downtime during a failure. Multiple replicas will not improve the performance of KEDA, it might only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 | Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
 
 ## HTTP Timeouts

--- a/content/docs/2.1/operate/cluster.md
+++ b/content/docs/2.1/operate/cluster.md
@@ -36,12 +36,12 @@ Here is an overview of all KEDA deployments and the supported replicas:
 
 | Deployment     | Support Replicas        | Reasoning                     |
 |----------------|-------------------------|-------------------------------|
-| Operator       | 1                       |                               |
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 | Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
 
 ## HTTP Timeouts
 
-Some scalers issue HTTP requests to external servers (i.e. cloud services). Each applicable scaler uses its own dedicated HTTP client with its own connection pool, and by default each client is set to time out any HTTP request after 3 seconds. 
+Some scalers issue HTTP requests to external servers (i.e. cloud services). Each applicable scaler uses its own dedicated HTTP client with its own connection pool, and by default each client is set to time out any HTTP request after 3 seconds.
 
 You can override this default by setting the `KEDA_HTTP_DEFAULT_TIMEOUT` environment variable to your desired timeout in milliseconds. For example, on Linux/Mac/Windows WSL2 operating systems, you'd use this command to set to 1 second:
 

--- a/content/docs/2.2/operate/cluster.md
+++ b/content/docs/2.2/operate/cluster.md
@@ -39,11 +39,11 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 1                |                                                                                                                  |
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 
-Some scalers issue HTTP requests to external servers (i.e. cloud services). Each applicable scaler uses its own dedicated HTTP client with its own connection pool, and by default each client is set to time out any HTTP request after 3 seconds. 
+Some scalers issue HTTP requests to external servers (i.e. cloud services). Each applicable scaler uses its own dedicated HTTP client with its own connection pool, and by default each client is set to time out any HTTP request after 3 seconds.
 
 You can override this default by setting the `KEDA_HTTP_DEFAULT_TIMEOUT` environment variable to your desired timeout in milliseconds. For example, on Linux/Mac/Windows WSL2 operating systems, you'd use this command to set to 1 second:
 

--- a/content/docs/2.2/operate/cluster.md
+++ b/content/docs/2.2/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be active. The rest will be standing by, which may reduce downtime during a failure. Multiple replicas will not improve the performance of KEDA, it might only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.3/operate/cluster.md
+++ b/content/docs/2.3/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 1                |                                                                                                                  |
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.3/operate/cluster.md
+++ b/content/docs/2.3/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be active. The rest will be standing by, which may reduce downtime during a failure. Multiple replicas will not improve the performance of KEDA, it might only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.4/operate/cluster.md
+++ b/content/docs/2.4/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 1                |                                                                                                                  |
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.4/operate/cluster.md
+++ b/content/docs/2.4/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be active. The rest will be standing by, which may reduce downtime during a failure. Multiple replicas will not improve the performance of KEDA, it might only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.5/operate/cluster.md
+++ b/content/docs/2.5/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 1                |                                                                                                                  |
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.5/operate/cluster.md
+++ b/content/docs/2.5/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover.<br /><br />This is only supported as of KEDA v2.6 if you are using our Helm chart.|
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be active. The rest will be standing by, which may reduce downtime during a failure. Multiple replicas will not improve the performance of KEDA, it might only reduce downtime during a failover.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.6/operate/cluster.md
+++ b/content/docs/2.6/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce a downtime during a failover.|
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be active. The rest will be standing by, which may reduce downtime during a failure. Multiple replicas will not improve the performance of KEDA, it could only reduce a downtime during a failover.|
 
 ## HTTP Timeouts
 

--- a/content/docs/2.6/operate/cluster.md
+++ b/content/docs/2.6/operate/cluster.md
@@ -39,7 +39,7 @@ Here is an overview of all KEDA deployments and the supported replicas:
 | Deployment     | Support Replicas | Reasoning                                                                                                        |
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Metrics Server | 1                | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-| Operator       | 1                |                                                                                                                  |
+| Operator       | 2                | While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce a downtime during a failover.|
 
 ## HTTP Timeouts
 


### PR DESCRIPTION
Document running multiple operator instances for HA reasons to reduce the time to spin up a new instance.

Thanks to @mtparet for the contribution

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Follow-up for #381
