### PR TITLE
Update info on AAD Pod Identity Parameter

### DIFF
--- a/content/docs/1.4/concepts/authentication.md
+++ b/content/docs/1.4/concepts/authentication.md
@@ -165,7 +165,7 @@ podIdentity:
   provider: azure # Optional. Default: false
 ```
 
-Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set aadPodIdentity={your-label-name}`.
+Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set podIdentity.activeDirectory.identity={your-label-name}`. The Helm Chart parameter may change, so it is recommended to refer to the [Keda Helm Chart Configuration on GitHub](https://github.com/kedacore/charts/tree/main/keda) for the latest information.
 
 #### EKS Pod Identity Webhook for AWS
 


### PR DESCRIPTION
Update info on AAD Pod Identity Parameter

I have been working on a deployment of Dapr/Keda to expand my knowledge in this area. I stumbled upon this doc, and planned to use it to enable Pod Identity for KEDA. The aadPodIdentity setting did not work for me. After reviewing the GitHub repo at kedacore/charts, I found that the correct parameter is actually podIdentity.activeDirectory.identity. Updating the docs to reflect that, and to also point to the helm chart for future reference.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
