### PR TITLE
Fix typo in kinesis stream example

### DIFF
--- a/content/docs/1.4/scalers/aws-kinesis.md
+++ b/content/docs/1.4/scalers/aws-kinesis.md
@@ -92,7 +92,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/1.5/scalers/aws-kinesis.md
+++ b/content/docs/1.5/scalers/aws-kinesis.md
@@ -92,7 +92,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.0/scalers/aws-kinesis.md
+++ b/content/docs/2.0/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.1/scalers/aws-kinesis.md
+++ b/content/docs/2.1/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.2/scalers/aws-kinesis.md
+++ b/content/docs/2.2/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.3/scalers/aws-kinesis.md
+++ b/content/docs/2.3/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.4/scalers/aws-kinesis.md
+++ b/content/docs/2.4/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.5/scalers/aws-kinesis.md
+++ b/content/docs/2.5/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream

--- a/content/docs/2.6/scalers/aws-kinesis.md
+++ b/content/docs/2.6/scalers/aws-kinesis.md
@@ -89,7 +89,7 @@ spec:
   triggers:
     - type: aws-kinesis-stream
       authenticationRef:
-        name: keda-trigger-auth-aws-credential
+        name: keda-trigger-auth-aws-credentials
       metadata:
         # Required
         streamName: myKinesisStream


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Fix typo in kineses stream example in Keda docs. There's typo in the name `keda-trigger-auth-aws-credentials` when it is used later in the Scaled Object to refer to the Trigger Authentication resource created with same name. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
