### PR TITLE
docs: Provide warning that entities are not managed for Azure Service Bus

### DIFF
--- a/content/docs/2.0/scalers/azure-service-bus.md
+++ b/content/docs/2.0/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus

--- a/content/docs/2.1/scalers/azure-service-bus.md
+++ b/content/docs/2.1/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus

--- a/content/docs/2.2/scalers/azure-service-bus.md
+++ b/content/docs/2.2/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus

--- a/content/docs/2.3/scalers/azure-service-bus.md
+++ b/content/docs/2.3/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus

--- a/content/docs/2.4/scalers/azure-service-bus.md
+++ b/content/docs/2.4/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus

--- a/content/docs/2.5/scalers/azure-service-bus.md
+++ b/content/docs/2.5/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus

--- a/content/docs/2.6/scalers/azure-service-bus.md
+++ b/content/docs/2.6/scalers/azure-service-bus.md
@@ -11,6 +11,8 @@ go_file = "azure_servicebus_scaler"
 
 This specification describes the `azure-servicebus` trigger for Azure Service Bus Queue or Topic.
 
+> ⚠️ **WARNING:** KEDA is not in charge of managing entities. If the queue, topic or subscription does not exist, it will not create them automatically.
+
 ```yaml
 triggers:
 - type: azure-servicebus


### PR DESCRIPTION
Provide a warning that entities are not managed for Azure Service Bus which is not clear at the moment for end-users.

This is done based on end-user feedback by @seanfeldman.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
