### PR TITLE
doc: Extend info about hpa metric value in faq

### DIFF
--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -66,7 +66,7 @@ The target metric value is used by the Horizontal Pod Autoscaler (HPA) to make s
 
 The current target value on the Horizontal Pod Autoscaler (HPA) often does not match with the metrics on the system you are scaling on. This is because of how the Horizontal Pod Autoscaler's (HPA) [scaling algorithm](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) works.
 
-If you are checking your metric directly in the HPA, take in consideration that KEDA currently only supports `average` metrics, so the value that you will see in the HPA is the average of the metric between the total amount of pods.
+If you are checking your metric directly in the HPA, take in consideration that KEDA currently only supports average metrics, so the value that you will see in the HPA is the average of the metric between the total amount of pods.
 """
 type = "Kubernetes"
 

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -65,6 +65,8 @@ a = """
 The target metric value is used by the Horizontal Pod Autoscaler (HPA) to make scaling decisions.
 
 The current target value on the Horizontal Pod Autoscaler (HPA) often does not match with the metrics on the system you are scaling on. This is because of how the Horizontal Pod Autoscaler's (HPA) [scaling algorithm](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) works.
+
+If you are checking your metric directly in the HPA, take in consideration that KEDA currently only supports `average` metrics, so the value that you will see in the HPA is the average of the metric between the total amount of pods.
 """
 type = "Kubernetes"
 

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -66,7 +66,7 @@ The target metric value is used by the Horizontal Pod Autoscaler (HPA) to make s
 
 The current target value on the Horizontal Pod Autoscaler (HPA) often does not match with the metrics on the system you are scaling on. This is because of how the Horizontal Pod Autoscaler's (HPA) [scaling algorithm](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) works.
 
-If you are checking your metric directly in the HPA, take in consideration that KEDA currently only supports average metrics, so the value that you will see in the HPA is the average of the metric between the total amount of pods.
+KEDA currently only supports average metrics. This means that the HPA will use the average value of the metric between the total amount of pods.
 """
 type = "Kubernetes"
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR extends the information about possible differences between the value that the user could see in the metric source and the target value in the HPA.

The change looks like this:
![image](https://user-images.githubusercontent.com/36899226/149221208-fd2c3ad1-1567-44c2-8758-fe22a308816f.png)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related https://github.com/kedacore/keda/discussions/2451