### PR TITLE
docs: Fix typo in scaling-deployment docs

### DIFF
--- a/content/docs/2.5/concepts/scaling-deployments.md
+++ b/content/docs/2.5/concepts/scaling-deployments.md
@@ -113,7 +113,7 @@ The `cooldownPeriod` only applies after a trigger occurs; when you first create 
   idleReplicaCount: 0   # Optional. Must be less than minReplicaCount
 ```
 
-> 💡 **NOTE:** Due to limitations in HPA controller the only supported value for this property is 0, it will not work corrently otherwise. See this [issue](https://github.com/kedacore/keda/issues/2314) for more details.
+> 💡 **NOTE:** Due to limitations in HPA controller the only supported value for this property is 0, it will not work correctly otherwise. See this [issue](https://github.com/kedacore/keda/issues/2314) for more details.
 
 If this property is set, KEDA will scale the resource down to this number of replicas. If there's some activity on target triggers KEDA will scale the target resource immediately to `minReplicaCount` and then will be scaling handled by HPA. When there is no activity, the target resource is again scaled down to `idleReplicaCount`. This seting must be less than `minReplicaCount`.
 

--- a/content/docs/2.6/concepts/scaling-deployments.md
+++ b/content/docs/2.6/concepts/scaling-deployments.md
@@ -113,7 +113,7 @@ The `cooldownPeriod` only applies after a trigger occurs; when you first create 
   idleReplicaCount: 0   # Optional. Must be less than minReplicaCount
 ```
 
-> 💡 **NOTE:** Due to limitations in HPA controller the only supported value for this property is 0, it will not work corrently otherwise. See this [issue](https://github.com/kedacore/keda/issues/2314) for more details.
+> 💡 **NOTE:** Due to limitations in HPA controller the only supported value for this property is 0, it will not work correctly otherwise. See this [issue](https://github.com/kedacore/keda/issues/2314) for more details.
 
 If this property is set, KEDA will scale the resource down to this number of replicas. If there's some activity on target triggers KEDA will scale the target resource immediately to `minReplicaCount` and then will be scaling handled by HPA. When there is no activity, the target resource is again scaled down to `idleReplicaCount`. This seting must be less than `minReplicaCount`.
 


### PR DESCRIPTION
This PR fixes a typo (corrently => correctly) in scaling-deployment.md
in 2.5 and 2.6 versions

Signed-off-by: Ram Cohen <ram.cohen@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
