### PR TITLE
docs: Provide Azure Application Insights scaler

### DIFF
--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -26,7 +26,7 @@ triggers:
     tenantIdFromEnv: TENANT_ID` # Optional, can use TriggerAuthentication as well
 ```
 
-This scaler is backed by the Azure Application Instance REST API. Please see [this](https://dev.applicationinsights.io/reference) page
+This scaler is backed by the Azure Application Instance REST API. Please see [this](https://docs.microsoft.com/en-us/rest/api/application-insights/metrics/get) page
 for further details.
 
 **Parameter list:**

--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -154,16 +154,16 @@ spec:
       - name: example
         image: nginx:1.16.1
         env:
+        - name: ACTIVE_DIRECTORY_ID
+          valueFrom:
+            secretKeyRef:
+              name: azure-app-insights-secrets
+              key: activeDirectoryClientId
         - name: ACTIVE_DIRECTORY_PASSWORD
           valueFrom:
             secretKeyRef:
               name: azure-app-insights-secrets
               key: activeDirectoryClientPassword
-        - name: ACTIVE_DIRECTORY_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: azure-app-insights-secrets
-              key: activeDirectoryClientId
         - name: APP_INSIGHTS_APP_ID
           valueFrom:
             secretKeyRef:
@@ -194,8 +194,8 @@ spec:
         metricAggregationType: avg
         metricFilter: cloud/roleName eq 'example'
         targetValue: "1"
+        activeDirectoryClientIdFromEnv: ACTIVE_DIRECTORY_ID
         activeDirectoryClientPasswordFromEnv: ACTIVE_DIRECTORY_PASSWORD
-        activeDirectoryClientIdFromEnv: ACTIVE_DIRECTORY_USERNAME
         applicationInsightsIdFromEnv: APP_INSIGHTS_APP_ID
         tenantIdFromEnv: TENANT_ID
 ```

--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -18,7 +18,7 @@ triggers:
     metricAggregationTimespan: "0:1"
     metricAggregationType: avg
     metricFilter: cloud/roleName eq 'role_name'
-    metricName: "customMetrics/example-metric"
+    metricId: "customMetrics/example-metric"
     targetValue: "1"
     activeDirectoryClientIdFromEnv: CLIENT_ID_ENV_NAME # Optional, can use TriggerAuthentication as well
     activeDirectoryClientPasswordFromEnv: CLIENT_PASSWORD_ENV_NAME # Optional, can use TriggerAuthentication as well
@@ -32,11 +32,11 @@ for further details.
 **Parameter list:**
 
 - `tenantId` - Id of the tenant that contains the Azure resource. This is used for authentication.
-- `metricName` - The name of the Application Insights metric to query. Use the `az monitor app-insights metrics get-metadata` to see a list of available metrics.
+- `metricId` - The name of the Application Insights metric to query. Run `az monitor app-insights metrics get-metadata` to see a list of available metrics.
 - `targetValue` - Target value to trigger scaling actions.
 - `metricAggregationType` - Aggregation method of the Azure Application Insights metric. The aggregation methods vary from metric to metric. The `az monitor app-insights metrics get-metadata` command can be used to determine which methods apply to a given metric. (Some common aggregation methods are `avg`, `count`, `sum`, `min`, and `max`)
 - `metricAggregationInterval` - Collection time of the metric in format `"hh:mm"`.
-- `appId` - Id of the application. This is a GUID that can be retrieved from the Application Insight's `API Access` blade in the Azure Portal.
+- `applicationInsightsId` - Id of the Application Insights instance to query. This is a GUID that can be retrieved from the Application Insight's `API Access` blade in the Azure Portal.
 - `tenantId` - Id of the tenant containing the Application Insights instance.
 - `activeDirectoryClientId` - Id of the Active Directory client. The client must have `Monitoring Reader` permissions for the Application Insights instance.
 - `activeDirectoryClientPassword` - Password of the Active Directory client password.
@@ -46,7 +46,7 @@ Some parameters can be provided using environmental variables, instead of settin
 
 - `activeDirectoryClientIdFromEnv` - Name of the environment variable that contains the Id of the Active Directory application. (Optional)
 - `activeDirectoryClientPasswordFromEnv` - Name of the environment variable that contains the Active Directory client password. (Optional)
-- `appIdFromEnv` - Name of the environment variable that contains the Application Insights Id. (Optional)
+- `applicationInsightsIdFromEnv` - Name of the environment variable that contains the Application Insights Id. (Optional)
 - `tenantIdFromEnv` - Name of the environment variable that contains the Id of the tenant that contains the Application Insights instance. (Optional)
 
 ### Authentication Parameters
@@ -70,7 +70,7 @@ metadata:
 data:
   activeDirectoryClientId: <clientId>
   activeDirectoryClientPassword: <clientPassword>
-  appId: <appInsightsAppId>
+  applicationInsightsId: <appInsightsAppId>
   tenantId: <tenantId>
 ---
 apiVersion: keda.sh/v1alpha1
@@ -85,9 +85,9 @@ spec:
     - parameter: activeDirectoryClientPassword
       name: azure-app-insights-secrets
       key: activeDirectoryClientPassword
-    - parameter: appId
+    - parameter: applicationInsightsId
       name: azure-app-insights-secrets
-      key: appId
+      key: applicationInsightsId
     - parameter: tenantId
       name: azure-app-insights-secrets
       key: tenantId
@@ -107,7 +107,7 @@ spec:
   triggers:
   - type: azure-app-insights
     metadata:
-      metricName: "customMetrics/example-metric"
+      metricId: "customMetrics/example-metric"
       metricAggregationTimespan: "0:5"
       metricAggregationType: avg
       metricFilter: cloud/roleName eq 'example'

--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -1,7 +1,7 @@
 +++
 title = "Azure Application Insights"
 layout = "scaler"
-availability = "v1.3+"
+availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on Azure Application Insights metrics."
 go_file = "azure_app_insights_scaler"
@@ -18,8 +18,7 @@ triggers:
     metricAggregationTimespan: "0:1"
     metricAggregationType: avg
     metricFilter: cloud/roleName eq 'role_name'
-    metricName: "metric_name"
-    metricNamespace: "customMetrics"
+    metricName: "customMetrics/example-metric"
     targetValue: "1"
     activeDirectoryClientIdFromEnv: CLIENT_ID_ENV_NAME # Optional, can use TriggerAuthentication as well
     activeDirectoryClientPasswordFromEnv: CLIENT_PASSWORD_ENV_NAME # Optional, can use TriggerAuthentication as well
@@ -33,23 +32,22 @@ for further details.
 **Parameter list:**
 
 - `tenantId` - Id of the tenant that contains the Azure resource. This is used for authentication.
-- `metricName` - Name of the Application Insights metric to query.
-- `metricNamespace` - Name of the metric's namespace.
+- `metricName` - The name of the Application Insights metric to query. Use the `az monitor app-insights metrics get-metadata` to see a list of available metrics.
 - `targetValue` - Target value to trigger scaling actions.
-- `metricAggregationType` - Aggregation method of the Azure Application Insights metric. Options include `avg`, `sum`, `min`, and `max`.
-- `metricAggregationInterval` - Collection time of the metric in format `"hh:mm"`
-- `appId` - Id of the application. This can be retrieved from the Application Insight's `API Access` blade in Azure Portal.
+- `metricAggregationType` - Aggregation method of the Azure Application Insights metric. The aggregation methods vary from metric to metric. The `az monitor app-insights metrics get-metadata` command can be used to determine which methods apply to a given metric. (Some common aggregation methods are `avg`, `count`, `sum`, `min`, and `max`)
+- `metricAggregationInterval` - Collection time of the metric in format `"hh:mm"`.
+- `appId` - Id of the application. This is a GUID that can be retrieved from the Application Insight's `API Access` blade in the Azure Portal.
 - `tenantId` - Id of the tenant containing the Application Insights instance.
-- `activeDirectoryClientId` - Id of the Active Directory application which requires at least `Monitoring Reader` permissions.
+- `activeDirectoryClientId` - Id of the Active Directory client. The client must have `Monitoring Reader` permissions for the Application Insights instance.
 - `activeDirectoryClientPassword` - Password of the Active Directory client password.
 - `metricFilter` - Further specify the metrics query using a filter. For example `cloud/roleName eq 'example`. (Optional)
 
 Some parameters can be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 
-- `activeDirectoryClientIdFromEnv` - Name of the environment variable that contains the Id of the Active Directory application.
-- `activeDirectoryClientPasswordFromEnv` - Name of the environment variable that contains the Active Directory client password.
-- `appIdFromEnv` - Name of the environment variable that contains the Application Insights Id.
-- `tenantIdFromEnv` - Name of the environment variable that contains the Id of the tenant that contains the Application Insights instance.
+- `activeDirectoryClientIdFromEnv` - Name of the environment variable that contains the Id of the Active Directory application. (Optional)
+- `activeDirectoryClientPasswordFromEnv` - Name of the environment variable that contains the Active Directory client password. (Optional)
+- `appIdFromEnv` - Name of the environment variable that contains the Application Insights Id. (Optional)
+- `tenantIdFromEnv` - Name of the environment variable that contains the Id of the tenant that contains the Application Insights instance. (Optional)
 
 ### Authentication Parameters
 
@@ -109,8 +107,7 @@ spec:
   triggers:
   - type: azure-app-insights
     metadata:
-      metricName: "example-metric"
-      metricNamespace: "customMetrics"
+      metricName: "customMetrics/example-metric"
       metricAggregationTimespan: "0:5"
       metricAggregationType: avg
       metricFilter: cloud/roleName eq 'example'

--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -37,7 +37,6 @@ for further details.
 - `metricAggregationType` - Aggregation method of the Azure Application Insights metric. The aggregation methods vary from metric to metric. The `az monitor app-insights metrics get-metadata` command can be used to determine which methods apply to a given metric. (Some common aggregation methods are `avg`, `count`, `sum`, `min`, and `max`)
 - `metricAggregationInterval` - Collection time of the metric in format `"hh:mm"`.
 - `applicationInsightsId` - Id of the Application Insights instance to query. This is a GUID that can be retrieved from the Application Insight's `API Access` blade in the Azure Portal.
-- `tenantId` - Id of the tenant containing the Application Insights instance.
 - `activeDirectoryClientId` - Id of the Active Directory client. The client must have `Monitoring Reader` permissions for the Application Insights instance.
 - `activeDirectoryClientPassword` - Password of the Active Directory client password.
 - `metricFilter` - Further specify the metrics query using a filter. For example `cloud/roleName eq 'example`. (Optional)
@@ -60,7 +59,12 @@ You can use the `TriggerAuthentication` CRD to configure the authentication by p
 - `applicationInsightsId` - Id of the Application Insights instance to query.
 - `tenantId` - Id of the tenant that contains the Azure resource.
 
-The user will need access to read data from the Azure resource.
+The principal will need `Monitoring Reader` access to query metrics from the Application Insights instance.
+
+**Pod identity based authentication:**
+
+[Azure Active Directory pod-managed identity](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) can be used
+in place of credential based authentication. The following section contains an example of a `TriggerAuthentication` using pod identity.
 
 ### Example
 

--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -22,7 +22,7 @@ triggers:
     targetValue: "1"
     activeDirectoryClientIdFromEnv: CLIENT_ID_ENV_NAME # Optional, can use TriggerAuthentication as well
     activeDirectoryClientPasswordFromEnv: CLIENT_PASSWORD_ENV_NAME # Optional, can use TriggerAuthentication as well
-    appIdFromEnv: APP_ID # Optional, can use TriggerAuthentication as well
+    applicationInsightsIdFromEnv: APP_ID # Optional, can use TriggerAuthentication as well
     tenantIdFromEnv: TENANT_ID` # Optional, can use TriggerAuthentication as well
 ```
 


### PR DESCRIPTION
Signed-off-by: Mark Rzasa <mark.rzasa@gmail.com>

This is the documentation for an Azure Application Insights scaler. This is related to this issue:

https://github.com/kedacore/keda/issues/1965

This pull request is marked as a draft because an app insights scaler may not be necessary to resolve issue 1965. Alternatively, the Azure Log Analytics scaler could be used to read app insights metrics from the AppMetrics table.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #1965
