### PR TITLE
Fix an error in docs related with RabbitMQ Scaler

### DIFF
--- a/content/docs/2.4/scalers/rabbitmq-queue.md
+++ b/content/docs/2.4/scalers/rabbitmq-queue.md
@@ -47,7 +47,7 @@ Some parameters could be provided using environmental variables, instead of sett
 
 > 💡 **Note:** `mode: MessageRate` requires protocol `http`.
 
-> 💡 **Note:** `useRegex: "true"` requires protocol `http` and ignores unacknowledged messages.
+> 💡 **Note:** `useRegex: "true"` requires protocol `http`.
 
 > ⚠ **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 

--- a/content/docs/2.5/scalers/rabbitmq-queue.md
+++ b/content/docs/2.5/scalers/rabbitmq-queue.md
@@ -51,7 +51,7 @@ Some parameters could be provided using environmental variables, instead of sett
 
 > 💡 **Note:** `mode: MessageRate` requires protocol `http`.
 
-> 💡 **Note:** `useRegex: "true"` requires protocol `http` and ignores unacknowledged messages.
+> 💡 **Note:** `useRegex: "true"` requires protocol `http`.
 
 > ⚠ **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 

--- a/content/docs/2.6/scalers/rabbitmq-queue.md
+++ b/content/docs/2.6/scalers/rabbitmq-queue.md
@@ -51,7 +51,7 @@ Some parameters could be provided using environmental variables, instead of sett
 
 > 💡 **Note:** `mode: MessageRate` requires protocol `http`.
 
-> 💡 **Note:** `useRegex: "true"` requires protocol `http` and ignores unacknowledged messages.
+> 💡 **Note:** `useRegex: "true"` requires protocol `http`.
 
 > ⚠ **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 

--- a/content/docs/2.7/scalers/rabbitmq-queue.md
+++ b/content/docs/2.7/scalers/rabbitmq-queue.md
@@ -51,7 +51,7 @@ Some parameters could be provided using environmental variables, instead of sett
 
 > 💡 **Note:** `mode: MessageRate` requires protocol `http`.
 
-> 💡 **Note:** `useRegex: "true"` requires protocol `http` and ignores unacknowledged messages.
+> 💡 **Note:** `useRegex: "true"` requires protocol `http`.
 
 > ⚠ **Important:** if you have unacknowledged messages and want to have these counted for the scaling to happen, make sure to utilize the `http` REST API interface which allows for these to be counted.
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

As we have been discussing [here](https://github.com/kedacore/keda/issues/2572), the docs are wrong because they say:
`> 💡 **Note:** `useRegex: "true"` requires protocol `http` and ignores unacknowledged messages`
But we are using the key `messages` which is already the total count of the messages, including unacknowledged

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda/issues/2572
