### PR TITLE
docs: KEDA v2.5+ requires Kubernetes v1.17

### DIFF
--- a/content/docs/2.0/operate/cluster.md
+++ b/content/docs/2.0/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.16.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,6 +23,17 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
+### Firewall
+
+KEDA requires to be accessible inside the cluster to be able to autoscale.
+
+Here is an overview of the required ports that need to be accessible for KEDA to work:
+
+| Port   | Why?                                         | Remarks                                              |
+| ------ | -------------------------------------------- | ---------------------------------------------------- |
+| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms, except for Google Cloud. |
+| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud                       |
+
 ## High Availability
 
 KEDA does not provide support for high-availability due to upstream limitations.
@@ -27,14 +44,3 @@ Here is an overview of all KEDA deployments and the supported replicas:
 |----------------|-------------------------|-------------------------------|
 | Operator       | 1                       |                               |
 | Metrics Server | 1                       | Limitation in [k8s custom metrics server](https://github.com/kubernetes-sigs/custom-metrics-apiserver/issues/70) |
-
-## Firewall requirements
-
-KEDA requires to be accessible inside the cluster to be able to autoscale.
-
-Here is an overview of the required ports that need to be accessible for KEDA to work:
-
-| Port   | Why?                                         | Remarks                                              |
-| ------ | -------------------------------------------- | ---------------------------------------------------- |
-| `443`  | Used by Kubernetes API server to get metrics | Required for all platforms, except for Google Cloud. |
-| `6443` | Used by Kubernetes API server to get metrics | Only required for Google Cloud                       |

--- a/content/docs/2.1/operate/cluster.md
+++ b/content/docs/2.1/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.16.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/content/docs/2.2/operate/cluster.md
+++ b/content/docs/2.2/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.16.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/content/docs/2.3/operate/cluster.md
+++ b/content/docs/2.3/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.16.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/content/docs/2.4/operate/cluster.md
+++ b/content/docs/2.4/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.16.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/content/docs/2.5/operate/cluster.md
+++ b/content/docs/2.5/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/content/docs/2.6/operate/cluster.md
+++ b/content/docs/2.6/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/content/docs/2.7/operate/cluster.md
+++ b/content/docs/2.7/operate/cluster.md
@@ -4,7 +4,13 @@ description = "Guidance & requirements for running KEDA in your cluster"
 weight = 100
 +++
 
-## Cluster capacity requirements
+## Requirements
+
+### Kubernetes
+
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+
+### Cluster Capacity
 
 The KEDA runtime require the following resources in a production-ready setup:
 
@@ -17,7 +23,7 @@ These are used by default when deploying through YAML.
 
 > 💡 For more info on CPU and Memory resource units and their meaning, see [this](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) link.
 
-## Firewall requirements
+### Firewall
 
 KEDA requires to be accessible inside the cluster to be able to autoscale.
 

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -6,7 +6,9 @@ type = "General"
 [[qna]]
 q = "What are the prerequisites for using KEDA?"
 a = """
-KEDA is designed to be run on any Kubernetes cluster. It uses a CRD (custom resource definition) and the Kubernetes metric server so you will have to use a Kubernetes version which supports these. Any Kubernetes cluster >= 1.17.0 has been tested and is supported."
+KEDA is designed, tested and is supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+
+It uses a CRD (custom resource definition) and the Kubernetes metric server so you will have to use a Kubernetes version which supports these.
 
 > 💡 Kubernetes v1.16 is supported with KEDA v2.4.0 or below
 """

--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -5,7 +5,11 @@ type = "General"
 
 [[qna]]
 q = "What are the prerequisites for using KEDA?"
-a = "KEDA is designed to be run on any Kubernetes cluster. It uses a CRD (custom resource definition) and the Kubernetes metric server so you will have to use a Kubernetes version which supports these. Any Kubernetes cluster >= 1.16.0 has been tested and should work."
+a = """
+KEDA is designed to be run on any Kubernetes cluster. It uses a CRD (custom resource definition) and the Kubernetes metric server so you will have to use a Kubernetes version which supports these. Any Kubernetes cluster >= 1.17.0 has been tested and is supported."
+
+> 💡 Kubernetes v1.16 is supported with KEDA v2.4.0 or below
+"""
 type = "General"
 
 [[qna]]


### PR DESCRIPTION
KEDA v2.5+ requires Kubernetes v1.17

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/charts/issues/241
