### PR TITLE
Netlify CLI: add framework flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "_check-links": "make check-links",
     "_prebuild": "echo placeholder for now > /dev/null",
     "_serve:hugo": "hugo serve -DFE --minify",
-    "_serve": "netlify dev -c \"npm run _serve:hugo\"",
+    "_serve": "netlify dev -c \"npm run _serve:hugo\" --framework hugo",
     "build:preview": "set -x && npm run _build -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "npm run _build",


### PR DESCRIPTION
When invoking `npm run serve`, the [Netlify-CLI dev command](https://cli.netlify.com/commands/dev) prompts us to choose a command, but it shouldn't because we explicitly provide a command via `-c`. We seem to be hitting the following issue: https://github.com/netlify/cli/issues/410. This PR implements the recommended workaround.

/cc @nate-double-u