### PR TITLE
Update link checking scripts / targets

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -3,3 +3,5 @@ IgnoreDirectoryMissingTrailingSlash: true
 CheckExternal: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
+IgnoreInternalURLs:
+  - /docs/2.6/scalers/solace-pub-sub/ # Due to https://github.com/kedacore/keda-docs/issues/693

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,24 @@
+HTMLTEST_DIR=tmp
+HTMLTEST?=htmltest # Specify as make arg if different
+HTMLTEST_ARGS?=--skip-external
+
+DOCS=public/docs
+LATEST_VERSION=$(shell grep -e '^docs' config.toml | grep -oe '\d\.\d' | head -1)
+LATEST_VERSION2=`grep -e '^docs' config.toml | grep -oe '\d\.\d' | head -1`
+
+# Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
+ifeq (, $(shell which $(HTMLTEST)))
+override HTMLTEST=$(HTMLTEST_DIR)/bin/htmltest
+ifeq (, $(shell which $(HTMLTEST)))
+GET_LINK_CHECKER_IF_NEEDED=get-link-checker
+endif
+endif
+
 build: clean
 	hugo -e development -DFE
 
 clean:
-	rm -rf public/* resources
+	rm -rf $(HTMLTEST_DIR) public/* resources
 
 serve:
 	hugo server \
@@ -23,10 +39,15 @@ preview-build: clean
 open:
 	open https://keda.sh
 
-link-checker-setup:
-	curl https://htmltest.wjdp.uk | bash
+check-links: $(GET_LINK_CHECKER_IF_NEEDED) make-redirects-for-checking
+	$(HTMLTEST) $(HTMLTEST_ARGS)
+	find public/* -type l -ls -exec rm -f {} \;
 
-run-link-checker:
-	bin/htmltest
+make-redirects-for-checking:
+	@echo "Creating symlinks of 'latest' to $(LATEST_VERSION) for the purpose of link checking"
+	(cd public && rm -f scalers && ln -s docs/$(LATEST_VERSION)/scalers scalers)
+	(cd public/docs && rm -f latest && ln -s $(LATEST_VERSION) latest)
 
-check-links: link-checker-setup run-link-checker
+get-link-checker:
+	rm -Rf $(HTMLTEST_DIR)/bin
+	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin


### PR DESCRIPTION
As of this PR, (internal) link checking passes (with one link being skipped):

```console
$ npm run check-links

>> precheck-links
>> npm run build
...
tmp/bin/htmltest --skip-external
Skipping the checking of external links.
htmltest started at 03:34:38 on public
========================================================================
✔✔✔ passed in 639.868346ms
tested 532 documents
...
```