### PR TITLE
Enable link checking for preview and production builds, adjust Netlify config

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,3 +5,4 @@ IgnoreAltMissing: true
 IgnoreEmptyHref: true
 IgnoreInternalURLs:
   - /docs/2.6/scalers/solace-pub-sub/ # Due to https://github.com/kedacore/keda-docs/issues/693
+  - /docs/latest/scalers/solace-pub-sub/ # Due to https://github.com/kedacore/keda-docs/issues/693

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,6 @@
 [build]
 publish = "public"
-command = "make production-build"
+command = "npm run build:preview"
 
-[context.deploy-preview]
-command = "make preview-build"
-
-[context.branch-deploy]
-command = "make preview-build"
+[context.production]
+command = "npm run build:production"


### PR DESCRIPTION
- **Enable link checking** for preview and production builds.
- Make targets using `hugo` were (potentially) picking up the wrong version of hugo; the proper command would be `npx hugo`, but we don't need those targets anymore since we have NPM scripts for each of them.
