### PR TITLE
Solace scaler file name fix

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -3,6 +3,3 @@ IgnoreDirectoryMissingTrailingSlash: true
 CheckExternal: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
-IgnoreInternalURLs:
-  - /docs/2.6/scalers/solace-pub-sub/ # Due to https://github.com/kedacore/keda-docs/issues/693
-  - /docs/latest/scalers/solace-pub-sub/ # Due to https://github.com/kedacore/keda-docs/issues/693

--- a/content/docs/2.4/scalers/solace-pub-sub.md
+++ b/content/docs/2.4/scalers/solace-pub-sub.md
@@ -92,7 +92,7 @@ spec:
       queueName:               SCALED_CONSUMER_QUEUE1
       messageCountTarget:      '50'
       messageSpoolUsageTarget: '100000'
-    authenticationRef: 
+    authenticationRef:
       name: solace-trigger-auth
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.5/scalers/solace-pub-sub.md
+++ b/content/docs/2.5/scalers/solace-pub-sub.md
@@ -5,9 +5,11 @@ maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
 layout = "scaler"
 go_file = "solace_scaler"
+aliases = ["solace"]
 +++
 
 ### Trigger Specification
+
 This specification describes the `solace-event-queue` trigger that scales based on a Solace PubSub+ Event Broker queue.
 
 ```yaml
@@ -26,6 +28,7 @@ triggers:
 ```
 
 **Parameter list:**
+
 - `solaceSempBaseURL` - Solace SEMP Endpoint in format: `<protocol>://<host-or-service>:<port>`.
 - `messageVpn` - Message VPN hosted on the Solace broker.
 - `queueName` - Message Queue to be monitored.
@@ -37,11 +40,13 @@ triggers:
 - `passwordFromEnv` - Environment variable set with password for the user account.
 
 **Parameter Requirements:**
+
 - Parameters resolving the target queue are all **required:** `solaceSempBaseURL`, `messageVpn`, `queueName`
 - **At least** one of `messageCountTarget` or `messageSpoolUsageTarget` is **required.** If both values are present, the metric value resulting in the higher desired replicas will be used. (Standard KEDA/HPA behavior)
 - The Solace PubSub+ Scaler polls the Solace SEMP REST API to monitor target queues. Currently, the scaler supports basic authentication. `username` and `password` are **required** for the `solace-event-queue` trigger to function. These values may be set directly in the trigger metadata or using a TriggerAuthentication record. See [Authentication Parameters](#authentication-parameters) below. Alternatively, credentials may be passed from environment variables identified by `usernameFromEnv` and `passwordFromEnv`.
 
 ### Authentication Parameters
+
 You can use TriggerAuthentication CRD to configure the username and password to connect to the management endpoint.
 
 **Username and Password based authentication:**
@@ -49,6 +54,7 @@ You can use TriggerAuthentication CRD to configure the username and password to 
 - `password` - Required. The password to use to connect to the Solace PubSub+ Event Broker's SEMP endpoint.
 
 ### Example
+
 The objects in the example below are declared in `namespace=solace`. It is not required to do so. If you do define a namespace for the configuration objects, then they should all be delcared in the same namespace.
 
 ```yaml
@@ -86,7 +92,7 @@ spec:
       queueName:               SCALED_CONSUMER_QUEUE1
       messageCountTarget:      '50'
       messageSpoolUsageTarget: '100000'
-    authenticationRef: 
+    authenticationRef:
       name: solace-trigger-auth
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.6/scalers/solace-pub-sub.md
+++ b/content/docs/2.6/scalers/solace-pub-sub.md
@@ -5,9 +5,11 @@ maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
 layout = "scaler"
 go_file = "solace_scaler"
+aliases = ["solace"]
 +++
 
 ### Trigger Specification
+
 This specification describes the `solace-event-queue` trigger that scales based on a Solace PubSub+ Event Broker queue.
 
 ```yaml
@@ -26,6 +28,7 @@ triggers:
 ```
 
 **Parameter list:**
+
 - `solaceSempBaseURL` - Solace SEMP Endpoint in format: `<protocol>://<host-or-service>:<port>`.
 - `messageVpn` - Message VPN hosted on the Solace broker.
 - `queueName` - Message Queue to be monitored.
@@ -37,11 +40,13 @@ triggers:
 - `passwordFromEnv` - Environment variable set with password for the user account.
 
 **Parameter Requirements:**
+
 - Parameters resolving the target queue are all **required:** `solaceSempBaseURL`, `messageVpn`, `queueName`
 - **At least** one of `messageCountTarget` or `messageSpoolUsageTarget` is **required.** If both values are present, the metric value resulting in the higher desired replicas will be used. (Standard KEDA/HPA behavior)
 - The Solace PubSub+ Scaler polls the Solace SEMP REST API to monitor target queues. Currently, the scaler supports basic authentication. `username` and `password` are **required** for the `solace-event-queue` trigger to function. These values may be set directly in the trigger metadata or using a TriggerAuthentication record. See [Authentication Parameters](#authentication-parameters) below. Alternatively, credentials may be passed from environment variables identified by `usernameFromEnv` and `passwordFromEnv`.
 
 ### Authentication Parameters
+
 You can use TriggerAuthentication CRD to configure the username and password to connect to the management endpoint.
 
 **Username and Password based authentication:**
@@ -49,6 +54,7 @@ You can use TriggerAuthentication CRD to configure the username and password to 
 - `password` - Required. The password to use to connect to the Solace PubSub+ Event Broker's SEMP endpoint.
 
 ### Example
+
 The objects in the example below are declared in `namespace=solace`. It is not required to do so. If you do define a namespace for the configuration objects, then they should all be delcared in the same namespace.
 
 ```yaml
@@ -86,7 +92,7 @@ spec:
       queueName:               SCALED_CONSUMER_QUEUE1
       messageCountTarget:      '50'
       messageSpoolUsageTarget: '100000'
-    authenticationRef: 
+    authenticationRef:
       name: solace-trigger-auth
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.7/scalers/solace-pub-sub.md
+++ b/content/docs/2.7/scalers/solace-pub-sub.md
@@ -8,6 +8,7 @@ go_file = "solace_scaler"
 +++
 
 ### Trigger Specification
+
 This specification describes the `solace-event-queue` trigger that scales based on a Solace PubSub+ Event Broker queue.
 
 ```yaml
@@ -26,6 +27,7 @@ triggers:
 ```
 
 **Parameter list:**
+
 - `solaceSempBaseURL` - Solace SEMP Endpoint in format: `<protocol>://<host-or-service>:<port>`.
 - `messageVpn` - Message VPN hosted on the Solace broker.
 - `queueName` - Message Queue to be monitored.
@@ -37,11 +39,13 @@ triggers:
 - `passwordFromEnv` - Environment variable set with password for the user account.
 
 **Parameter Requirements:**
+
 - Parameters resolving the target queue are all **required:** `solaceSempBaseURL`, `messageVpn`, `queueName`
 - **At least** one of `messageCountTarget` or `messageSpoolUsageTarget` is **required.** If both values are present, the metric value resulting in the higher desired replicas will be used. (Standard KEDA/HPA behavior)
 - The Solace PubSub+ Scaler polls the Solace SEMP REST API to monitor target queues. Currently, the scaler supports basic authentication. `username` and `password` are **required** for the `solace-event-queue` trigger to function. These values may be set directly in the trigger metadata or using a TriggerAuthentication record. See [Authentication Parameters](#authentication-parameters) below. Alternatively, credentials may be passed from environment variables identified by `usernameFromEnv` and `passwordFromEnv`.
 
 ### Authentication Parameters
+
 You can use TriggerAuthentication CRD to configure the username and password to connect to the management endpoint.
 
 **Username and Password based authentication:**
@@ -49,6 +53,7 @@ You can use TriggerAuthentication CRD to configure the username and password to 
 - `password` - Required. The password to use to connect to the Solace PubSub+ Event Broker's SEMP endpoint.
 
 ### Example
+
 The objects in the example below are declared in `namespace=solace`. It is not required to do so. If you do define a namespace for the configuration objects, then they should all be delcared in the same namespace.
 
 ```yaml
@@ -86,7 +91,7 @@ spec:
       queueName:               SCALED_CONSUMER_QUEUE1
       messageCountTarget:      '50'
       messageSpoolUsageTarget: '100000'
-    authenticationRef: 
+    authenticationRef:
       name: solace-trigger-auth
 ---
 apiVersion: keda.sh/v1alpha1


### PR DESCRIPTION
- Closes #693
- Adds aliases so as to avoid 404 for all officially published versions (which excludes 2.7, since that hasn't been officially released yet).
- Ensures that there were no unnecessary differences between the file versions -- such as a change in whitespace. 

View the file diff by ignoring changes in whitespace.

Preview & redirect tests:

- https://deploy-preview-705--keda.netlify.app/docs/2.4/scalers/solace-pub-sub
- https://deploy-preview-705--keda.netlify.app/docs/2.5/scalers/solace-pub-sub
- https://deploy-preview-705--keda.netlify.app/docs/2.5/scalers/solace
- https://deploy-preview-705--keda.netlify.app/docs/2.6/scalers/solace-pub-sub
- https://deploy-preview-705--keda.netlify.app/docs/2.6/scalers/solace
- https://deploy-preview-705--keda.netlify.app/docs/2.7/scalers/solace-pub-sub
