### PR TITLE
Fix deploy 404s

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,6 +1,6 @@
 {{ $docsLatest := index site.Params.versions.docs 0 -}}
 
-/docs     /docs/2.6     301!
+/docs     /docs/{{ $docsLatest }}     301!
 /docs/latest/*     /docs/{{ $docsLatest }}/:splat
 
 {{ $topLevel := slice "scalers" "faq" "troubleshooting" "operate" "concepts" "deploy" -}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,19 +1,16 @@
-{{- $docsLatest := index site.Params.versions.docs 0 -}}
-{{- $scalers    := where site.RegularPages "Section" "scalers" }}
-/docs     /docs/{{ $docsLatest }}     301!
+{{ $docsLatest := index site.Params.versions.docs 0 -}}
+
+/docs     /docs/2.6     301!
 /docs/latest/*     /docs/{{ $docsLatest }}/:splat
-/scalers     /docs/{{ $docsLatest }}/scalers     301!
-/docs/scalers/*     /docs/{{ $docsLatest }}/scalers/:splat
-/faq     /docs/{{ $docsLatest }}/faq     301!
-/docs/faq/*     /docs/{{ $docsLatest }}/faq/:splat
-/troubleshooting     /docs/{{ $docsLatest }}/troubleshooting     301!
-/docs/troubleshooting/*     /docs/{{ $docsLatest }}/troubleshooting/:splat
-/operate     /docs/{{ $docsLatest }}/operate     301!
-/docs/operate/*     /docs/{{ $docsLatest }}/operate/:splat
-/concepts     /docs/{{ $docsLatest }}/concepts     301!
-/docs/concepts/*     /docs/{{ $docsLatest }}/concepts/:splat
-/deploy     /docs/{{ $docsLatest }}deploy     301!
-/docs/deploy/*     /docs/{{ $docsLatest }}/deploy/:splat
+
+{{ $topLevel := slice "scalers" "faq" "troubleshooting" "operate" "concepts" "deploy" -}}
+{{ range $name := $topLevel -}}
+{{ $docp := printf "docs/%s/*" $name -}}
+{{ $name | printf "/%-29s" }}  /docs/{{ $docsLatest }}/{{ $name }}     301!
+{{ $docp | printf "/%-29s" }}  /docs/{{ $docsLatest }}/{{ $name }}/:splat
+{{ end -}}
+
+{{ $scalers    := where site.RegularPages "Section" "scalers" -}}
 {{- range $scalers -}}
 {{- $path := index (split .RelPermalink "/") 2 }}
 /docs/scalers/{{ $path }}     /scalers/{{ $path }}


### PR DESCRIPTION
- Contributes to #692 for the `deploy` path
- This is the resulting diff in the generated `_redirects` file, when we ignore changes in whitespace:
  ```console
  $ (cd public && git diff -bw --ignore-blank-lines)
  ```
  ```diff
  diff --git a/_redirects b/_redirects
  index 5d40ff6..07b3c0a 100644
  --- a/_redirects
  +++ b/_redirects
  @@ -11,5 +11,5 @@
   /docs/operate/*                 /docs/2.6/operate/:splat
   /concepts                       /docs/2.6/concepts     301!
   /docs/concepts/*                /docs/2.6/concepts/:splat
  -/deploy     /docs/2.6deploy     301!
  +/deploy                         /docs/2.6/deploy     301!
   /docs/deploy/*                  /docs/2.6/deploy/:splat
  ```
  Note the added `/`.

Redirect test:

- https://deploy-preview-708--keda.netlify.app/deploy
  vs.
  https://keda.sh/deploy (before this PR is merged, this results in a 301 then a 404)