### PR TITLE
Document the support of maxSessions in selenium grid scaler

### DIFF
--- a/content/docs/2.7/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.7/scalers/selenium-grid-scaler.md
@@ -9,9 +9,9 @@ go_file = "selenium_grid_scaler"
 
 ### Trigger Specification
 
-This specification describes the `selenium-grid` trigger that scales browser nodes based on number of requests in session queue.
+This specification describes the `selenium-grid` trigger that scales browser nodes based on number of requests in session queue and the max sessions per grid.
 
-The scaler creates one browser node per pending request in session queue. You will have to create one trigger per browser capability that you would like to support in your Selenium Grid.
+The scaler creates one browser node per pending request in session queue, divided by the max amount of sessions that can run in parallel. You will have to create one trigger per browser capability that you would like to support in your Selenium Grid.
 
 The below is an example trigger configuration for chrome node.
 


### PR DESCRIPTION
Signed-off-by: Alejandro Dominguez <adborroto90@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Update the documentation to mention that grid maxSession is consider when scaling Selenium Grid. Currently, the Selenium Grid Scaler of KEDA ignoring the maxSessions per node.


* [Issue](https://github.com/kedacore/keda/issues/2618)
* [Issue fix](https://github.com/kedacore/keda/pull/2774)

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes [2618](https://github.com/kedacore/keda/issues/2618)
