### PR TITLE
Drop View-latest button for Next release

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -3,7 +3,3 @@ IgnoreDirectoryMissingTrailingSlash: true
 CheckExternal: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
-IgnoreInternalURLs:
-  - /docs/2.6/scalers/aws-dynamodb/
-  - /docs/2.6/scalers/azure-data-explorer/
-  - /docs/2.6/scalers/gcp-storage/

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -8,6 +8,7 @@
 {{ $version       := index (split .File.Path "/") 1 }}
 {{ $latest        := index (index site.Params.versions .Section) 0 }}
 {{ $isLatest      := eq $version $latest }}
+{{ $isNextVersion := not (in (index site.Params.versions .Section) $version) -}}
 <section class="hero">
   <div class="hero-body">
     <div class="container">
@@ -16,7 +17,7 @@
         <sup>
           {{ if $isLatest }}
           <span class="tag is-success">Latest</span>
-          {{ else }}
+          {{ else if not $isNextVersion }}
           {{ $url := replaceRE $version $latest .RelPermalink }}
           <a href="{{ $url }}">
             <span class="tag is-warning">Click here for latest</span>


### PR DESCRIPTION
- Closes #721
- Old the 2.7 pages are affected by this PR:
  ```console
  $ (cd public && git diff) | grep ^diff | grep -v 2.7
  $
  ```

Previews:

- https://deploy-preview-723--keda.netlify.app/docs/2.7/scalers/aws-dynamodb/, page title has no View-latest button
- https://deploy-preview-723--keda.netlify.app/docs/2.6/scalers/activemq/, still has a **Latest** tag
- https://deploy-preview-723--keda.netlify.app/docs/2.4/scalers/cron/, still has a View-latest button