### PR TITLE
 Fix the link in scaling-deployments.md

### DIFF
--- a/content/docs/2.1/concepts/scaling-deployments.md
+++ b/content/docs/2.1/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.2/concepts/scaling-deployments.md
+++ b/content/docs/2.2/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.3/concepts/scaling-deployments.md
+++ b/content/docs/2.3/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.4/concepts/scaling-deployments.md
+++ b/content/docs/2.4/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.5/concepts/scaling-deployments.md
+++ b/content/docs/2.5/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.6/concepts/scaling-deployments.md
+++ b/content/docs/2.6/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledjob_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.6/concepts/scaling-deployments.md
+++ b/content/docs/2.6/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledjob_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.7/concepts/scaling-deployments.md
+++ b/content/docs/2.7/concepts/scaling-deployments.md
@@ -31,7 +31,7 @@ The only constraint is that the target `Custom Resource` must define `/scale` [s
 
 This specification describes the `ScaledObject` Custom Resource definition which is used to define how KEDA should scale your application and what the triggers are. The `.spec.ScaleTargetRef` section holds the reference to the target resource, ie. `Deployment`, `StatefulSet` or `Custom Resource`. 
 
-[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/api/v1alpha1/scaledobject_types.go)
+[`scaledobject_types.go`](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go)
 
 ```yaml
 apiVersion: keda.sh/v1alpha1


### PR DESCRIPTION
Update the links for scaledobject_types.go in keda 2.6

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
