### PR TITLE
Fix: kafka default max partitions number bug

### DIFF
--- a/content/docs/2.5/scalers/apache-kafka.md
+++ b/content/docs/2.5/scalers/apache-kafka.md
@@ -8,7 +8,7 @@ go_file = "kafka_scaler"
 +++
 
 > **Notice:**
-> - By default, the number of replicas will not exceed the number of partitions on a topic.
+> - By default, the number of replicas will not exceed the number of partitions on a topic and will not exceed 100 as the default value of the ScaledObject.
  That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 

--- a/content/docs/2.5/scalers/apache-kafka.md
+++ b/content/docs/2.5/scalers/apache-kafka.md
@@ -8,7 +8,7 @@ go_file = "kafka_scaler"
 +++
 
 > **Notice:**
-> - By default, the number of replicas will not exceed the number of partitions on a topic and will not exceed 100 as the default value of the ScaledObject.
+> - By default, the number of replicas will not exceed the number of partitions on a topic and will not exceed maxReplicaCount.
  That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 

--- a/content/docs/2.5/scalers/apache-kafka.md
+++ b/content/docs/2.5/scalers/apache-kafka.md
@@ -8,7 +8,7 @@ go_file = "kafka_scaler"
 +++
 
 > **Notice:**
-> - By default, the number of replicas will not exceed the number of partitions on a topic and will not exceed maxReplicaCount.
+> - By default, the number of replicas will not exceed the number of partitions on a topic and will not exceed `maxReplicaCount`.
  That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -14,7 +14,7 @@ go_file = "kafka_scaler"
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
-> - Duo to bug in Kafka scaler (https://github.com/kedacore/keda/issues/2888), by default the number of replicas will not exceed 100, even in case of more the 100 partitions.
+> - Duo to open bug in Kafka scaler (https://github.com/kedacore/keda/issues/2888), by default the number of replicas will not exceed 100, even in case of more the 100 partitions.
 
 ### Trigger Specification
 

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -14,6 +14,7 @@ go_file = "kafka_scaler"
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
+> - Duo to bug in Kafka scaler (https://github.com/kedacore/keda/issues/2888), by default the number of replicas will not exceed 100, even in case of more the 100 partitions.
 
 ### Trigger Specification
 

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -11,10 +11,10 @@ go_file = "kafka_scaler"
 > - By default, the number of replicas will not exceed:
 >   - The number of partitions on a topic when a topic is specified;
 >   - The number of partitions of *all topics* in the consumer group when no topic is specified;
+>   - 100, the default value of the ScaledObject;
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
-> - Duo to open bug in Kafka scaler (https://github.com/kedacore/keda/issues/2888), by default the number of replicas will not exceed 100, even in case of more the 100 partitions.
 
 ### Trigger Specification
 

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -11,7 +11,7 @@ go_file = "kafka_scaler"
 > - By default, the number of replicas will not exceed:
 >   - The number of partitions on a topic when a topic is specified;
 >   - The number of partitions of *all topics* in the consumer group when no topic is specified;
->   - maxReplicaCount, the default value of the ScaledObject;
+>   - `maxReplicaCount` specified in `ScaledObject`/`ScaledJob`. If not specifed, then the default value of `maxReplicaCount` is taken into account;
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -11,7 +11,7 @@ go_file = "kafka_scaler"
 > - By default, the number of replicas will not exceed:
 >   - The number of partitions on a topic when a topic is specified;
 >   - The number of partitions of *all topics* in the consumer group when no topic is specified;
->   - 100, the default value of the ScaledObject;
+>   - maxReplicaCount, the default value of the ScaledObject;
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.

--- a/content/docs/2.7/scalers/apache-kafka.md
+++ b/content/docs/2.7/scalers/apache-kafka.md
@@ -11,7 +11,7 @@ go_file = "kafka_scaler"
 > - By default, the number of replicas will not exceed:
 >   - The number of partitions on a topic when a topic is specified;
 >   - The number of partitions of *all topics* in the consumer group when no topic is specified;
->   - maxReplicaCount, the default value of the ScaledObject;
+>   - `maxReplicaCount` specified in `ScaledObject`/`ScaledJob`. If not specifed, then the default value of `maxReplicaCount` is taken into account;
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.

--- a/content/docs/2.7/scalers/apache-kafka.md
+++ b/content/docs/2.7/scalers/apache-kafka.md
@@ -11,7 +11,7 @@ go_file = "kafka_scaler"
 > - By default, the number of replicas will not exceed:
 >   - The number of partitions on a topic when a topic is specified;
 >   - The number of partitions of *all topics* in the consumer group when no topic is specified;
->   - 100, the default value of the ScaledObject;
+>   - maxReplicaCount, the default value of the ScaledObject;
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.

--- a/content/docs/2.7/scalers/apache-kafka.md
+++ b/content/docs/2.7/scalers/apache-kafka.md
@@ -11,6 +11,7 @@ go_file = "kafka_scaler"
 > - By default, the number of replicas will not exceed:
 >   - The number of partitions on a topic when a topic is specified;
 >   - The number of partitions of *all topics* in the consumer group when no topic is specified;
+>   - 100, the default value of the ScaledObject;
 >
 >   That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. See `allowIdleConsumers` below to disable this default behavior.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.


### PR DESCRIPTION
Signed-off-by: liortct <liortct@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

There is an [open bug](https://github.com/kedacore/keda/issues/2888) in Kafka scaler, I added a documentation about this bug.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
