### PR TITLE
doc(newrelic): add doc for new relic account and region from auth config

### DIFF
--- a/content/docs/2.7/scalers/new-relic.md
+++ b/content/docs/2.7/scalers/new-relic.md
@@ -74,11 +74,9 @@ spec:
   - parameter: queryKey
     name: new-relic-secret
     key: apiKey
-  secretTargetRef:
   - parameter: account
     name: new-relic-secret
     key: account
-  secretTargetRef:
   - parameter: region
     name: new-relic-secret
     key: region

--- a/content/docs/2.7/scalers/new-relic.md
+++ b/content/docs/2.7/scalers/new-relic.md
@@ -46,6 +46,10 @@ You can use `TriggerAuthentication` CRD to configure the authentication with a `
 
 - `queryKey` - The API key that will be leveraged to connect to New Relic and make requests. [official documentation](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/)
 
+- `account` - The account within New Relic that the request should be targeted against. This can be used to replace the value that would be provider in the trigger.
+
+- `region` - The region to connect to for the New Relic apis. This can be used to replace the value that would be provider in the trigger.
+
 ### Example
 
 ```yaml
@@ -57,6 +61,8 @@ metadata:
 type: Opaque
 data:
   apiKey: TlJBSy0xMjM0NTY3ODkwMTIzNDU2Nwo= # base64 encoding of the new relic api key NRAK-12345678901234567
+  account: MTIzNDU2 # base64 encoding of the new relic account number 123456
+  region: VVM= # base64 encoding of the new relic region US
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -68,6 +74,14 @@ spec:
   - parameter: queryKey
     name: new-relic-secret
     key: apiKey
+  secretTargetRef:
+  - parameter: account
+    name: new-relic-secret
+    key: account
+  secretTargetRef:
+  - parameter: region
+    name: new-relic-secret
+    key: region
 
 ---
 apiVersion: keda.sh/v1alpha1
@@ -82,8 +96,6 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        account: 1234567
-        region: "US"
         nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
         noDataError: "true"
         threshold: 1000

--- a/content/docs/2.7/scalers/new-relic.md
+++ b/content/docs/2.7/scalers/new-relic.md
@@ -46,9 +46,9 @@ You can use `TriggerAuthentication` CRD to configure the authentication with a `
 
 - `queryKey` - The API key that will be leveraged to connect to New Relic and make requests. [official documentation](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/)
 
-- `account` - The account within New Relic that the request should be targeted against. This can be used to replace the value that would be provider in the trigger.
+- `account` - The account within New Relic that the request should be targeted against. This can be used to replace the value that would be provided in the trigger.
 
-- `region` - The region to connect to for the New Relic apis. This can be used to replace the value that would be provider in the trigger.
+- `region` - The region to connect to for the New Relic apis. This can be used to replace the value that would be provided in the trigger.
 
 ### Example
 


### PR DESCRIPTION
Signed-off-by: Ivan Santos <301291+pragmaticivan@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adds documentation changes to include `account` and `region` via Auth config.
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #2883
