### PR TITLE
Clarify that pause happens with any replica count

### DIFF
--- a/content/docs/2.7/concepts/scaling-deployments.md
+++ b/content/docs/2.7/concepts/scaling-deployments.md
@@ -224,7 +224,7 @@ metadata:
     autoscaling.keda.sh/paused-replicas: "0"
 ```
 
-The above annotation will scale your current workload to 0 replicas and pause autoscaling. You can set the value of replicas for an object to be paused at to any arbitary number. To enable autoscaling again, simply remove the annotation from the `ScaledObject`definition.
+The presensce of this annotation will pause autoscaling no matter what number of replicas is provided. The above annotation will scale your current workload to 0 replicas and pause autoscaling. You can set the value of replicas for an object to be paused at to any arbitary number. To enable autoscaling again, simply remove the annotation from the `ScaledObject`definition.
 
 ## Long-running executions
 


### PR DESCRIPTION
Based on the discussion in the issue  I think that pause happens no matter of "paused-replicas" value?
https://github.com/kedacore/keda/issues/944
When I read it I was not sure what happens if value is >0
@zroubalik @aryan9600 @tomkerkhove @JorTurFer

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
