### PR TITLE
docs: Provide "Why does KEDA use external metrics and not custom metrics instead?" FAQ

### DIFF
--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -77,6 +77,21 @@ KEDA currently only supports average metrics. This means that the HPA will use t
 type = "Kubernetes"
 
 [[qna]]
+q = "Why does KEDA use external metrics and not custom metrics instead?"
+a = """
+Kubernetes allows you to autoscale based on custom & external metrics which are fundamentally different:
+- **Custom metrics** are metrics that come from applications solely running on the Kubernetes cluster (Prometheus)
+- **External metrics** are metrics that represent the state of an application/service that is running outside of the Kubernetes cluster (AWS, Azure, GCP, Datadog, etc.)
+
+Because KEDA primarily serves metrics for metric sources outside of the Kubernetes cluster, it uses external metrics and not custom metrics.
+
+This is why KEDA registers the `v1beta1.external.metrics.k8s.io` namespace in the API service.
+
+Read [this article](https://cloud.google.com/kubernetes-engine/docs/concepts/custom-and-external-metrics) by Google Cloud to learn more.
+"""
+type = "Kubernetes"
+
+[[qna]]
 q = "How can I get involved?"
 a = """
 There are several ways to get involved.


### PR DESCRIPTION
Provide long overdue "Why does KEDA use external metrics and not custom metrics instead?" FAQ to explain difference between external/custom metrics and why we use external.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
