### PR TITLE
Update Helm uninstall procedure

### DIFF
--- a/content/docs/2.4/deploy.md
+++ b/content/docs/2.4/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}

--- a/content/docs/2.5/deploy.md
+++ b/content/docs/2.5/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}

--- a/content/docs/2.6/deploy.md
+++ b/content/docs/2.6/deploy.md
@@ -43,10 +43,19 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobject -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting the ScaledObjects, they will become orphaned. In this situation, you will need to patch the ScaledObjects to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobject | awk '{ print $1 }' | awk 'NR!=1 {print}');
+do kubectl patch scaledobject $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}

--- a/content/docs/2.6/deploy.md
+++ b/content/docs/2.6/deploy.md
@@ -43,18 +43,22 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects that you have created. Once that is done, the Helm chart can be uninstalled:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
-kubectl delete $(kubectl get scaledobject -oname)
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
 ```
 
-Note: if you uninstall the Helm chart without first deleting the ScaledObjects, they will become orphaned. In this situation, you will need to patch the ScaledObjects to remove their finalizers. Once this is done, they should automatically be removed:
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
 
 ```sh
-for i in $(kubectl get scaledobject | awk '{ print $1 }' | awk 'NR!=1 {print}');
-do kubectl patch scaledobject $i -p '{"metadata":{"finalizers":null}}' --type=merge
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
 done
 ```
 

--- a/content/docs/2.7/deploy.md
+++ b/content/docs/2.7/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}


### PR DESCRIPTION
Update Helm uninstall procedure to cover the removal of ScaledObjects before (or after) the Helm chart is removed, as discussed in https://github.com/kedacore/keda/discussions/2301. I've made an update to cover 2.6, but I note docs for 2.7 are in place now too. If the proposed changes are acceptable, I can also duplicate them to the 2.7 deployment doc, if desired.