### PR TITLE
Added alternative expression field in AWS CloudWatch scaler

### DIFF
--- a/content/docs/2.7/scalers/aws-cloudwatch.md
+++ b/content/docs/2.7/scalers/aws-cloudwatch.md
@@ -17,11 +17,11 @@ triggers:
   metadata:
     # Required: namespace
     namespace: AWS/SQS
-    # Required if not querying with expression: Dimension Name - Supports specifying multiple dimension names by using ";" as a separator i.e. dimensionName: QueueName;QueueName
+    # Optional: Dimension Name
     dimensionName: QueueName
-    # Required if not querying with expression: Dimension Value - Supports specifying multiple dimension values by using ";" as a separator i.e. dimensionValue: queue1;queue2
+    # Optional: Dimension Value
     dimensionValue: keda
-    # Required if querying with expression: Expression query - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-insights-querylanguage.html
+    # Optional: Expression query
     expression: SELECT MAX("ApproximateNumberOfMessagesVisible") FROM "AWS/SQS" WHERE QueueName = 'keda'
     metricName: ApproximateNumberOfMessagesVisible
     targetMetricValue: "2"
@@ -46,6 +46,10 @@ triggers:
 ```
 
 **Parameter list:**
+
+- `dimensionName` - Supports specifying multiple dimension names by using ";" as a separator i.e. dimensionName: QueueName;QueueName (Optional, Required when `expression` is not specified)
+- `dimensionValue` - Supports specifying multiple dimension values by using ";" as a separator i.e. dimensionValue: queue1;queue2 (Optional, Required when `expression` is not specified)
+- `expression` - Supports query with [expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-insights-querylanguage.html) (Optional, Required when `dimensionName` & `dimensionValue` are not specified)
 
 - `identityOwner` - Receive permissions on the CloudWatch via Pod Identity or from the KEDA operator itself (see below). (Values: `pod`, `operator`, Default: `pod`, Optional)
 

--- a/content/docs/2.7/scalers/aws-cloudwatch.md
+++ b/content/docs/2.7/scalers/aws-cloudwatch.md
@@ -17,10 +17,12 @@ triggers:
   metadata:
     # Required: namespace
     namespace: AWS/SQS
-    # Required: Dimension Name - Supports specifying multiple dimension names by using ";" as a separator i.e. dimensionName: QueueName;QueueName
+    # Required if not querying with expression: Dimension Name - Supports specifying multiple dimension names by using ";" as a separator i.e. dimensionName: QueueName;QueueName
     dimensionName: QueueName
-    # Required: Dimension Value - Supports specifying multiple dimension values by using ";" as a separator i.e. dimensionValue: queue1;queue2
+    # Required if not querying with expression: Dimension Value - Supports specifying multiple dimension values by using ";" as a separator i.e. dimensionValue: queue1;queue2
     dimensionValue: keda
+    # Required if querying with expression: Expression query - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-insights-querylanguage.html
+    expression: SELECT MAX("ApproximateNumberOfMessagesVisible") FROM "AWS/SQS" WHERE QueueName = 'keda'
     metricName: ApproximateNumberOfMessagesVisible
     targetMetricValue: "2"
     minMetricValue: "0"


### PR DESCRIPTION
Signed-off-by: Dekel Barzilay <dekelev@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Relates to changes from these PRs https://github.com/kedacore/keda/pull/2911 & https://github.com/kedacore/keda/pull/2997

Added alternative expression field in AWS CloudWatch scaler.
Here's an example ScaledObject config:
```
awsRegion: us-east-1
expression: >-
  SELECT MIN(MessageCount) FROM "AWS/AmazonMQ" WHERE Broker =
  'production' and Queue = 'worker'
metricCollectionTime: '60'
metricName: WorkerMessageCount
metricStatPeriod: '60'
minMetricValue: '0'
namespace: AWS/AmazonMQ
targetMetricValue: '100'
```

### Checklist

- [ x] Commits are signed with Developer Certificate of Origin (DCO)

