### PR TITLE
Add an example about Azure Pipelines scale down period

### DIFF
--- a/content/docs/2.7/scalers/azure-pipelines.md
+++ b/content/docs/2.7/scalers/azure-pipelines.md
@@ -92,6 +92,11 @@ spec:
     name: azdevops-deployment
   minReplicaCount: 1
   maxReplicaCount: 5 
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 1800 # Pool scale down after 30 minutes of idle time, range 0 - 3600 seconds
   triggers:
   - type: azure-pipelines
     metadata:


### PR DESCRIPTION
cooldownPeriod does not affect deployments where the minReplicaCount is not zero. The default scale down interval is just 300 seconds, i.e. 5 minutes

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
