### PR TITLE
Fix latest indicator in version selector

### DIFF
--- a/layouts/partials/doc-version-selector.html
+++ b/layouts/partials/doc-version-selector.html
@@ -38,7 +38,7 @@
   <div class="dropdown-menu" id="dropdown-menu" role="menu">
     <div class="dropdown-content">
       {{ range $versionsOfDoc }}
-      {{ $isLatest := eq . $version }}
+      {{ $isLatest := eq . $latest }}
       <a class="dropdown-item" href="/{{ $section }}/{{ . }}">
         <span>
           {{ . }}

--- a/layouts/partials/general-version-selector.html
+++ b/layouts/partials/general-version-selector.html
@@ -28,7 +28,7 @@
   <div class="dropdown-menu" id="dropdown-menu" role="menu">
     <div class="dropdown-content">
       {{ range $allVersions }}
-      {{ $isLatest := eq . $version }}
+      {{ $isLatest := eq . $latest }}
       <a class="dropdown-item" href="/docs/{{ . }}">
         <span>
           {{ . }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Fix the latest indicator that is being applied to the wrong version in version dropdown. /cc @tomkerkhove 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #763
