### PR TITLE
docs: Update uninstall procedure for Helm deployments

### DIFF
--- a/content/docs/2.4/deploy.md
+++ b/content/docs/2.4/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}

--- a/content/docs/2.5/deploy.md
+++ b/content/docs/2.5/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}

--- a/content/docs/2.6/deploy.md
+++ b/content/docs/2.6/deploy.md
@@ -43,14 +43,26 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
 ```
 
-## Deploying with Operator Hub {#operatorhub}
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
 
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+```
+
+## Deploying with Operator Hub {#operatorhub}
 ### Install
 
 1. On Operator Hub Marketplace locate and install KEDA operator to namespace `keda`

--- a/content/docs/2.7/deploy.md
+++ b/content/docs/2.7/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}

--- a/content/docs/2.8/deploy.md
+++ b/content/docs/2.8/deploy.md
@@ -43,10 +43,23 @@ Deploying KEDA with Helm is very simple:
 
 ### Uninstall
 
-If you want to remove KEDA from a cluster you can run one of the following:
+If you want to remove KEDA from a cluster, you first need to remove any ScaledObjects and ScaledJobs that you have created. Once that is done, the Helm chart can be uninstalled:
 
 ```sh
+kubectl delete $(kubectl get scaledobjects,scaledjobs -oname)
 helm uninstall keda -n keda
+```
+
+Note: if you uninstall the Helm chart without first deleting any ScaledObject or ScaledJob resources you have created, they will become orphaned. In this situation, you will need to patch the resources to remove their finalizers. Once this is done, they should automatically be removed:
+
+```sh
+for i in $(kubectl get scaledobjects -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+
+for i in $(kubectl get scaledjobs -oname);
+do kubectl patch $i -p '{"metadata":{"finalizers":null}}' --type=merge
+done
 ```
 
 ## Deploying with Operator Hub {#operatorhub}


### PR DESCRIPTION
Update Helm uninstall procedure to cover the removal of ScaledObjects and/or ScaledJobs, either before or after the Helm chart is removed. As discussed in kedacore/keda#2301. This PR replaces #754, which I have now closed.