### PR TITLE
docs: Support for scaling on in-flight messages in AWS SQS Queue

### DIFF
--- a/content/docs/2.8/scalers/aws-sqs.md
+++ b/content/docs/2.8/scalers/aws-sqs.md
@@ -30,7 +30,8 @@ triggers:
 
 > For the purposes of scaling, the default formula for "actual messages" is equal to `ApproximateNumberOfMessages` + `ApproximateNumberOfMessagesNotVislble`, since `NotVisible` in SQS terms means the message is still in-flight/processing. If you wish to only scale on `ApproximateNumberOfMessages` set `scaleOnInFlight` to `false`.
 
-- `scaleOnInFlight` - Bool flag to set the metrics to scale on. When set to `false` "actual messages" is equal to `ApproximateNumberOfMessages`. When set to `true` "actual messages" is equal to `ApproximateNumberOfMessages` + `ApproximateNumberOfMessagesNotVislble`, since `NotVisible` in SQS terms means the message is still in-flight/processing. (default: true)
+- `scaleOnInFlight` - Indication whether or not to scale on queued messages or to include in-flight messages as well.
+  - When set to `false` "actual messages" is equal to `ApproximateNumberOfMessages`. When set to `true` "actual messages" is equal to `ApproximateNumberOfMessages` + `ApproximateNumberOfMessagesNotVislble`, since `NotVisible` in SQS terms means the message is still in-flight/processing. (default: true)
 - `awsRegion` - AWS Region for the SQS Queue.
 - `identityOwner` - Receive permissions on the SQS Queue via Pod Identity or from the KEDA operator itself (see below). (Values: `pod`, `operator`, Default: `pod`, Optional)
 

--- a/content/docs/2.8/scalers/aws-sqs.md
+++ b/content/docs/2.8/scalers/aws-sqs.md
@@ -28,8 +28,9 @@ triggers:
 - `queueURL` - Full URL for the SQS Queue. The simple name of the queue can be used in case there's no ambiguity.
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual messages in the SQS Queue is 30, the scaler scales to 3 pods. (default: 5)
 
-> For the purposes of scaling, "actual messages" is equal to `ApproximateNumberOfMessages` + `ApproximateNumberOfMessagesNotVislble`, since `NotVisible` in SQS terms means the message is still in-flight/processing.
+> For the purposes of scaling, the default formula for "actual messages" is equal to `ApproximateNumberOfMessages` + `ApproximateNumberOfMessagesNotVislble`, since `NotVisible` in SQS terms means the message is still in-flight/processing. If you wish to only scale on `ApproximateNumberOfMessages` set `scaleOnInFlight` to `false`.
 
+- `scaleOnInFlight` - Bool flag to set the metrics to scale on. When set to `false` "actual messages" is equal to `ApproximateNumberOfMessages`. When set to `true` "actual messages" is equal to `ApproximateNumberOfMessages` + `ApproximateNumberOfMessagesNotVislble`, since `NotVisible` in SQS terms means the message is still in-flight/processing. (default: true)
 - `awsRegion` - AWS Region for the SQS Queue.
 - `identityOwner` - Receive permissions on the SQS Queue via Pod Identity or from the KEDA operator itself (see below). (Values: `pod`, `operator`, Default: `pod`, Optional)
 
@@ -176,4 +177,51 @@ spec:
       queueURL: myQueue
       queueLength: "5"
       awsRegion: "eu-west-1"
+```
+
+#### Scaling on ApproximateNumberOfMessages only
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secrets
+data:
+  AWS_ACCESS_KEY_ID: <encoded-user-id> # Required.
+  AWS_SECRET_ACCESS_KEY: <encoded-key> # Required.
+  AWS_SESSION_TOKEN: <encoded-session-token> # Required when using temporary credentials.
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-aws-credentials
+  namespace: keda-test
+spec:
+  secretTargetRef:
+  - parameter: awsAccessKeyID     # Required.
+    name: test-secrets            # Required.
+    key: AWS_ACCESS_KEY_ID        # Required.
+  - parameter: awsSecretAccessKey # Required.
+    name: test-secrets            # Required.
+    key: AWS_SECRET_ACCESS_KEY    # Required.
+  - parameter: awsSessionToken    # Required when using temporary credentials.
+    name: test-secrets            # Required when using temporary credentials.
+    key: AWS_SESSION_TOKEN        # Required when using temporary credentials.
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: aws-sqs-queue-scaledobject
+  namespace: keda-test
+spec:
+  scaleTargetRef:
+    name: nginx-deployment
+  triggers:
+  - type: aws-sqs-queue
+    authenticationRef:
+      name: keda-trigger-auth-aws-credentials
+    metadata:
+      queueURL: myQueue
+      queueLength: "5"
+      awsRegion: "eu-west-1"
+      scaleOnInFlight: false
 ```


### PR DESCRIPTION
Signed-off-by: Liam Storkey <liam.storkey@ip-10-0-0-12.ap-southeast-2.compute.internal>

added docs for new config options for scale on in flight metrics

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/keda/pull/3132
Relates to https://github.com/kedacore/keda/issues/3133