### PR TITLE
Add doc for new dapr checkpoint strategy for Azure Event Hubs scalar

### DIFF
--- a/content/docs/2.8/scalers/azure-event-hub.md
+++ b/content/docs/2.8/scalers/azure-event-hub.md
@@ -40,7 +40,8 @@ triggers:
 - `checkpointStrategy` - configure the checkpoint behaviour of different Event Hub SDKs. (Values: `azureFunction`, `blobMetadata`, `goSdk`, default: `""`, Optional)
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
-    - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing, for example Dapr.
+    - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
+    - `dapr` - Used for Dapr Pub/sub API using Azure Event Hubs.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).


### PR DESCRIPTION
Adds documentation for the new dapr checkpoint strategy for Azure Event Hubs scalar. Explains the new option `dapr`  for the `checkpointStrategy` field. Removes dapr reference from `goSdk` checkpoint strategy documentation. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/keda/pull/3139
Relates to https://github.com/kedacore/keda/issues/3141
