### PR TITLE
Document ScaledObject support for Value metric type in FAQ

### DIFF
--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -72,7 +72,7 @@ The target metric value is used by the Horizontal Pod Autoscaler (HPA) to make s
 
 The current target value on the Horizontal Pod Autoscaler (HPA) often does not match with the metrics on the system you are scaling on. This is because of how the Horizontal Pod Autoscaler's (HPA) [scaling algorithm](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) works.
 
-KEDA currently only supports average metrics. This means that the HPA will use the average value of the metric between the total amount of pods.
+By default, KEDA scalers use average metrics (the `AverageValue` metric type). This means that the HPA will use the average value of the metric between the total amount of pods. As of KEDA v2.7, ScaledObjects also support the `Value` metric type. You can learn more about it [here](/docs/latest/concepts/scaling-deployments/#triggers).
 """
 type = "Kubernetes"
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Update FAQ to reflect the `Value` metric type support added in https://github.com/kedacore/keda/pull/2309.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to #657

Signed-off-by: amirschw <24677563+amirschw@users.noreply.github.com>