### PR TITLE
doc: Add a note on scalers which support float target value

### DIFF
--- a/content/docs/2.8/scalers/aws-cloudwatch.md
+++ b/content/docs/2.8/scalers/aws-cloudwatch.md
@@ -24,8 +24,8 @@ triggers:
     # Optional: Expression query
     expression: SELECT MAX("ApproximateNumberOfMessagesVisible") FROM "AWS/SQS" WHERE QueueName = 'keda'
     metricName: ApproximateNumberOfMessagesVisible
-    targetMetricValue: "2"
-    minMetricValue: "0"
+    targetMetricValue: "2.1"
+    minMetricValue: "1.5"
     # Required: region
     awsRegion: "eu-west-1"
     # Optional: AWS Access Key ID, can use TriggerAuthentication as well
@@ -60,7 +60,8 @@ triggers:
 - `metricStatPeriod` - Which frequency is going to be used by the related query. Used to define **Period**. The value cannot be an arbitrary number, that it must be supported by Cloudwatch. More details can be found from ([official documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#CloudWatchPeriods)). (Default: `300`, Optional)
 - `metricUnit` - Which unit is going to be used by the query. Used to define **Unit** ([official documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Unit)). (Default: `Average`, Optional)
 - `metricEndTimeOffset` - How long in seconds to offset the **EndTime** ([official documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html)). Due to the eventual consistency model which is used by Cloudwatch, the latest datapoint one can get from Cloudwatch might not be accurate. The `metricEndTimeOffset` config provides a way to skip the most recent datapoint if needed. (Default: `0`, Optional)
-
+- `minMetricValue`- Returned value in case of empty response from cloudwatch. (Default: 0, This value can be a float)
+- `targetMetricValue`- Target value for the metric. (Default: 0, This value can be a float)
 
 ### Authentication Parameters
 
@@ -128,7 +129,7 @@ spec:
       dimensionName: QueueName
       dimensionValue: keda
       metricName: ApproximateNumberOfMessagesVisible
-      targetMetricValue: "2"
+      targetMetricValue: "2.1"
       minMetricValue: "0"
       awsRegion: "eu-west-1"
     authenticationRef:

--- a/content/docs/2.8/scalers/azure-app-insights.md
+++ b/content/docs/2.8/scalers/azure-app-insights.md
@@ -19,7 +19,7 @@ triggers:
     metricAggregationType: avg
     metricFilter: cloud/roleName eq 'role_name'
     metricId: "customMetrics/example-metric"
-    targetValue: "1"
+    targetValue: "1.5"
     activeDirectoryClientIdFromEnv: CLIENT_ID_ENV_NAME # Optional, can use TriggerAuthentication as well
     activeDirectoryClientPasswordFromEnv: CLIENT_PASSWORD_ENV_NAME # Optional, can use TriggerAuthentication as well
     applicationInsightsIdFromEnv: APP_ID # Optional, can use TriggerAuthentication as well
@@ -39,7 +39,7 @@ for further details.
 
 - `tenantId` - Id of the tenant that contains the Azure resource. This is used for authentication.
 - `metricId` - The name of the Application Insights metric to query. Use the [Azure Command Line Interface](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) to run `az monitor app-insights metrics get-metadata` to see a list of available metrics.
-- `targetValue` - Target value to trigger scaling actions.
+- `targetValue` - Target value to trigger scaling actions. (This value can be a float)
 - `metricAggregationType` - Aggregation method of the Azure Application Insights metric. The aggregation methods vary from metric to metric. The `az monitor app-insights metrics get-metadata` command can be used to determine which methods apply to a given metric. (Some common aggregation methods are `avg`, `count`, `sum`, `min`, and `max`)
 - `metricAggregationInterval` - Collection time of the metric in format `"hh:mm"`.
 - `applicationInsightsId` - Id of the Application Insights instance to query. This is a GUID that can be retrieved from the Application Insight's `API Access` blade in the Azure Portal.

--- a/content/docs/2.8/scalers/azure-data-explorer.md
+++ b/content/docs/2.8/scalers/azure-data-explorer.md
@@ -21,7 +21,7 @@ triggers:
       StormEvents
       | summarize StormCount = count() by State
       | top 1 by StormCount desc
-    threshold: "1000"
+    threshold: "10.5"
     tenantId: 045ef409-6dee-4893-a824-5612eac467b1 # Can use TriggerAuthentication as well
     clientId: 4ba039f1-d69c-434e-9268-4a2bb7bba90d # Can use TriggerAuthentication as well
     clientSecret: t0p-s3cret  # Can use TriggerAuthentication as well
@@ -40,7 +40,7 @@ triggers:
 - `endpoint` - The endpoint to query your Data Explorer Cluster.
 - `databaseName` - The name of the Data Explorer Database to query.
 - `query` - Data Explorer query.
-- `threshold` - Value that is used as a threshold to calculate # of pods for scale target.
+- `threshold` - Value that is used as a threshold to calculate # of pods for scale target. (This value can be a float)
 - `tenantId` - Id of the Azure AD tenant.
 - `clientId` - Id of the Azure AD application.
 - `clientSecret` - Password of the Azure AD application.

--- a/content/docs/2.8/scalers/azure-log-analytics.md
+++ b/content/docs/2.8/scalers/azure-log-analytics.md
@@ -41,7 +41,7 @@ triggers:
                 | project Limit = CounterValue, TimeGenerated, CounterPath, AppName)
                 on AppName
         | project MetricValue, Threshold = Limit * ThresholdCoefficient
-      threshold: "1900000000"
+      threshold: "10.7"
       # Alternatively, you can use existing environment variables to read configuration from:
       # See details in "Parameter list" section
       workspaceIdFromEnv: LOG_ANALYTICS_WORKSPACE_ID_ENV_NAME # Optional. You can use this instead of `workspaceId` parameter.
@@ -63,7 +63,7 @@ triggers:
 - `clientSecret` - Password from your Azure AD Application/service principal.
 - `workspaceId` - Id of Log Analytics workspace. Follow [this](https://docs.microsoft.com/en-us/cli/azure/monitor/log-analytics/workspace?view=azure-cli-latest#az-monitor-log-analytics-workspace-list) link to get your Log Analytics workspace id.
 - `query` - Log Analytics [kusto](https://docs.microsoft.com/en-us/azure/azure-monitor/log-query/get-started-queries) query, JSON escaped. You can use [this](https://www.freeformatter.com/json-escape.html) tool to convert your query from Log Analytics query editor to JSON escaped string, and then review YAML specific escapes.
-- `threshold` - Value that is used as a threshold to calculate # of pods for scale target.
+- `threshold` - Value that is used as a threshold to calculate # of pods for scale target. (This value can be a float)
 - `metricName` - Name to assign to the metric. (Optional, if not set KEDA will generate a name based on the workspaceId)
 - `cloud` - Name of the cloud environment that the Azure Log Analytics workspace belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `logAnalyticsResourceURL` - Log Analytics REST API URL of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `https://api.loganalytics.azure.cn/` for `AzureChinaCloud`).

--- a/content/docs/2.8/scalers/azure-monitor.md
+++ b/content/docs/2.8/scalers/azure-monitor.md
@@ -22,7 +22,7 @@ triggers:
     metricName: kube_pod_status_ready
     metricFilter: namespace eq 'default'
     metricAggregationInterval: "0:1:0"
-    targetValue: "1"
+    targetValue: "0.5"
     activeDirectoryClientId: <client id value> # Optional, can use TriggerAuthentication as well
     activeDirectoryClientIdFromEnv: CLIENT_ID_ENV_NAME # Optional, can use TriggerAuthentication as well
     activeDirectoryClientPasswordFromEnv: CLIENT_PASSWORD_ENV_NAME # Optional, can use TriggerAuthentication as well
@@ -44,7 +44,7 @@ triggers:
   - Azure metrics are available as a list in the [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported).
   - Custom metric name when querying Azure Monitor [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-custom-overview).
 - `metricNamespace` - Name of the metric namespace. Required when `metricName` is a custom metric.
-- `targetValue` - Target value to trigger scaling actions.
+- `targetValue` - Target value to trigger scaling actions. (This value can be a float)
 - `metricAggregationType` - Aggregation method of the Azure Monitor metric. Options include `Average`, `Total`, `Maximum` with a full list in the [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported).
 - `metricFilter` - Name of the filter to be more specific by using dimensions listed in the [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported). (Optional)
 - `metricAggregationInterval` - Collection time of the metric in format `"hh:mm:ss"` (Default: `"0:5:0"`, Optional)

--- a/content/docs/2.8/scalers/datadog.md
+++ b/content/docs/2.8/scalers/datadog.md
@@ -23,19 +23,19 @@ triggers:
   metricType: Value
   metadata:
     query: "sum:trace.redis.command.hits{env:none,service:redis}.as_count()"
-    queryValue: "7"
+    queryValue: "7.75"
     type: "global" # Deprecated in favor of trigger.metricType
     age: "120"
-    metricUnavailableValue: "0"
+    metricUnavailableValue: "1.5"
 ```
 
 **Parameter list:**
 
 - `query` - The Datadog query to run.
-- `queryValue` - Value to reach to start scaling.
+- `queryValue` - Value to reach to start scaling (This value can be a float).
 - `type` - Whether to start scaling based on the value or the average between pods. (Values: `average`, `global`, Default:`average`, Optional)
 - `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional) 
-- `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional)
+- `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
 

--- a/content/docs/2.8/scalers/graphite.md
+++ b/content/docs/2.8/scalers/graphite.md
@@ -19,7 +19,7 @@ triggers:
     serverAddress: http://<graphite-host>:81
     metricName: request-count # Note: name to identify the metric
     query: stats.counters.http.hello-world.request.count.count # Note: query must return a vector/scalar single element response
-    threshold: '100'
+    threshold: '10.5'
     queryTime: '-10Minutes' # Note: Query time in from argv Seconds/Minutes/Hours
 ```
 **Parameter list:**
@@ -27,7 +27,7 @@ triggers:
 - `serverAddress` - Address of Graphite
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique
 - `query` - Query to run.
-- `threshold` - Value to start scaling for.
+- `threshold` - Value to start scaling for. (This value can be a float)
 - `queryTime` - Relative time range to execute query against. Please see the [graphite API docs](https://graphite-api.readthedocs.io/en/latest/api.html#from-until) for more information.
 
 ### Authentication Parameters

--- a/content/docs/2.8/scalers/huawei-cloudeye.md
+++ b/content/docs/2.8/scalers/huawei-cloudeye.md
@@ -19,8 +19,8 @@ triggers:
     metricName: mb_l7_qps
     dimensionName: lbaas_instance_id
     dimensionValue: 5e052238-0346-xxb0-86ea-92d9f33e29d2
-    targetMetricValue: "100"
-    minMetricValue: "1"
+    targetMetricValue: "5.5"
+    minMetricValue: "1.1"
 ```
 
 **Parameter list:**
@@ -29,8 +29,8 @@ triggers:
 - `metricName` - Name of the metric.
 - `dimensionName` - Name of the metric dimension.
 - `dimensionValue` - Value of the metric dimension.
-- `targetMetricValue` - Target value for your metric.
-- `minMetricValue` - Minimum value for your metric. If the actual value of the metric you get from cloudeye is less than the minimum value, then the scaler is not active.
+- `targetMetricValue` - Target value for your metric. (This value can be a float)
+- `minMetricValue` - Minimum value for your metric. If the actual value of the metric you get from cloudeye is less than the minimum value, then the scaler is not active. (This value can be a float)
 - `metricCollectionTime` - Collection time of the metric in seconds. Equivalent to the earliest start time of the end time. (default: 300)
 - `metricFilter` - Aggregation method of the metric. (Values: `average`, `max`, `min`, `sum`, Default: `average`, Optional)
 - `metricPeriod` - Granularity of the metric in seconds. (Default: 300, Optional)

--- a/content/docs/2.8/scalers/influxdb.md
+++ b/content/docs/2.8/scalers/influxdb.md
@@ -18,7 +18,7 @@ triggers:
       serverURL: http://influxdb:8086
       organizationName: influx-org
       organizationNameFromEnv: INFLUXDB_ORG_NAME # Optional: You can use this instead of `organizationName` parameter. See details in "Parameter List" section
-      thresholdValue: '4'
+      thresholdValue: '4.4'
       query: |
         from(bucket: "bucket-of-interest")
         |> range(start: -12h)
@@ -35,7 +35,7 @@ triggers:
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.
 - `serverURL` - Holds the url value of the InfluxDB server.
-- `thresholdValue` - Provided by the user. This value can vary from use case to use case depending on the data of interest, and is needed to trigger the scaling in/out depending on what value comes back from the query.
+- `thresholdValue` - Provided by the user. This value can vary from use case to use case depending on the data of interest, and is needed to trigger the scaling in/out depending on what value comes back from the query. (This value can be a float)
 - `query` - Flux query that will yield the value for the scaler to compare the `thresholdValue` against.
 - `metricName` - Name to assign to the metric. If not set KEDA will generate a name based organization name. If using more than one trigger it is required that all `metricName`(s) be unique. (Optional)
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)

--- a/content/docs/2.8/scalers/kubernetes-workload.md
+++ b/content/docs/2.8/scalers/kubernetes-workload.md
@@ -14,13 +14,13 @@ triggers:
 - type: kubernetes-workload
   metadata:
     podSelector: 'app=backend'
-    value: '1'
+    value: '0.5'
 ```
 
 **Parameter list:**
 
 - `podSelector` - [Label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) that will be used to get the pod count. It supports multiple selectors split by a comma character (`,`). It also supports [set-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) and a mix of them.
-- `value` - Target relation between the scaled workload and the amount of pods which matches the selector. It will be calculated following this formula: `relation = (pods which match selector) / (scaled workload pods)`.
+- `value` - Target relation between the scaled workload and the amount of pods which matches the selector. It will be calculated following this formula: `relation = (pods which match selector) / (scaled workload pods)`. (This value can be a float)
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 

--- a/content/docs/2.8/scalers/metrics-api.md
+++ b/content/docs/2.8/scalers/metrics-api.md
@@ -19,7 +19,7 @@ Here is an example of trigger configuration using metrics-api scaler:
 triggers:
 - type: metrics-api
   metadata:
-    targetValue: "8"
+    targetValue: "8.8"
     url: "http://api:3232/api/v1/stats"
     valueLocation: "components.worker.tasks"
 ```
@@ -28,7 +28,7 @@ triggers:
 
 - `url` - Full URL of the API operation to call to get the metric value (eg. `http://app:1317/api/v1/stats`).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
-- `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0.
+- `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 
 ### Authentication Parameters
 

--- a/content/docs/2.8/scalers/mssql.md
+++ b/content/docs/2.8/scalers/mssql.md
@@ -17,7 +17,7 @@ triggers:
   metadata:
     connectionStringFromEnv: MSSQL_CONNECTION_STRING
     query: "SELECT COUNT(*) FROM backlog WHERE state='running' OR state='queued'"
-    targetValue: 1
+    targetValue: "5.5"
     metricName: backlog_process_count # optional - the generated value would be `mssql-{sha256hash}`
 ```
 
@@ -42,7 +42,7 @@ triggers:
 The `mssql` trigger always requires the following information:
 
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
-- `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA).
+- `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 
 To connect to the MSSQL instance, you can provide either:
 

--- a/content/docs/2.8/scalers/mysql.md
+++ b/content/docs/2.8/scalers/mysql.md
@@ -14,7 +14,7 @@ This specification describes the `mysql` trigger that scales based on result of 
 The trigger always requires the following information:
 
 - `query` - A MySQL query that should return single numeric value.
-- `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA.
+- `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 
 To provide information about how to connect to MySQL you can provide:
 
@@ -86,7 +86,7 @@ spec:
   triggers:
   - type: mysql
     metadata:
-      queryValue: "4"
+      queryValue: "4.4"
       query: "SELECT CEIL(COUNT(*) / 6) FROM task_instance WHERE state='running' OR state='queued'"
     authenticationRef:
       name: keda-trigger-auth-mysql-secret

--- a/content/docs/2.8/scalers/new-relic.md
+++ b/content/docs/2.8/scalers/new-relic.md
@@ -26,7 +26,7 @@ triggers:
       # Required: nrql
       nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
       # Required: threshold
-      threshold: 100
+      threshold: "50.50"
 ```
 
 **Parameter list:**
@@ -36,7 +36,7 @@ triggers:
 - `region` - The region to connect to for the New Relic apis. (Values: `LOCAL`, `EU`, `STAGING`, `US`, Default: `US`, Optional)
 - `noDataError` - Should queries that return nodata be treated as an error (Values: `true`, `false`, Default: `false`, Optional)
 - `nrql` - The New Relic query that will be run to get the data requested. [official documentation](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/)
-- `threshold` - A threshold that is used as the `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the HPA configuration.
+- `threshold` - A threshold that is used as the `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the HPA configuration. (This value can be a float)
 
 ### Authentication Parameters
 

--- a/content/docs/2.8/scalers/openstack-metric.md
+++ b/content/docs/2.8/scalers/openstack-metric.md
@@ -21,7 +21,7 @@ triggers:
     metricID: 003bb589-166d-439d-8c31-cbf098d863de #required
     aggregationMethod: "mean" #required
     granularity: 300 #required (seconds)
-    threshold: 1250 #required
+    threshold: "1.250" #required
     timeout: 30 #optional
 ```
 
@@ -32,7 +32,7 @@ triggers:
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
-- `threshold` - The target value that, when reached, will scale the application.
+- `threshold` - The target value that, when reached, will scale the application. (This value can be a float)
 - `timeout` - The timeout, in seconds, for the HTTP client requests that will query the Metric API.  (Default: `30`, Optional)
 
 ### Authentication Parameters

--- a/content/docs/2.8/scalers/postgresql.md
+++ b/content/docs/2.8/scalers/postgresql.md
@@ -32,7 +32,7 @@ internally.
 Finally, a user inserts a query that returns the desired value.
 
 - `query` - What query to poll postgresql with. Query must return an integer.
-- `targetQueryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA.
+- `targetQueryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on either the connection string if set or the db name. If using more than one trigger it is required that all metricNames be unique. (Optional)
 
 This is an example of using a full connection string with `AIRFLOW_CONN_AIRFLOW_DB` set as `postgresql://test@localhost`:
@@ -43,7 +43,7 @@ triggers:
   metadata:
     connectionFromEnv: AIRFLOW_CONN_AIRFLOW_DB
     query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
-    targetQueryValue: 1
+    targetQueryValue: "1.1"
     metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
 
@@ -61,7 +61,7 @@ triggers:
     dbName: test_db_name
     sslmode: disable
     query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
-    targetQueryValue: 1
+    targetQueryValue: "2.2"
     metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
 ```
 

--- a/content/docs/2.8/scalers/predictkube.md
+++ b/content/docs/2.8/scalers/predictkube.md
@@ -27,7 +27,7 @@ triggers:
     prometheusAddress: http://<prometheus-host>:9090
     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
     queryStep: "2m"
-    threshold: '100'
+    threshold: '100.50'
 ```
 
 **Parameter list:**
@@ -37,7 +37,7 @@ triggers:
 - `prometheusAddress` - Address of Prometheus server.
 - `query` - Predict the query that will yield the value for the scaler to compare against the `threshold`. The query must return a vector/scalar single element response.
 - `queryStep` - The maximum time between two slices within the boundaries for QML range query, used in the query.
-- `threshold` - Value to start scaling for.
+- `threshold` - Value to start scaling for. (This value can be a float)
 
 ### Authentication Parameters
 

--- a/content/docs/2.8/scalers/prometheus.md
+++ b/content/docs/2.8/scalers/prometheus.md
@@ -19,7 +19,7 @@ triggers:
     serverAddress: http://<prometheus-host>:9090
     metricName: http_requests_total # Note: name to identify the metric, generated value would be `prometheus-http_requests_total`
     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m])) # Note: query must return a vector/scalar single element response
-    threshold: '100'
+    threshold: '100.50'
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgId: my-org # Optional. X-Scope-OrgID header for Cortex.
@@ -31,7 +31,7 @@ triggers:
 - `serverAddress` - Address of Prometheus. server
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
-- `threshold` - Value to start scaling for.
+- `threshold` - Value to start scaling for. (This value can be a float)
 - `namespace` - A namespace that should be used for namespaced queries. These are required by some highly available Prometheus setups, such as [Thanos](https://thanos.io). (Optional)
 - `cortexOrgId` - The `X-Scope-OrgID` header to query multi tenant [Cortex](https://cortexmetrics.io/). (Optional)
 - `ignoreNullValues` - Value to reporting error when Prometheus target is lost (Values: `true`,`false`, Default: `true`, Optional)

--- a/content/docs/2.8/scalers/rabbitmq-queue.md
+++ b/content/docs/2.8/scalers/rabbitmq-queue.md
@@ -18,7 +18,7 @@ triggers:
     host: amqp://localhost:5672/vhost # Optional. If not specified, it must be done by using TriggerAuthentication.
     protocol: auto # Optional. Specifies protocol to use, either amqp or http, or auto to autodetect based on the `host` value. Default value is auto.
     mode: QueueLength # QueueLength or MessageRate
-    value: "100" # message backlog or publish/sec. target per instance
+    value: "100.50" # message backlog or publish/sec. target per instance
     queueName: testqueue
     vhostName: / # Optional. If not specified, use the vhost in the `host` connection string.
     # Alternatively, you can use existing environment variables to read configuration from:
@@ -31,7 +31,7 @@ triggers:
 - `host` - Host of RabbitMQ with format `<protocol>://<host>:<port>/vhost`. The resolved host should follow a format like `amqp://guest:password@localhost:5672/vhost` or `http://guest:password@localhost:15672/vhost`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 - `queueName` - Name of the queue to read message from.
 - `mode` - QueueLength to trigger on number of messages in the queue. MessageRate to trigger on the publish rate into the queue. (Values: `QueueLength`, `MessageRate`)
-- `value` - Message backlog or Publish/sec. rate to trigger on.
+- `value` - Message backlog or Publish/sec. rate to trigger on. (This value can be a float when `mode: MessageRate`)
 - `protocol` - Protocol to be used for communication. (Values: `auto`, `http`, `amqp`, Default: `auto`, Optional)
 - `vhostName` - Vhost to use for the connection, overrides any vhost set in the connection string from `host`/`hostFromEnv`. (Optional)
 - `queueLength` - DEPRECATED! Use `mode: QueueLength` and `value: ##` instead. Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. Default is 20 unless `publishRate` is specified, in which case `queueLength` is disabled for this trigger.


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

After merging the PR to support `mili` unit in core, there are some scalers that support `float` as target value (because the scaler logic already supported float64 and it made sense). 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related https://github.com/kedacore/keda/issues/3135
