### PR TITLE
fix: expand readOnlyRootFilesystem answer

### DIFF
--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -124,6 +124,15 @@ args:
   - '--tls-cert-file=/certs/tls.crt'
   - '--tls-private-key-file=/certs/tls.key'
 ```
+It is also possible to run KEDA with `readOnlyRootFilesystem=true` by creating an emptyDir volume and mounting it to the path where,
+by default, metrics server writes its generated cert. The corresponding helm command is:
+```
+helm install keda kedacore/keda --namespace keda \
+  --set 'volumes.metricsApiServer.extraVolumes[0].name=keda-volume' \
+  --set 'volumes.metricsApiServer.extraVolumeMounts[0].name=keda-volume' \
+  --set 'volumes.metricsApiServer.extraVolumeMounts[0].mountPath=/apiserver.local.config/certificates/' \
+  --set 'securityContext.metricServer.readOnlyRootFilesystem=true'
+```
 """
 type = "Features"
 


### PR DESCRIPTION
Expands FAQ answer regarding running keda-metrics-apiserver with readOnlyRootFilesystem=true

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to:
* https://github.com/kedacore/keda/issues/3292
* https://github.com/kedacore/keda/pull/2938
* https://github.com/kedacore/keda/discussions/2880
