### PR TITLE
chore: Remove Docplanner Tech as partner

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -440,10 +440,6 @@ logo = "zapier.png"
 
 # "Partners" section on the Community page
 [[params.partners]]
-url = "https://docplanner.tech"
-logo = "docplanner-tech.png"
-
-[[params.partners]]
 url = "https://microsoft.com"
 logo = "microsoft.png"
 


### PR DESCRIPTION
Remove Docplanner Tech as partner given @JorTurFer is switching companies

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)