### PR TITLE
chore: Clarification about activation

### DIFF
--- a/content/docs/2.8/concepts/scaling-deployments.md
+++ b/content/docs/2.8/concepts/scaling-deployments.md
@@ -255,7 +255,7 @@ There are some important topics to take into account:
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
-> ⚠️ **NOTE:** If scaler's page doesn't define the specific parameter is because that specific scaler doesn't support activation value.
+> ⚠️ **NOTE:** If scaler's page doesn't define the specific parameter is because that specific scaler doesn't support activation value and is always 0.
 
 ## Long-running executions
 

--- a/content/docs/2.8/concepts/scaling-deployments.md
+++ b/content/docs/2.8/concepts/scaling-deployments.md
@@ -255,6 +255,8 @@ There are some important topics to take into account:
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
+> ⚠️ **NOTE:** If scaler's page doesn't define the specific parameter is because that specific scaler doesn't support activation value.
+
 ## Long-running executions
 
 One important consideration to make is how this pattern can work with long running executions.  Imagine a deployment triggers on a RabbitMQ queue message.  Each message takes 3 hours to process.  It's possible that if many queue messages arrive, KEDA will help drive scaling out to many replicas - let's say 4.  Now the HPA makes a decision to scale down from 4 replicas to 2.  There is no way to control which of the 2 replicas get terminated to scale down.  That means the HPA may attempt to terminate a replica that is 2.9 hours into processing a 3 hour queue message.

--- a/content/docs/2.8/concepts/scaling-deployments.md
+++ b/content/docs/2.8/concepts/scaling-deployments.md
@@ -255,7 +255,7 @@ There are some important topics to take into account:
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
-> ⚠️ **NOTE:** If scaler's page doesn't define the specific parameter is because that specific scaler doesn't support activation value and is always 0.
+> ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.
 
 ## Long-running executions
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Some scalers like CPU/Memory, Cron, etc don't implement activation feature because it doesn't make sense for them. This PR adds a note clarifying that if the scaler page doesn't define the parameter for the scaler it is because the scaler doesn't support activation

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
