### PR TITLE
Drop scalers-related dead code

### DIFF
--- a/archetypes/scaler.md
+++ b/archetypes/scaler.md
@@ -3,7 +3,6 @@ title = "{{ replace .Name "-" " " | title }}"
 availability = ""
 maintainer = ""
 description = "Insert description here"
-layout = "scaler"
 +++
 
 ### Trigger Specification
@@ -33,4 +32,4 @@ The user will need access to read data from Huawei Cloudeye.
 
 ### Example
 
-*Provide an example of how to configure the trigger, preferably using TriggerAuthentication* 
+*Provide an example of how to configure the trigger, preferably using TriggerAuthentication*

--- a/content/docs/1.4/scalers/apache-kafka.md
+++ b/content/docs/1.4/scalers/apache-kafka.md
@@ -1,14 +1,13 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
 go_file = "kafka_scaler"
 +++
 
-> **Notice:** 
-> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. 
+> **Notice:**
+> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 
 ### Trigger Specification

--- a/content/docs/1.4/scalers/aws-cloudwatch.md
+++ b/content/docs/1.4/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."
@@ -41,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
@@ -70,7 +69,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/1.4/scalers/aws-kinesis.md
+++ b/content/docs/1.4/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -36,7 +35,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/1.4/concepts/authentication/).
 
@@ -64,7 +63,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/1.4/scalers/aws-sqs.md
+++ b/content/docs/1.4/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."
@@ -19,7 +18,7 @@ triggers:
     queueURL: https://sqs.eu-west-1.amazonaws.com/account_id/QueueName
     queueLength: "5"  # Default: "5"
     # Required: awsRegion
-    awsRegion: "eu-west-1" 
+    awsRegion: "eu-west-1"
     identityOwner: pod | operator # Optional. Default: pod
 ```
 **Parameter list:**
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
@@ -64,7 +63,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:
@@ -96,5 +95,5 @@ spec:
     metadata:
       queueURL: myQueue
       queueLength: "5"
-      awsRegion: "eu-west-1" 
+      awsRegion: "eu-west-1"
 ```

--- a/content/docs/1.4/scalers/azure-event-hub.md
+++ b/content/docs/1.4/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."
@@ -17,7 +16,7 @@ triggers:
 - type: azure-eventhub
   metadata:
     connection: EVENTHUB_CONNECTIONSTRING_ENV_NAME # Connection string for Event Hub namespace appended with "EntityPath=<event_hub_name>"
-    storageConnection: STORAGE_CONNECTIONSTRING_ENV_NAME # Connection string for account used to store checkpoint. As of now the Event Hub scaler only reads from Azure Blob Storage. 
+    storageConnection: STORAGE_CONNECTIONSTRING_ENV_NAME # Connection string for account used to store checkpoint. As of now the Event Hub scaler only reads from Azure Blob Storage.
     consumerGroup: $Default # Optional. Consumer group of event hub consumer. Default: $Default
     unprocessedEventThreshold: '64' # Optional. Target number of unprocessed events across all partitions in Event Hub for HPA. Default: 64 events.
     blobContainer: 'name_of_container' # Optional. Container name to store checkpoint. This is needed when a using an Event Hub application written in dotnet or java, and not an Azure function.

--- a/content/docs/1.4/scalers/azure-monitor.md
+++ b/content/docs/1.4/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."
@@ -65,7 +64,7 @@ data:
 ---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
-metadata: 
+metadata:
   name: azure-monitor-trigger-auth
 spec:
   secretTargetRef:
@@ -90,7 +89,7 @@ spec:
   triggers:
   - type: azure-monitor
     metadata:
-      resourceURI: Microsoft.ContainerService/managedClusters/azureMonitorCluster 
+      resourceURI: Microsoft.ContainerService/managedClusters/azureMonitorCluster
       tenantId: xxx-xxx-xxx-xxx-xxx
       subscriptionId: yyy-yyy-yyy-yyy-yyy
       resourceGroupName: azureMonitor

--- a/content/docs/1.4/scalers/azure-service-bus.md
+++ b/content/docs/1.4/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/1.4/scalers/azure-storage-blob.md
+++ b/content/docs/1.4/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."
@@ -17,7 +16,7 @@ triggers:
 - type: azure-blob
   metadata:
     blobContainerName: functions-blob # Required: Name of Azure Blob Storage container
-    blobCount: '5' # Optional. Amount of blobs to scale out on. Default: 5 blobs 
+    blobCount: '5' # Optional. Amount of blobs to scale out on. Default: 5 blobs
     connection: STORAGE_CONNECTIONSTRING_ENV_NAME # Optional if TriggerAuthentication defined with pod identity or connection string authentication.
     blobPrefix:  # Optional. Prefix for the Blob. Use this to specify sub path for the blobs if required. Default : ""
     blobDelimiter: # Optional. Delimiter for identifying the blob Prefix. Default: "/"

--- a/content/docs/1.4/scalers/azure-storage-queue.md
+++ b/content/docs/1.4/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/1.4/scalers/external.md
+++ b/content/docs/1.4/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/1.4/scalers/gcp-pub-sub.md
+++ b/content/docs/1.4/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -16,7 +15,7 @@ triggers:
 - type: gcp-pubsub
   metadata:
     subscriptionSize: "5" # Optional - Default is 5
-    subscriptionName: "mysubscription" # Required 
+    subscriptionName: "mysubscription" # Required
     credentials: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```
 
@@ -45,6 +44,6 @@ spec:
   - type: gcp-pubsub
     metadata:
       subscriptionSize: "5"
-      subscriptionName: "mysubscription" # Required 
+      subscriptionName: "mysubscription" # Required
       credentials: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```

--- a/content/docs/1.4/scalers/huawei-cloudeye.md
+++ b/content/docs/1.4/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/1.4/scalers/liiklus-topic.md
+++ b/content/docs/1.4/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/1.4/scalers/mysql.md
+++ b/content/docs/1.4/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."
@@ -16,7 +15,7 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
-To provide information about how to connect to MySQL you can provide: 
+To provide information about how to connect to MySQL you can provide:
 - `connectionString` - MySQL connection string that should point to environment variable with valid value.
 
 Or provide more detailed information:

--- a/content/docs/1.4/scalers/nats-streaming.md
+++ b/content/docs/1.4/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -38,7 +37,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     deploymentName: gonuts-sub
   triggers:

--- a/content/docs/1.4/scalers/postgresql.md
+++ b/content/docs/1.4/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."
@@ -13,13 +12,13 @@ This specification describes the `postgresql` trigger that scales based on a pos
 
 The Postgresql scaler allows for two connection options:
 
-A user can offer a full connection string 
+A user can offer a full connection string
 (often in the form of an environment variable secret)
 
 - `connection` - PostgreSQL connection string that should point to environment variable with valid value.
 
 Alternatively, a user can specify individual
-arguments (host, userName, password, etc.), and the scaler will form a connection string 
+arguments (host, userName, password, etc.), and the scaler will form a connection string
 internally.
 
 - `host:` - Service URL to postgresql. Note that you should use a full svc URL as KEDA will need to contact postgresql from a different namespace.
@@ -53,7 +52,7 @@ triggers:
   metadata:
     userName: "kedaUser"
     password: PG_PASSWORD
-    host: postgres-svc.namespace.cluster.local #use the cluster-wide namespace as KEDA 
+    host: postgres-svc.namespace.cluster.local #use the cluster-wide namespace as KEDA
                                                 #lives in a different namespace from your postgres
     port: "5432"
     dbName: postgresql

--- a/content/docs/1.4/scalers/prometheus.md
+++ b/content/docs/1.4/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."

--- a/content/docs/1.4/scalers/rabbitmq-queue.md
+++ b/content/docs/1.4/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/1.4/scalers/redis-lists.md
+++ b/content/docs/1.4/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."
@@ -25,7 +24,7 @@ triggers:
 
 The `address` field in the spec holds the host and port of the redis server. This could be an external redis server or one running in the kubernetes cluster.
 
-As an alternative to the `address` field the user can specify `host` and `port` parameters. 
+As an alternative to the `address` field the user can specify `host` and `port` parameters.
 
 Provide the `password` field if the redis server requires a password. Both the hostname and password fields need to be set to the names of the environment variables in the target deployment that contain the host name and password respectively.
 

--- a/content/docs/1.5/scalers/apache-kafka.md
+++ b/content/docs/1.5/scalers/apache-kafka.md
@@ -1,14 +1,13 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
 go_file = "kafka_scaler"
 +++
 
-> **Notice:** 
-> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. 
+> **Notice:**
+> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 
 ### Trigger Specification

--- a/content/docs/1.5/scalers/artemis.md
+++ b/content/docs/1.5/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
 ```
@@ -31,7 +30,7 @@ triggers:
 - `brokerName` - Name of the broker as defined in Artemis.
 - `brokerAddress` - Address name of the broker.
 - `queueLength` - How much messages are in the queue. (Default: `10`, Optional.)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/1.5/scalers/aws-cloudwatch.md
+++ b/content/docs/1.5/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."
@@ -40,7 +39,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
@@ -69,7 +68,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/1.5/scalers/aws-kinesis.md
+++ b/content/docs/1.5/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -36,7 +35,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/1.5/concepts/authentication/).
 
@@ -64,7 +63,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/1.5/scalers/aws-sqs.md
+++ b/content/docs/1.5/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."
@@ -19,7 +18,7 @@ triggers:
     queueURL: https://sqs.eu-west-1.amazonaws.com/account_id/QueueName
     queueLength: "5"  # Default: "5"
     # Required: awsRegion
-    awsRegion: "eu-west-1" 
+    awsRegion: "eu-west-1"
     identityOwner: pod | operator # Optional. Default: pod
 ```
 **Parameter list:**
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
@@ -64,7 +63,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:
@@ -96,5 +95,5 @@ spec:
     metadata:
       queueURL: myQueue
       queueLength: "5"
-      awsRegion: "eu-west-1" 
+      awsRegion: "eu-west-1"
 ```

--- a/content/docs/1.5/scalers/azure-event-hub.md
+++ b/content/docs/1.5/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."
@@ -17,7 +16,7 @@ triggers:
 - type: azure-eventhub
   metadata:
     connection: EVENTHUB_CONNECTIONSTRING_ENV_NAME # Connection string for Event Hub namespace appended with "EntityPath=<event_hub_name>"
-    storageConnection: STORAGE_CONNECTIONSTRING_ENV_NAME # Connection string for account used to store checkpoint. As of now the Event Hub scaler only reads from Azure Blob Storage. 
+    storageConnection: STORAGE_CONNECTIONSTRING_ENV_NAME # Connection string for account used to store checkpoint. As of now the Event Hub scaler only reads from Azure Blob Storage.
     consumerGroup: $Default # Optional. Consumer group of event hub consumer. Default: $Default
     unprocessedEventThreshold: '64' # Optional. Target number of unprocessed events across all partitions in Event Hub for HPA. Default: 64 events.
     blobContainer: 'name_of_container' # Optional. Container name to store checkpoint. This is needed when a using an Event Hub application written in dotnet or java, and not an Azure function.

--- a/content/docs/1.5/scalers/azure-monitor.md
+++ b/content/docs/1.5/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."
@@ -65,7 +64,7 @@ data:
 ---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
-metadata: 
+metadata:
   name: azure-monitor-trigger-auth
 spec:
   secretTargetRef:
@@ -90,7 +89,7 @@ spec:
   triggers:
   - type: azure-monitor
     metadata:
-      resourceURI: Microsoft.ContainerService/managedClusters/azureMonitorCluster 
+      resourceURI: Microsoft.ContainerService/managedClusters/azureMonitorCluster
       tenantId: xxx-xxx-xxx-xxx-xxx
       subscriptionId: yyy-yyy-yyy-yyy-yyy
       resourceGroupName: azureMonitor

--- a/content/docs/1.5/scalers/azure-service-bus.md
+++ b/content/docs/1.5/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/1.5/scalers/azure-storage-blob.md
+++ b/content/docs/1.5/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."
@@ -17,7 +16,7 @@ triggers:
 - type: azure-blob
   metadata:
     blobContainerName: functions-blob # Required: Name of Azure Blob Storage container
-    blobCount: '5' # Optional. Amount of blobs to scale out on. Default: 5 blobs 
+    blobCount: '5' # Optional. Amount of blobs to scale out on. Default: 5 blobs
     connection: STORAGE_CONNECTIONSTRING_ENV_NAME # Optional if TriggerAuthentication defined with pod identity or connection string authentication.
     blobPrefix:  # Optional. Prefix for the Blob. Use this to specify sub path for the blobs if required. Default : ""
     blobDelimiter: # Optional. Delimiter for identifying the blob Prefix. Default: "/"

--- a/content/docs/1.5/scalers/azure-storage-queue.md
+++ b/content/docs/1.5/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/1.5/scalers/cron.md
+++ b/content/docs/1.5/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/1.5/scalers/external.md
+++ b/content/docs/1.5/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/1.5/scalers/gcp-pub-sub.md
+++ b/content/docs/1.5/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -16,7 +15,7 @@ triggers:
 - type: gcp-pubsub
   metadata:
     subscriptionSize: "5" # Optional - Default is 5
-    subscriptionName: "mysubscription" # Required 
+    subscriptionName: "mysubscription" # Required
     credentials: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```
 
@@ -45,6 +44,6 @@ spec:
   - type: gcp-pubsub
     metadata:
       subscriptionSize: "5"
-      subscriptionName: "mysubscription" # Required 
+      subscriptionName: "mysubscription" # Required
       credentials: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```

--- a/content/docs/1.5/scalers/huawei-cloudeye.md
+++ b/content/docs/1.5/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.k8s.io/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/1.5/scalers/liiklus-topic.md
+++ b/content/docs/1.5/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/1.5/scalers/mysql.md
+++ b/content/docs/1.5/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."
@@ -16,7 +15,7 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
-To provide information about how to connect to MySQL you can provide: 
+To provide information about how to connect to MySQL you can provide:
 - `connectionString` - MySQL connection string that should point to environment variable with valid value.
 
 Or provide more detailed information:

--- a/content/docs/1.5/scalers/nats-streaming.md
+++ b/content/docs/1.5/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -38,7 +37,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     deploymentName: gonuts-sub
   triggers:

--- a/content/docs/1.5/scalers/postgresql.md
+++ b/content/docs/1.5/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."
@@ -13,13 +12,13 @@ This specification describes the `postgresql` trigger that scales based on a pos
 
 The Postgresql scaler allows for two connection options:
 
-A user can offer a full connection string 
+A user can offer a full connection string
 (often in the form of an environment variable secret)
 
 - `connection` - PostgreSQL connection string that should point to environment variable with valid value.
 
 Alternatively, a user can specify individual
-arguments (host, userName, password, etc.), and the scaler will form a connection string 
+arguments (host, userName, password, etc.), and the scaler will form a connection string
 internally.
 
 - `host:` - Service URL to postgresql. Note that you should use a full svc URL as KEDA will need to contact postgresql from a different namespace.
@@ -53,7 +52,7 @@ triggers:
   metadata:
     userName: "kedaUser"
     password: PG_PASSWORD
-    host: postgres-svc.namespace.cluster.local #use the cluster-wide namespace as KEDA 
+    host: postgres-svc.namespace.cluster.local #use the cluster-wide namespace as KEDA
                                                 #lives in a different namespace from your postgres
     port: "5432"
     dbName: postgresql

--- a/content/docs/1.5/scalers/prometheus.md
+++ b/content/docs/1.5/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."

--- a/content/docs/1.5/scalers/rabbitmq-queue.md
+++ b/content/docs/1.5/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."
@@ -30,16 +29,16 @@ triggers:
 - `queueName` - Name of the queue to read message from.
 - `queueLength` - Queue length target for HPA. (Default: `20`, Optional)
 - `includeUnacked` - By default `includeUnacked` is `false` in this case scaler uses AMQP protocol, requires `host` and only counts messages in the queue and ignores unacked messages. If `includeUnacked` is `true` then `host` is not required but `apiHost` is required in this case scaler uses HTTP management API and counts messages in the queue + unacked messages count. `host` or `apiHost` value comes from authentication trigger. (Optional)
-- `apiHost` - It has similar format as of `host` but for HTTP API endpoint, like https://guest:password@localhost:443/vhostname. 
+- `apiHost` - It has similar format as of `host` but for HTTP API endpoint, like https://guest:password@localhost:443/vhostname.
 
-Note `host` and `apiHost` both have an optional vhost name after the host slash which will be used to scope API request. 
+Note `host` and `apiHost` both have an optional vhost name after the host slash which will be used to scope API request.
 
 ### Authentication Parameters
 
 TriggerAuthentication CRD is used to connect and authenticate to RabbitMQ:
 
 - `host` - AMQP URI connection string, like `amqp://guest:password@localhost:5672/vhost`.
-- `apiHost` - HTTP API endpoint, like `https://guest:password@localhost:443/vhostname`. 
+- `apiHost` - HTTP API endpoint, like `https://guest:password@localhost:443/vhostname`.
 
 ### Example
 

--- a/content/docs/1.5/scalers/redis-lists.md
+++ b/content/docs/1.5/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."
@@ -25,7 +24,7 @@ triggers:
 
 The `address` field in the spec holds the host and port of the redis server. This could be an external redis server or one running in the kubernetes cluster.
 
-As an alternative to the `address` field the user can specify `host` and `port` parameters. 
+As an alternative to the `address` field the user can specify `host` and `port` parameters.
 
 Provide the `password` field if the redis server requires a password. Both the hostname and password fields need to be set to the names of the environment variables in the target deployment that contain the host name and password respectively.
 

--- a/content/docs/1.5/scalers/redis-streams.md
+++ b/content/docs/1.5/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."
@@ -36,14 +35,14 @@ triggers:
 - `address` - Name of the environment variable your deployment uses to get the Redis server URL. The resolved host should follow a format like `my-redis:6379`.
    - This is usually resolved from a `Secret V1` or a `ConfigMap V1` collections. `env` and `envFrom` are both supported.
 
-> As an alternative to the `address` field, the user can specify `host` and `port` parameters. 
+> As an alternative to the `address` field, the user can specify `host` and `port` parameters.
 
-- `host` - Name of the environment variable your deployment uses to get the Redis server host. 
+- `host` - Name of the environment variable your deployment uses to get the Redis server host.
     - This is usually resolved from a `Secret V1` or a `ConfigMap V1` collections. `env` and `envFrom` are both supported.
 
 > It is not required if `address` has been provided..
 
-- `port` - Name of the environment variable your deployment uses to get the Redis server port. 
+- `port` - Name of the environment variable your deployment uses to get the Redis server port.
    - This is usually resolved from a `Secret V1` or a `ConfigMap V1` collections. `env` and `envFrom` are both supported.
 
 > It is only to be used along with the `host` attribute and not required if `address` has been provided.

--- a/content/docs/2.0/scalers/apache-kafka.md
+++ b/content/docs/2.0/scalers/apache-kafka.md
@@ -1,14 +1,13 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
 go_file = "kafka_scaler"
 +++
 
-> **Notice:** 
-> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. 
+> **Notice:**
+> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 
 ### Trigger Specification

--- a/content/docs/2.0/scalers/artemis.md
+++ b/content/docs/2.0/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"

--- a/content/docs/2.0/scalers/aws-cloudwatch.md
+++ b/content/docs/2.0/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."

--- a/content/docs/2.0/scalers/aws-kinesis.md
+++ b/content/docs/2.0/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.0/concepts/authentication/).
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.0/scalers/aws-sqs.md
+++ b/content/docs/2.0/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."
@@ -34,7 +33,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.0/scalers/azure-event-hub.md
+++ b/content/docs/2.0/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.0/scalers/azure-log-analytics.md
+++ b/content/docs/2.0/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -102,7 +101,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -121,7 +120,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -206,7 +205,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -264,7 +263,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.0/scalers/azure-monitor.md
+++ b/content/docs/2.0/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.0/scalers/azure-service-bus.md
+++ b/content/docs/2.0/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.0/scalers/azure-storage-blob.md
+++ b/content/docs/2.0/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.0/scalers/azure-storage-queue.md
+++ b/content/docs/2.0/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.0/scalers/cpu.md
+++ b/content/docs/2.0/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user define multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.0/scalers/cron.md
+++ b/content/docs/2.0/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.0/scalers/external-push.md
+++ b/content/docs/2.0/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.0/scalers/external.md
+++ b/content/docs/2.0/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.0/scalers/gcp-pub-sub.md
+++ b/content/docs/2.0/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -29,14 +28,14 @@ The `credentialsFromEnv` property maps to the name of an environment variable in
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -64,7 +63,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -80,5 +79,5 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```

--- a/content/docs/2.0/scalers/huawei-cloudeye.md
+++ b/content/docs/2.0/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.0/scalers/ibm-mq.md
+++ b/content/docs/2.0/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.0/scalers/liiklus-topic.md
+++ b/content/docs/2.0/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.0/scalers/memory.md
+++ b/content/docs/2.0/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.0/scalers/metrics-api.md
+++ b/content/docs/2.0/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -47,7 +46,7 @@ You can use `TriggerAuthentication` CRD to configure the authentication. Specify
 **Basic authentication:**
 - `authMode` - It must be set to `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
-- `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, 
+- `password` - Provide the password to be used for authentication. For convenience, this has been marked optional,
 because many application implements basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
@@ -81,7 +80,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -109,7 +108,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -155,7 +154,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -204,7 +203,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.0/scalers/mysql.md
+++ b/content/docs/2.0/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.0/scalers/nats-streaming.md
+++ b/content/docs/2.0/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -46,7 +45,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.0/scalers/postgresql.md
+++ b/content/docs/2.0/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.0/scalers/prometheus.md
+++ b/content/docs/2.0/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."

--- a/content/docs/2.0/scalers/rabbitmq-queue.md
+++ b/content/docs/2.0/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.0/scalers/redis-lists.md
+++ b/content/docs/2.0/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.0/scalers/redis-streams.md
+++ b/content/docs/2.0/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.1/scalers/apache-kafka.md
+++ b/content/docs/2.1/scalers/apache-kafka.md
@@ -1,14 +1,13 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
 go_file = "kafka_scaler"
 +++
 
-> **Notice:** 
-> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. 
+> **Notice:**
+> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 
 ### Trigger Specification

--- a/content/docs/2.1/scalers/artemis.md
+++ b/content/docs/2.1/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"

--- a/content/docs/2.1/scalers/aws-cloudwatch.md
+++ b/content/docs/2.1/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."

--- a/content/docs/2.1/scalers/aws-kinesis.md
+++ b/content/docs/2.1/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.1/concepts/authentication/).
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.1/scalers/aws-sqs.md
+++ b/content/docs/2.1/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."
@@ -34,7 +33,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials.
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.1/scalers/azure-event-hub.md
+++ b/content/docs/2.1/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.1/scalers/azure-log-analytics.md
+++ b/content/docs/2.1/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -102,7 +101,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -121,7 +120,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -206,7 +205,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -264,7 +263,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.1/scalers/azure-monitor.md
+++ b/content/docs/2.1/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.1/scalers/azure-service-bus.md
+++ b/content/docs/2.1/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.1/scalers/azure-storage-blob.md
+++ b/content/docs/2.1/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.1/scalers/azure-storage-queue.md
+++ b/content/docs/2.1/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.1/scalers/cpu.md
+++ b/content/docs/2.1/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.1/scalers/cron.md
+++ b/content/docs/2.1/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.1/scalers/external-push.md
+++ b/content/docs/2.1/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.1/scalers/external.md
+++ b/content/docs/2.1/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.1/scalers/gcp-pub-sub.md
+++ b/content/docs/2.1/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -29,14 +28,14 @@ The `credentialsFromEnv` property maps to the name of an environment variable in
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -64,7 +63,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -80,5 +79,5 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```

--- a/content/docs/2.1/scalers/huawei-cloudeye.md
+++ b/content/docs/2.1/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.1/scalers/ibm-mq.md
+++ b/content/docs/2.1/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.1/scalers/influxdb.md
+++ b/content/docs/2.1/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.1/scalers/liiklus-topic.md
+++ b/content/docs/2.1/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.1/scalers/memory.md
+++ b/content/docs/2.1/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.1/scalers/metrics-api.md
+++ b/content/docs/2.1/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -80,7 +79,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -108,7 +107,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -154,7 +153,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -203,7 +202,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.1/scalers/mongodb.md
+++ b/content/docs/2.1/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -85,7 +84,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on masked version of the server hostname and collection name. For example: **mongodb-mongodb---test_user-test_password@xxx-27017-test-test_collection**. If using more than one trigger it is required that all `metricName`(s) be unique. The value will be prefixed with `mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.1/scalers/mysql.md
+++ b/content/docs/2.1/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.1/scalers/nats-streaming.md
+++ b/content/docs/2.1/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -46,7 +45,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.1/scalers/openstack-swift.md
+++ b/content/docs/2.1/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     containerName: my-container # Required
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -120,7 +119,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.1/scalers/postgresql.md
+++ b/content/docs/2.1/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.1/scalers/prometheus.md
+++ b/content/docs/2.1/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."

--- a/content/docs/2.1/scalers/rabbitmq-queue.md
+++ b/content/docs/2.1/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.1/scalers/redis-cluster-lists.md
+++ b/content/docs/2.1/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.1/scalers/redis-cluster-streams.md
+++ b/content/docs/2.1/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.1/scalers/redis-lists.md
+++ b/content/docs/2.1/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.1/scalers/redis-streams.md
+++ b/content/docs/2.1/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.2/scalers/apache-kafka.md
+++ b/content/docs/2.2/scalers/apache-kafka.md
@@ -1,14 +1,13 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
 go_file = "kafka_scaler"
 +++
 
-> **Notice:** 
-> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount. 
+> **Notice:**
+> - No. of replicas will not exceed the number of partitions on a topic. That is, if `maxReplicaCount` is set more than number of partitions, the scaler won't scale up to target maxReplicaCount.
 > - This is so because if there are more number of consumers than the number of partitions in a topic, then extra consumer will have to sit idle.
 
 ### Trigger Specification

--- a/content/docs/2.2/scalers/artemis.md
+++ b/content/docs/2.2/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"
@@ -33,7 +32,7 @@ triggers:
 - `brokerAddress` - Address of the broker.
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.2/scalers/aws-cloudwatch.md
+++ b/content/docs/2.2/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."

--- a/content/docs/2.2/scalers/aws-kinesis.md
+++ b/content/docs/2.2/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.2/concepts/authentication/).
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.2/scalers/aws-sqs.md
+++ b/content/docs/2.2/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.2/scalers/azure-event-hub.md
+++ b/content/docs/2.2/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.2/scalers/azure-log-analytics.md
+++ b/content/docs/2.2/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -102,7 +101,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -121,7 +120,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -206,7 +205,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -264,7 +263,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.2/scalers/azure-monitor.md
+++ b/content/docs/2.2/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.2/scalers/azure-service-bus.md
+++ b/content/docs/2.2/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.2/scalers/azure-storage-blob.md
+++ b/content/docs/2.2/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.2/scalers/azure-storage-queue.md
+++ b/content/docs/2.2/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.2/scalers/cpu.md
+++ b/content/docs/2.2/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.2/scalers/cron.md
+++ b/content/docs/2.2/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.2/scalers/external-push.md
+++ b/content/docs/2.2/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.2/scalers/external.md
+++ b/content/docs/2.2/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.2/scalers/gcp-pub-sub.md
+++ b/content/docs/2.2/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -29,14 +28,14 @@ The `credentialsFromEnv` property maps to the name of an environment variable in
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -64,7 +63,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -80,5 +79,5 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```

--- a/content/docs/2.2/scalers/huawei-cloudeye.md
+++ b/content/docs/2.2/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.2/scalers/ibm-mq.md
+++ b/content/docs/2.2/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.2/scalers/influxdb.md
+++ b/content/docs/2.2/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.2/scalers/liiklus-topic.md
+++ b/content/docs/2.2/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.2/scalers/memory.md
+++ b/content/docs/2.2/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.2/scalers/metrics-api.md
+++ b/content/docs/2.2/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -82,7 +81,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -110,7 +109,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -156,7 +155,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -205,7 +204,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.2/scalers/mongodb.md
+++ b/content/docs/2.2/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -85,7 +84,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on masked version of the server hostname and collection name. For example: **mongodb-mongodb---test_user-test_password@xxx-27017-test-test_collection**. If using more than one trigger it is required that all `metricName`(s) be unique. The value will be prefixed with `mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.2/scalers/mssql.md
+++ b/content/docs/2.2/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.2/scalers/mysql.md
+++ b/content/docs/2.2/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.2/scalers/nats-streaming.md
+++ b/content/docs/2.2/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -46,7 +45,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.2/scalers/openstack-swift.md
+++ b/content/docs/2.2/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     swiftURL: http://localhost:8080/v1/b161dc815cd24bda84d94d9a0e73cf78  # Optional
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -125,7 +124,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.2/scalers/postgresql.md
+++ b/content/docs/2.2/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.2/scalers/prometheus.md
+++ b/content/docs/2.2/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."

--- a/content/docs/2.2/scalers/rabbitmq-queue.md
+++ b/content/docs/2.2/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.2/scalers/redis-cluster-lists.md
+++ b/content/docs/2.2/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.2/scalers/redis-cluster-streams.md
+++ b/content/docs/2.2/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.2/scalers/redis-lists.md
+++ b/content/docs/2.2/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.2/scalers/redis-streams.md
+++ b/content/docs/2.2/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.3/scalers/apache-kafka.md
+++ b/content/docs/2.3/scalers/apache-kafka.md
@@ -1,6 +1,5 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."

--- a/content/docs/2.3/scalers/artemis.md
+++ b/content/docs/2.3/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"
@@ -34,7 +33,7 @@ triggers:
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
 - `corsHeader` - Value to populate the Origin header field for CORS filtering. (Default: `"http://<<managmentEndpoint>>"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.3/scalers/aws-cloudwatch.md
+++ b/content/docs/2.3/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."

--- a/content/docs/2.3/scalers/aws-kinesis.md
+++ b/content/docs/2.3/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.3/concepts/authentication/).
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.3/scalers/aws-sqs.md
+++ b/content/docs/2.3/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.3/scalers/azure-event-hub.md
+++ b/content/docs/2.3/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.3/scalers/azure-log-analytics.md
+++ b/content/docs/2.3/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -102,7 +101,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -121,7 +120,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -206,7 +205,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -264,7 +263,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.3/scalers/azure-monitor.md
+++ b/content/docs/2.3/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.3/scalers/azure-pipelines.md
+++ b/content/docs/2.3/scalers/azure-pipelines.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Pipelines"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on agent pool queues for Azure Pipelines."
@@ -46,7 +45,7 @@ As an alternative to using environment variables, you can authenticate with Azur
 
 ### How to determine your pool ID
 
-There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`. 
+There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`.
 
 It is also possible to get the pool ID using the UI by browsing to the agent pool from the organization (Organization settings -> Agent pools -> `{agentPoolName}`) and getting it from the URL.
 The URL should be similar to `https://dev.azure.com/{organization}/_settings/agentpools?poolId={poolID}&view=jobs`
@@ -86,7 +85,7 @@ spec:
   scaleTargetRef:
     name: azdevops-deployment
   minReplicaCount: 1
-  maxReplicaCount: 5 
+  maxReplicaCount: 5
   triggers:
   - type: azure-pipelines
     metadata:

--- a/content/docs/2.3/scalers/azure-service-bus.md
+++ b/content/docs/2.3/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.3/scalers/azure-storage-blob.md
+++ b/content/docs/2.3/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.3/scalers/azure-storage-queue.md
+++ b/content/docs/2.3/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.3/scalers/cpu.md
+++ b/content/docs/2.3/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.3/scalers/cron.md
+++ b/content/docs/2.3/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.3/scalers/external-push.md
+++ b/content/docs/2.3/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.3/scalers/external.md
+++ b/content/docs/2.3/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.3/scalers/gcp-pub-sub.md
+++ b/content/docs/2.3/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -29,14 +28,14 @@ The `credentialsFromEnv` property maps to the name of an environment variable in
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -64,7 +63,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -80,5 +79,5 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```

--- a/content/docs/2.3/scalers/huawei-cloudeye.md
+++ b/content/docs/2.3/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.3/scalers/ibm-mq.md
+++ b/content/docs/2.3/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.3/scalers/influxdb.md
+++ b/content/docs/2.3/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.3/scalers/liiklus-topic.md
+++ b/content/docs/2.3/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.3/scalers/memory.md
+++ b/content/docs/2.3/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.3/scalers/metrics-api.md
+++ b/content/docs/2.3/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -80,7 +79,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -108,7 +107,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -154,7 +153,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -203,7 +202,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.3/scalers/mongodb.md
+++ b/content/docs/2.3/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -85,7 +84,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on masked version of the server hostname and collection name. For example: **mongodb-mongodb---test_user-test_password@xxx-27017-test-test_collection**. If using more than one trigger it is required that all `metricName`(s) be unique. The value will be prefixed with `mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.3/scalers/mssql.md
+++ b/content/docs/2.3/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.3/scalers/mysql.md
+++ b/content/docs/2.3/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.3/scalers/nats-streaming.md
+++ b/content/docs/2.3/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -46,7 +45,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.3/scalers/openstack-metric.md
+++ b/content/docs/2.3/scalers/openstack-metric.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Metric"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on a threshold reached by a specific measure from OpenStack Metric API."
@@ -28,7 +27,7 @@ triggers:
 > Protocol (http or https) should always be provided when specifying URLs
 
 **Parameter list:**
-- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`. 
+- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`.
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
@@ -105,19 +104,19 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-      metricsURL: http://localhost:8041/v1/metric 
+      metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
-      threshold: 1250 
-      timeout: 30 
+      granularity: 300
+      threshold: 1250
+      timeout: 30
     authenticationRef:
         name: openstack-metric-password-trigger-authentication
 ```
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1
@@ -162,10 +161,10 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-       metricsURL: http://localhost:8041/v1/metric 
+       metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
+      granularity: 300
       threshold: 1250
     authenticationRef:
         name: openstack-metric-appcredentials-trigger-authentication

--- a/content/docs/2.3/scalers/openstack-swift.md
+++ b/content/docs/2.3/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     swiftURL: http://localhost:8080/v1/b161dc815cd24bda84d94d9a0e73cf78  # Optional
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -125,7 +124,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.3/scalers/postgresql.md
+++ b/content/docs/2.3/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.3/scalers/prometheus.md
+++ b/content/docs/2.3/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."
@@ -31,7 +30,7 @@ triggers:
 
 ### Authentication Parameters
 
-Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication. 
+Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. It is possible to specify multiple authentication types i.e. `authModes: "tls,basic"` Specify `authModes` and other trigger parameters along with secret credentials in `TriggerAuthentication` as mentioned below:
 
@@ -82,7 +81,7 @@ metadata:
   namespace: default
 data:
   bearerToken: "BEARER_TOKEN"
-  ca: "CUSTOM_CA_CERT" 
+  ca: "CUSTOM_CA_CERT"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -131,7 +130,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -181,7 +180,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---
@@ -234,10 +233,10 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.3/scalers/rabbitmq-queue.md
+++ b/content/docs/2.3/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.3/scalers/redis-cluster-lists.md
+++ b/content/docs/2.3/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.3/scalers/redis-cluster-streams.md
+++ b/content/docs/2.3/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.3/scalers/redis-lists.md
+++ b/content/docs/2.3/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.3/scalers/redis-streams.md
+++ b/content/docs/2.3/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.4/scalers/apache-kafka.md
+++ b/content/docs/2.4/scalers/apache-kafka.md
@@ -1,6 +1,5 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."

--- a/content/docs/2.4/scalers/artemis.md
+++ b/content/docs/2.4/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"
@@ -34,7 +33,7 @@ triggers:
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
 - `corsHeader` - Value to populate the Origin header field for CORS filtering. (Default: `"http://<<managmentEndpoint>>"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.4/scalers/aws-cloudwatch.md
+++ b/content/docs/2.4/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."

--- a/content/docs/2.4/scalers/aws-kinesis.md
+++ b/content/docs/2.4/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.4/scalers/aws-sqs.md
+++ b/content/docs/2.4/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.4/scalers/azure-event-hub.md
+++ b/content/docs/2.4/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.4/scalers/azure-log-analytics.md
+++ b/content/docs/2.4/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -102,7 +101,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -121,7 +120,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -206,7 +205,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -264,7 +263,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.4/scalers/azure-monitor.md
+++ b/content/docs/2.4/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.4/scalers/azure-pipelines.md
+++ b/content/docs/2.4/scalers/azure-pipelines.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Pipelines"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on agent pool queues for Azure Pipelines."
@@ -46,7 +45,7 @@ As an alternative to using environment variables, you can authenticate with Azur
 
 ### How to determine your pool ID
 
-There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`. 
+There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`.
 
 It is also possible to get the pool ID using the UI by browsing to the agent pool from the organization (Organization settings -> Agent pools -> `{agentPoolName}`) and getting it from the URL.
 The URL should be similar to `https://dev.azure.com/{organization}/_settings/agentpools?poolId={poolID}&view=jobs`
@@ -86,7 +85,7 @@ spec:
   scaleTargetRef:
     name: azdevops-deployment
   minReplicaCount: 1
-  maxReplicaCount: 5 
+  maxReplicaCount: 5
   triggers:
   - type: azure-pipelines
     metadata:

--- a/content/docs/2.4/scalers/azure-service-bus.md
+++ b/content/docs/2.4/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.4/scalers/azure-storage-blob.md
+++ b/content/docs/2.4/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.4/scalers/azure-storage-queue.md
+++ b/content/docs/2.4/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.4/scalers/cpu.md
+++ b/content/docs/2.4/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.4/scalers/cron.md
+++ b/content/docs/2.4/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.4/scalers/external-push.md
+++ b/content/docs/2.4/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.4/scalers/external.md
+++ b/content/docs/2.4/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.4/scalers/gcp-pub-sub.md
+++ b/content/docs/2.4/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -29,13 +28,13 @@ The `credentialsFromEnv` property maps to the name of an environment variable in
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -63,7 +62,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -79,5 +78,5 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```

--- a/content/docs/2.4/scalers/huawei-cloudeye.md
+++ b/content/docs/2.4/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.4/scalers/ibm-mq.md
+++ b/content/docs/2.4/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.4/scalers/influxdb.md
+++ b/content/docs/2.4/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.4/scalers/kubernetes-workload.md
+++ b/content/docs/2.4/scalers/kubernetes-workload.md
@@ -1,6 +1,5 @@
 +++
 title = "Kubernetes Workload"
-layout = "scaler"
 availability = "v2.4+"
 maintainer = "Community"
 description = "Scale applications based on the amount of pods which matches the given selectors."

--- a/content/docs/2.4/scalers/liiklus-topic.md
+++ b/content/docs/2.4/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.4/scalers/memory.md
+++ b/content/docs/2.4/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.4/scalers/metrics-api.md
+++ b/content/docs/2.4/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -80,7 +79,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -108,7 +107,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -154,7 +153,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -203,7 +202,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.4/scalers/mongodb.md
+++ b/content/docs/2.4/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"

--- a/content/docs/2.4/scalers/mssql.md
+++ b/content/docs/2.4/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.4/scalers/mysql.md
+++ b/content/docs/2.4/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.4/scalers/nats-streaming.md
+++ b/content/docs/2.4/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -48,7 +47,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.4/scalers/openstack-metric.md
+++ b/content/docs/2.4/scalers/openstack-metric.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Metric"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on a threshold reached by a specific measure from OpenStack Metric API."
@@ -28,7 +27,7 @@ triggers:
 > Protocol (http or https) should always be provided when specifying URLs
 
 **Parameter list:**
-- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`. 
+- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`.
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
@@ -105,19 +104,19 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-      metricsURL: http://localhost:8041/v1/metric 
+      metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
-      threshold: 1250 
-      timeout: 30 
+      granularity: 300
+      threshold: 1250
+      timeout: 30
     authenticationRef:
         name: openstack-metric-password-trigger-authentication
 ```
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1
@@ -162,10 +161,10 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-       metricsURL: http://localhost:8041/v1/metric 
+       metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
+      granularity: 300
       threshold: 1250
     authenticationRef:
         name: openstack-metric-appcredentials-trigger-authentication

--- a/content/docs/2.4/scalers/openstack-swift.md
+++ b/content/docs/2.4/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     swiftURL: http://localhost:8080/v1/b161dc815cd24bda84d94d9a0e73cf78  # Optional
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -125,7 +124,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.4/scalers/postgresql.md
+++ b/content/docs/2.4/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.4/scalers/prometheus.md
+++ b/content/docs/2.4/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."
@@ -31,7 +30,7 @@ triggers:
 
 ### Authentication Parameters
 
-Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication. 
+Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. It is possible to specify multiple authentication types i.e. `authModes: "tls,basic"` Specify `authModes` and other trigger parameters along with secret credentials in `TriggerAuthentication` as mentioned below:
 
@@ -82,7 +81,7 @@ metadata:
   namespace: default
 data:
   bearerToken: "BEARER_TOKEN"
-  ca: "CUSTOM_CA_CERT" 
+  ca: "CUSTOM_CA_CERT"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -131,7 +130,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -181,7 +180,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---
@@ -234,10 +233,10 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.4/scalers/rabbitmq-queue.md
+++ b/content/docs/2.4/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.4/scalers/redis-cluster-lists.md
+++ b/content/docs/2.4/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.4/scalers/redis-cluster-streams.md
+++ b/content/docs/2.4/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.4/scalers/redis-lists.md
+++ b/content/docs/2.4/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.4/scalers/redis-streams.md
+++ b/content/docs/2.4/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.4/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.4/scalers/selenium-grid-scaler.md
@@ -3,7 +3,6 @@ title = "Selenium Grid Scaler"
 availability = "v2.4+"
 maintainer = "Volvo Cars"
 description = "Scales Selenium browser nodes based on number of requests waiting in session queue"
-layout = "scaler"
 go_file = "selenium_grid_scaler"
 +++
 

--- a/content/docs/2.4/scalers/solace-pub-sub.md
+++ b/content/docs/2.4/scalers/solace-pub-sub.md
@@ -3,7 +3,6 @@ title = "Solace PubSub+ Event Broker"
 availability = "2.4+"
 maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
-layout = "scaler"
 go_file = "solace_scaler"
 +++
 

--- a/content/docs/2.5/scalers/apache-kafka.md
+++ b/content/docs/2.5/scalers/apache-kafka.md
@@ -1,6 +1,5 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."

--- a/content/docs/2.5/scalers/artemis.md
+++ b/content/docs/2.5/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"
@@ -34,7 +33,7 @@ triggers:
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
 - `corsHeader` - Value to populate the Origin header field for CORS filtering. (Default: `"http://<<managmentEndpoint>>"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.5/scalers/aws-cloudwatch.md
+++ b/content/docs/2.5/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."
@@ -40,7 +39,7 @@ triggers:
     # Optional: Metric Unit
     metricUnit: "Count" # default ""
     # Optional: Metric EndTime Offset
-    metricEndTimeOffset: "60" # default 0    
+    metricEndTimeOffset: "60" # default 0
 ```
 
 **Parameter list:**

--- a/content/docs/2.5/scalers/aws-kinesis.md
+++ b/content/docs/2.5/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
 
@@ -63,7 +62,7 @@ metadata:
 data:
   AWS_ACCESS_KEY_ID: <encoded-user-id>
   AWS_SECRET_ACCESS_KEY: <encoded-key>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.5/scalers/aws-sqs.md
+++ b/content/docs/2.5/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.5/scalers/azure-event-hub.md
+++ b/content/docs/2.5/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.5/scalers/azure-log-analytics.md
+++ b/content/docs/2.5/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -103,7 +102,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -122,7 +121,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -207,7 +206,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -265,7 +264,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.5/scalers/azure-monitor.md
+++ b/content/docs/2.5/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.5/scalers/azure-pipelines.md
+++ b/content/docs/2.5/scalers/azure-pipelines.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Pipelines"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on agent pool queues for Azure Pipelines."
@@ -46,7 +45,7 @@ As an alternative to using environment variables, you can authenticate with Azur
 
 ### How to determine your pool ID
 
-There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`. 
+There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`.
 
 It is also possible to get the pool ID using the UI by browsing to the agent pool from the organization (Organization settings -> Agent pools -> `{agentPoolName}`) and getting it from the URL.
 The URL should be similar to `https://dev.azure.com/{organization}/_settings/agentpools?poolId={poolID}&view=jobs`
@@ -86,7 +85,7 @@ spec:
   scaleTargetRef:
     name: azdevops-deployment
   minReplicaCount: 1
-  maxReplicaCount: 5 
+  maxReplicaCount: 5
   triggers:
   - type: azure-pipelines
     metadata:

--- a/content/docs/2.5/scalers/azure-service-bus.md
+++ b/content/docs/2.5/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.5/scalers/azure-storage-blob.md
+++ b/content/docs/2.5/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.5/scalers/azure-storage-queue.md
+++ b/content/docs/2.5/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.5/scalers/cassandra.md
+++ b/content/docs/2.5/scalers/cassandra.md
@@ -3,7 +3,6 @@ title = "Cassandra"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on Cassandra query results."
-layout = "scaler"
 go_file = "cassandra_scaler"
 +++
 
@@ -86,5 +85,5 @@ spec:
       targetQueryValue: "1"
       metricName: "test_keyspace"
     authenticationRef:
-      name: keda-trigger-auth-cassandra-secret      
+      name: keda-trigger-auth-cassandra-secret
 ```

--- a/content/docs/2.5/scalers/cpu.md
+++ b/content/docs/2.5/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.5/scalers/cron.md
+++ b/content/docs/2.5/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.5/scalers/elasticsearch.md
+++ b/content/docs/2.5/scalers/elasticsearch.md
@@ -3,7 +3,6 @@ title = "Elasticsearch"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on elasticsearch search template query result."
-layout = "scaler"
 go_file = "elasticsearch_scaler"
 +++
 
@@ -90,4 +89,4 @@ spec:
         params: "dummy_value:1"
       authenticationRef:
         name: keda-trigger-auth-elasticsearch-secret
-``` 
+```

--- a/content/docs/2.5/scalers/external-push.md
+++ b/content/docs/2.5/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.5/scalers/external.md
+++ b/content/docs/2.5/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.5/scalers/gcp-pub-sub.md
+++ b/content/docs/2.5/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform Pub/Sub."
@@ -32,7 +31,7 @@ The Google Cloud Platform (GCP) Pub/Sub trigger allows you to scale based on the
 - Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`.
 
 You can use either `subscriptionSize` to define the target average which the deployment will be scaled on or `mode` and `value` fields. `subscriptionSize` field is deprecated, it is recommended to use `mode` and `value` fields instead. Scaler will not work if you define both `subscriptionSize` and at least one of `mode` or `value`.
-The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`. 
+The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`.
 The `value` determines the target average which the deployment will be scaled on. The default value is 5 for `SubscriptionSize` and 10 for `OldestUnackedMessageAge`.
 
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
@@ -91,7 +90,7 @@ metadata:
   name: gcp-pubsub-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret  # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ---

--- a/content/docs/2.5/scalers/graphite.md
+++ b/content/docs/2.5/scalers/graphite.md
@@ -1,6 +1,5 @@
 +++
 title = "Graphite"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on metrics in Graphite."

--- a/content/docs/2.5/scalers/huawei-cloudeye.md
+++ b/content/docs/2.5/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.5/scalers/ibm-mq.md
+++ b/content/docs/2.5/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.5/scalers/influxdb.md
+++ b/content/docs/2.5/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.5/scalers/kubernetes-workload.md
+++ b/content/docs/2.5/scalers/kubernetes-workload.md
@@ -1,6 +1,5 @@
 +++
 title = "Kubernetes Workload"
-layout = "scaler"
 availability = "v2.4+"
 maintainer = "Community"
 description = "Scale applications based on the amount of pods which matches the given selectors."

--- a/content/docs/2.5/scalers/liiklus-topic.md
+++ b/content/docs/2.5/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.5/scalers/memory.md
+++ b/content/docs/2.5/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.5/scalers/metrics-api.md
+++ b/content/docs/2.5/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -84,7 +83,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -112,7 +111,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -158,7 +157,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  token: "PlaceYourTokenHere" 
+  token: "PlaceYourTokenHere"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -169,7 +168,7 @@ spec:
   secretTargetRef:
     - parameter: token
       name: keda-metric-api-secret
-      key: token    
+      key: token
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -202,7 +201,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -251,7 +250,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.5/scalers/mongodb.md
+++ b/content/docs/2.5/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -85,7 +84,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.5/scalers/mssql.md
+++ b/content/docs/2.5/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.5/scalers/mysql.md
+++ b/content/docs/2.5/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.5/scalers/nats-streaming.md
+++ b/content/docs/2.5/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -92,7 +91,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.5/scalers/openstack-metric.md
+++ b/content/docs/2.5/scalers/openstack-metric.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Metric"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on a threshold reached by a specific measure from OpenStack Metric API."
@@ -28,7 +27,7 @@ triggers:
 > Protocol (http or https) should always be provided when specifying URLs
 
 **Parameter list:**
-- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`. 
+- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`.
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
@@ -105,19 +104,19 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-      metricsURL: http://localhost:8041/v1/metric 
+      metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
-      threshold: 1250 
-      timeout: 30 
+      granularity: 300
+      threshold: 1250
+      timeout: 30
     authenticationRef:
         name: openstack-metric-password-trigger-authentication
 ```
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1
@@ -162,10 +161,10 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-       metricsURL: http://localhost:8041/v1/metric 
+       metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
+      granularity: 300
       threshold: 1250
     authenticationRef:
         name: openstack-metric-appcredentials-trigger-authentication

--- a/content/docs/2.5/scalers/openstack-swift.md
+++ b/content/docs/2.5/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     swiftURL: http://localhost:8080/v1/b161dc815cd24bda84d94d9a0e73cf78  # Optional
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -125,7 +124,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.5/scalers/postgresql.md
+++ b/content/docs/2.5/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.5/scalers/prometheus.md
+++ b/content/docs/2.5/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."
@@ -31,7 +30,7 @@ triggers:
 
 ### Authentication Parameters
 
-Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication. 
+Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. It is possible to specify multiple authentication types i.e. `authModes: "tls,basic"` Specify `authModes` and other trigger parameters along with secret credentials in `TriggerAuthentication` as mentioned below:
 
@@ -82,7 +81,7 @@ metadata:
   namespace: default
 data:
   bearerToken: "BEARER_TOKEN"
-  ca: "CUSTOM_CA_CERT" 
+  ca: "CUSTOM_CA_CERT"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -181,7 +180,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---
@@ -234,10 +233,10 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.5/scalers/rabbitmq-queue.md
+++ b/content/docs/2.5/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.5/scalers/redis-cluster-lists.md
+++ b/content/docs/2.5/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.5/scalers/redis-cluster-streams.md
+++ b/content/docs/2.5/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.5/scalers/redis-lists.md
+++ b/content/docs/2.5/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.5/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.5/scalers/redis-sentinel-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Sentinel topology"

--- a/content/docs/2.5/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.5/scalers/redis-sentinel-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Sentinel topology"

--- a/content/docs/2.5/scalers/redis-streams.md
+++ b/content/docs/2.5/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.5/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.5/scalers/selenium-grid-scaler.md
@@ -3,7 +3,6 @@ title = "Selenium Grid Scaler"
 availability = "v2.4+"
 maintainer = "Volvo Cars"
 description = "Scales Selenium browser nodes based on number of requests waiting in session queue"
-layout = "scaler"
 go_file = "selenium_grid_scaler"
 +++
 

--- a/content/docs/2.5/scalers/solace-pub-sub.md
+++ b/content/docs/2.5/scalers/solace-pub-sub.md
@@ -3,7 +3,6 @@ title = "Solace PubSub+ Event Broker"
 availability = "2.4+"
 maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
-layout = "scaler"
 go_file = "solace_scaler"
 aliases = ["solace"]
 +++

--- a/content/docs/2.6/scalers/activemq.md
+++ b/content/docs/2.6/scalers/activemq.md
@@ -3,7 +3,6 @@ title = "ActiveMQ"
 availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Queue."
-layout = "scaler"
 go_file = "activemq_scaler"
 +++
 
@@ -27,12 +26,12 @@ triggers:
 - `destinationName` - Name of the queue to check for the message count.
 - `brokerName` - Name of the broker as defined in ActiveMQ.
 - `targetQueueSize` - Target value for queue length passed to the scaler. The scaler will cause the replicas to increase if the queue message count is greater than the target value per active replica. (Default: `10`, Optional)
-- `restAPITemplate` - Template to build REST API url to get queue size. (Default: `"http://{{.ManagementEndpoint}}/api/jolokia/read/org.apache.activemq:type=Broker,brokerName={{.BrokerName}},destinationType=Queue,destinationName={{.DestinationName}}/QueueSize"`, Optional) 
+- `restAPITemplate` - Template to build REST API url to get queue size. (Default: `"http://{{.ManagementEndpoint}}/api/jolokia/read/org.apache.activemq:type=Broker,brokerName={{.BrokerName}},destinationType=Queue,destinationName={{.DestinationName}}/QueueSize"`, Optional)
 
 **Parameter Requirements:**
 
 - In case of `restAPITemplate` parameter is not used, parameters resolving the REST API Template are all **required**: `managementEndpoint`, `destinationName`, `brokerName`.
-- ActiveMQ Scaler polls the ActiveMQ REST API to monitor message count of target queue. Currently, the scaler supports basic authentication. `username` and `password` are **required**. See [Authentication Parameters](#authentication-parameters) below. 
+- ActiveMQ Scaler polls the ActiveMQ REST API to monitor message count of target queue. Currently, the scaler supports basic authentication. `username` and `password` are **required**. See [Authentication Parameters](#authentication-parameters) below.
 
 ### Authentication Parameters
 

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -1,6 +1,5 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."

--- a/content/docs/2.6/scalers/artemis.md
+++ b/content/docs/2.6/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"
@@ -34,7 +33,7 @@ triggers:
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
 - `corsHeader` - Value to populate the Origin header field for CORS filtering. (Default: `"http://<<managmentEndpoint>>"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.6/scalers/aws-cloudwatch.md
+++ b/content/docs/2.6/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."
@@ -40,7 +39,7 @@ triggers:
     # Optional: Metric Unit
     metricUnit: "Count" # default ""
     # Optional: Metric EndTime Offset
-    metricEndTimeOffset: "60" # default 0    
+    metricEndTimeOffset: "60" # default 0
 ```
 
 **Parameter list:**

--- a/content/docs/2.6/scalers/aws-kinesis.md
+++ b/content/docs/2.6/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
 
@@ -65,7 +64,7 @@ data:
   AWS_ACCESS_KEY_ID: <encoded-user-id> # Required.
   AWS_SECRET_ACCESS_KEY: <encoded-key> # Required.
   AWS_SESSION_TOKEN: <encoded-session-token> # Required when using temporary credentials.
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.6/scalers/aws-sqs.md
+++ b/content/docs/2.6/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.6/scalers/azure-app-insights.md
+++ b/content/docs/2.6/scalers/azure-app-insights.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Application Insights"
-layout = "scaler"
 availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on Azure Application Insights metrics."

--- a/content/docs/2.6/scalers/azure-event-hub.md
+++ b/content/docs/2.6/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.6/scalers/azure-log-analytics.md
+++ b/content/docs/2.6/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -103,7 +102,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -122,7 +121,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -207,7 +206,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -265,7 +264,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.6/scalers/azure-monitor.md
+++ b/content/docs/2.6/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.6/scalers/azure-pipelines.md
+++ b/content/docs/2.6/scalers/azure-pipelines.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Pipelines"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on agent pool queues for Azure Pipelines."
@@ -51,7 +50,7 @@ As an alternative to using environment variables, you can authenticate with Azur
 
 ### How to determine your pool ID
 
-There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`. 
+There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`.
 
 It is also possible to get the pool ID using the UI by browsing to the agent pool from the organization (Organization settings -> Agent pools -> `{agentPoolName}`) and getting it from the URL.
 The URL should be similar to `https://dev.azure.com/{organization}/_settings/agentpools?poolId={poolID}&view=jobs`
@@ -91,7 +90,7 @@ spec:
   scaleTargetRef:
     name: azdevops-deployment
   minReplicaCount: 1
-  maxReplicaCount: 5 
+  maxReplicaCount: 5
   triggers:
   - type: azure-pipelines
     metadata:

--- a/content/docs/2.6/scalers/azure-service-bus.md
+++ b/content/docs/2.6/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.6/scalers/azure-storage-blob.md
+++ b/content/docs/2.6/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.6/scalers/azure-storage-queue.md
+++ b/content/docs/2.6/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.6/scalers/cassandra.md
+++ b/content/docs/2.6/scalers/cassandra.md
@@ -3,7 +3,6 @@ title = "Cassandra"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on Cassandra query results."
-layout = "scaler"
 go_file = "cassandra_scaler"
 +++
 
@@ -86,5 +85,5 @@ spec:
       targetQueryValue: "1"
       metricName: "test_keyspace"
     authenticationRef:
-      name: keda-trigger-auth-cassandra-secret      
+      name: keda-trigger-auth-cassandra-secret
 ```

--- a/content/docs/2.6/scalers/cpu.md
+++ b/content/docs/2.6/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.6/scalers/cron.md
+++ b/content/docs/2.6/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.6/scalers/datadog.md
+++ b/content/docs/2.6/scalers/datadog.md
@@ -1,6 +1,5 @@
 +++
 title = "Datadog"
-layout = "scaler"
 availability = "v2.6+"
 maintainer = "Datadog"
 description = "Scale applications based on Datadog."
@@ -32,7 +31,7 @@ triggers:
 - `query` - The Datadog query to run.
 - `queryValue` - Value to reach to start scaling.
 - `type` - Whether to start scaling based on the value or the average between pods. (Values: `average`, `global`, Default:`average`, Optional)
-- `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional) 
+- `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional)
 
 ### Authentication
 

--- a/content/docs/2.6/scalers/elasticsearch.md
+++ b/content/docs/2.6/scalers/elasticsearch.md
@@ -3,7 +3,6 @@ title = "Elasticsearch"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on elasticsearch search template query result."
-layout = "scaler"
 go_file = "elasticsearch_scaler"
 +++
 
@@ -90,4 +89,4 @@ spec:
         params: "dummy_value:1"
       authenticationRef:
         name: keda-trigger-auth-elasticsearch-secret
-``` 
+```

--- a/content/docs/2.6/scalers/external-push.md
+++ b/content/docs/2.6/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.6/scalers/external.md
+++ b/content/docs/2.6/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.6/scalers/gcp-pub-sub.md
+++ b/content/docs/2.6/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform Pub/Sub."
@@ -32,7 +31,7 @@ The Google Cloud Platform (GCP) Pub/Sub trigger allows you to scale based on the
 - Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`.
 
 You can use either `subscriptionSize` to define the target average which the deployment will be scaled on or `mode` and `value` fields. `subscriptionSize` field is deprecated, it is recommended to use `mode` and `value` fields instead. Scaler will not work if you define both `subscriptionSize` and at least one of `mode` or `value`.
-The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`. 
+The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`.
 The `value` determines the target average which the deployment will be scaled on. The default value is 5 for `SubscriptionSize` and 10 for `OldestUnackedMessageAge`.
 
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
@@ -91,7 +90,7 @@ metadata:
   name: gcp-pubsub-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret  # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ---

--- a/content/docs/2.6/scalers/graphite.md
+++ b/content/docs/2.6/scalers/graphite.md
@@ -1,6 +1,5 @@
 +++
 title = "Graphite"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on metrics in Graphite."

--- a/content/docs/2.6/scalers/huawei-cloudeye.md
+++ b/content/docs/2.6/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.6/scalers/ibm-mq.md
+++ b/content/docs/2.6/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.6/scalers/influxdb.md
+++ b/content/docs/2.6/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.6/scalers/kubernetes-workload.md
+++ b/content/docs/2.6/scalers/kubernetes-workload.md
@@ -1,6 +1,5 @@
 +++
 title = "Kubernetes Workload"
-layout = "scaler"
 availability = "v2.4+"
 maintainer = "Community"
 description = "Scale applications based on the count of running pods that match the given selectors."

--- a/content/docs/2.6/scalers/liiklus-topic.md
+++ b/content/docs/2.6/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.6/scalers/memory.md
+++ b/content/docs/2.6/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.6/scalers/metrics-api.md
+++ b/content/docs/2.6/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -84,7 +83,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -112,7 +111,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -158,7 +157,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  token: "PlaceYourTokenHere" 
+  token: "PlaceYourTokenHere"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -169,7 +168,7 @@ spec:
   secretTargetRef:
     - parameter: token
       name: keda-metric-api-secret
-      key: token    
+      key: token
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -202,7 +201,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -251,7 +250,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.6/scalers/mongodb.md
+++ b/content/docs/2.6/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -85,7 +84,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.6/scalers/mssql.md
+++ b/content/docs/2.6/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.6/scalers/mysql.md
+++ b/content/docs/2.6/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.6/scalers/nats-streaming.md
+++ b/content/docs/2.6/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -92,7 +91,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.6/scalers/new-relic.md
+++ b/content/docs/2.6/scalers/new-relic.md
@@ -3,7 +3,6 @@ title = "New Relic"
 availability = "2.6+"
 maintainer = "Community"
 description = "Scale applications based on New Relic NRQL"
-layout = "scaler"
 go_file = "newrelic_scaler"
 +++
 

--- a/content/docs/2.6/scalers/openstack-metric.md
+++ b/content/docs/2.6/scalers/openstack-metric.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Metric"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on a threshold reached by a specific measure from OpenStack Metric API."
@@ -28,7 +27,7 @@ triggers:
 > Protocol (http or https) should always be provided when specifying URLs
 
 **Parameter list:**
-- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`. 
+- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`.
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
@@ -105,19 +104,19 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-      metricsURL: http://localhost:8041/v1/metric 
+      metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
-      threshold: 1250 
-      timeout: 30 
+      granularity: 300
+      threshold: 1250
+      timeout: 30
     authenticationRef:
         name: openstack-metric-password-trigger-authentication
 ```
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1
@@ -162,10 +161,10 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-       metricsURL: http://localhost:8041/v1/metric 
+       metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
+      granularity: 300
       threshold: 1250
     authenticationRef:
         name: openstack-metric-appcredentials-trigger-authentication

--- a/content/docs/2.6/scalers/openstack-swift.md
+++ b/content/docs/2.6/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     swiftURL: http://localhost:8080/v1/b161dc815cd24bda84d94d9a0e73cf78  # Optional
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -125,7 +124,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.6/scalers/postgresql.md
+++ b/content/docs/2.6/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.6/scalers/predictkube.md
+++ b/content/docs/2.6/scalers/predictkube.md
@@ -3,7 +3,6 @@ title = "Predictkube"
 availability = "v2.6+"
 maintainer = "Dysnix"
 description = "AI-based predictive scaling based on Prometheus metrics & PredictKube SaaS."
-layout = "scaler"
 go_file = "predictkube_scaler"
 +++
 

--- a/content/docs/2.6/scalers/prometheus.md
+++ b/content/docs/2.6/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."
@@ -34,7 +33,7 @@ triggers:
 
 ### Authentication Parameters
 
-Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication. 
+Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. It is possible to specify multiple authentication types i.e. `authModes: "tls,basic"` Specify `authModes` and other trigger parameters along with secret credentials in `TriggerAuthentication` as mentioned below:
 
@@ -85,7 +84,7 @@ metadata:
   namespace: default
 data:
   bearerToken: "BEARER_TOKEN"
-  ca: "CUSTOM_CA_CERT" 
+  ca: "CUSTOM_CA_CERT"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -184,7 +183,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---
@@ -237,10 +236,10 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.6/scalers/rabbitmq-queue.md
+++ b/content/docs/2.6/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.6/scalers/redis-cluster-lists.md
+++ b/content/docs/2.6/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.6/scalers/redis-cluster-streams.md
+++ b/content/docs/2.6/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.6/scalers/redis-lists.md
+++ b/content/docs/2.6/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.6/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.6/scalers/redis-sentinel-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Sentinel topology"

--- a/content/docs/2.6/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.6/scalers/redis-sentinel-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Sentinel topology"

--- a/content/docs/2.6/scalers/redis-streams.md
+++ b/content/docs/2.6/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.6/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.6/scalers/selenium-grid-scaler.md
@@ -3,7 +3,6 @@ title = "Selenium Grid Scaler"
 availability = "v2.4+"
 maintainer = "Volvo Cars"
 description = "Scales Selenium browser nodes based on number of requests waiting in session queue"
-layout = "scaler"
 go_file = "selenium_grid_scaler"
 +++
 

--- a/content/docs/2.6/scalers/solace-pub-sub.md
+++ b/content/docs/2.6/scalers/solace-pub-sub.md
@@ -3,7 +3,6 @@ title = "Solace PubSub+ Event Broker"
 availability = "2.4+"
 maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
-layout = "scaler"
 go_file = "solace_scaler"
 aliases = ["solace"]
 +++

--- a/content/docs/2.7/scalers/activemq.md
+++ b/content/docs/2.7/scalers/activemq.md
@@ -3,7 +3,6 @@ title = "ActiveMQ"
 availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Queue."
-layout = "scaler"
 go_file = "activemq_scaler"
 +++
 
@@ -33,7 +32,7 @@ triggers:
 **Parameter Requirements:**
 
 - In case of `restAPITemplate` parameter is not used, parameters resolving the REST API Template are all **required**: `managementEndpoint`, `destinationName`, `brokerName`.
-- ActiveMQ Scaler polls the ActiveMQ REST API to monitor message count of target queue. Currently, the scaler supports basic authentication. `username` and `password` are **required**. See [Authentication Parameters](#authentication-parameters) below. 
+- ActiveMQ Scaler polls the ActiveMQ REST API to monitor message count of target queue. Currently, the scaler supports basic authentication. `username` and `password` are **required**. See [Authentication Parameters](#authentication-parameters) below.
 
 ### Authentication Parameters
 

--- a/content/docs/2.7/scalers/apache-kafka.md
+++ b/content/docs/2.7/scalers/apache-kafka.md
@@ -1,6 +1,5 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."

--- a/content/docs/2.7/scalers/artemis.md
+++ b/content/docs/2.7/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,11 +14,11 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
-    queueLength: '10' 
+    queueLength: '10'
     username: 'ARTEMIS_USERNAME'
     password: 'ARTEMIS_PASSWORD'
     restApiTemplate: # Optional. Default : "http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"
@@ -34,7 +33,7 @@ triggers:
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (default: 10)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
 - `corsHeader` - Value to populate the Origin header field for CORS filtering. (Default: `"http://<<managmentEndpoint>>"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.7/scalers/aws-cloudwatch.md
+++ b/content/docs/2.7/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."
@@ -42,7 +41,7 @@ triggers:
     # Optional: Metric Unit
     metricUnit: "Count" # default ""
     # Optional: Metric EndTime Offset
-    metricEndTimeOffset: "60" # default 0    
+    metricEndTimeOffset: "60" # default 0
 ```
 
 **Parameter list:**

--- a/content/docs/2.7/scalers/aws-dynamodb.md
+++ b/content/docs/2.7/scalers/aws-dynamodb.md
@@ -3,7 +3,6 @@ title = "AWS DynamoDB"
 availability = "v2.7+"
 maintainer = "Community"
 description = "Scale applications based on the records count in AWS DynamoDB"
-layout = "scaler"
 go_file = "aws_dynamodb_scaler"
 +++
 
@@ -28,7 +27,7 @@ triggers:
     # Required: expressionAttributeValues
     expressionAttributeValues: '{ ":key" : {"S":"partition_key_target_value"}}'
     # Optional. Default: pod
-    identityOwner: pod | operator 
+    identityOwner: pod | operator
 ```
 
 **Parameter list:**

--- a/content/docs/2.7/scalers/aws-kinesis.md
+++ b/content/docs/2.7/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -35,7 +34,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
 
@@ -65,7 +64,7 @@ data:
   AWS_ACCESS_KEY_ID: <encoded-user-id> # Required.
   AWS_SECRET_ACCESS_KEY: <encoded-key> # Required.
   AWS_SESSION_TOKEN: <encoded-session-token> # Required when using temporary credentials.
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.7/scalers/aws-sqs.md
+++ b/content/docs/2.7/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.7/scalers/azure-app-insights.md
+++ b/content/docs/2.7/scalers/azure-app-insights.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Application Insights"
-layout = "scaler"
 availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on Azure Application Insights metrics."

--- a/content/docs/2.7/scalers/azure-data-explorer.md
+++ b/content/docs/2.7/scalers/azure-data-explorer.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Data Explorer"
-layout = "scaler"
 availability = "v2.7+"
 maintainer = "Community"
 description = "Scale applications based on Azure Data Explorer query result."

--- a/content/docs/2.7/scalers/azure-event-hub.md
+++ b/content/docs/2.7/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.7/scalers/azure-log-analytics.md
+++ b/content/docs/2.7/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -112,7 +111,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -131,7 +130,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -216,7 +215,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -274,7 +273,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.7/scalers/azure-monitor.md
+++ b/content/docs/2.7/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.7/scalers/azure-pipelines.md
+++ b/content/docs/2.7/scalers/azure-pipelines.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Pipelines"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on agent pool queues for Azure Pipelines."
@@ -51,7 +50,7 @@ As an alternative to using environment variables, you can authenticate with Azur
 
 ### How to determine your pool ID
 
-There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`. 
+There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`.
 
 It is also possible to get the pool ID using the UI by browsing to the agent pool from the organization (Organization settings -> Agent pools -> `{agentPoolName}`) and getting it from the URL.
 The URL should be similar to `https://dev.azure.com/{organization}/_settings/agentpools?poolId={poolID}&view=jobs`
@@ -91,7 +90,7 @@ spec:
   scaleTargetRef:
     name: azdevops-deployment
   minReplicaCount: 1
-  maxReplicaCount: 5 
+  maxReplicaCount: 5
   triggers:
   - type: azure-pipelines
     metadata:

--- a/content/docs/2.7/scalers/azure-service-bus.md
+++ b/content/docs/2.7/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.7/scalers/azure-storage-blob.md
+++ b/content/docs/2.7/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.7/scalers/azure-storage-queue.md
+++ b/content/docs/2.7/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.7/scalers/cassandra.md
+++ b/content/docs/2.7/scalers/cassandra.md
@@ -3,7 +3,6 @@ title = "Cassandra"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on Cassandra query results."
-layout = "scaler"
 go_file = "cassandra_scaler"
 +++
 
@@ -86,5 +85,5 @@ spec:
       targetQueryValue: "1"
       metricName: "test_keyspace"
     authenticationRef:
-      name: keda-trigger-auth-cassandra-secret      
+      name: keda-trigger-auth-cassandra-secret
 ```

--- a/content/docs/2.7/scalers/cpu.md
+++ b/content/docs/2.7/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.7/scalers/cron.md
+++ b/content/docs/2.7/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.7/scalers/datadog.md
+++ b/content/docs/2.7/scalers/datadog.md
@@ -1,6 +1,5 @@
 +++
 title = "Datadog"
-layout = "scaler"
 availability = "v2.6+"
 maintainer = "Datadog"
 description = "Scale applications based on Datadog."
@@ -34,7 +33,7 @@ triggers:
 - `query` - The Datadog query to run.
 - `queryValue` - Value to reach to start scaling.
 - `type` - Whether to start scaling based on the value or the average between pods. (Values: `average`, `global`, Default:`average`, Optional)
-- `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional) 
+- `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional)
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.

--- a/content/docs/2.7/scalers/elasticsearch.md
+++ b/content/docs/2.7/scalers/elasticsearch.md
@@ -3,7 +3,6 @@ title = "Elasticsearch"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on elasticsearch search template query result."
-layout = "scaler"
 go_file = "elasticsearch_scaler"
 +++
 
@@ -90,4 +89,4 @@ spec:
         params: "dummy_value:1"
       authenticationRef:
         name: keda-trigger-auth-elasticsearch-secret
-``` 
+```

--- a/content/docs/2.7/scalers/external-push.md
+++ b/content/docs/2.7/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.7/scalers/external.md
+++ b/content/docs/2.7/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.7/scalers/gcp-pub-sub.md
+++ b/content/docs/2.7/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -22,30 +21,30 @@ triggers:
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```
 
-The Google Cloud Platform‎ (GCP) Pub/Sub trigger allows you to scale based on the number of messages or oldest unacked message age in your Pub/Sub subscription. 
+The Google Cloud Platform‎ (GCP) Pub/Sub trigger allows you to scale based on the number of messages or oldest unacked message age in your Pub/Sub subscription.
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the required stack driver metrics in order to read the number of messages in the Pub/Sub subscription.
 
 `subscriptionName` defines the subscription that should be monitored. You can use different formulas:
 
 - Just the subscription name, in which case you will reference a subscription from the current project or the one specified in the credentials file used.
-- Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`. 
+- Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`.
 
 You can use either `subscriptionSize` to define the target average which the deployment will be scaled on or `mode` and `value` fields. `subscriptionSize` field is deprecated, it is recommended to use `mode` and `value` fields instead. Scaler will not work if you define both `subscriptionSize` and at least one of `mode` or `value`.
-The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`. 
+The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`.
 The `value` determines the target average which the deployment will be scaled on. The default value is 5 for `SubscriptionSize` and 10 for `OldestUnackedMessageAge`.
 
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -74,7 +73,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -90,7 +89,7 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```
 
 **Identity based authentication:**

--- a/content/docs/2.7/scalers/gcp-stackdriver.md
+++ b/content/docs/2.7/scalers/gcp-stackdriver.md
@@ -3,7 +3,6 @@ title = "Google Cloud Platform Stackdriver"
 availability = "2.7+"
 maintainer = "Community"
 description = "Scale applications based on a metric obtained from Stackdriver."
-layout = "scaler"
 go_file = "gcp_stackdriver_scaler"
 +++
 
@@ -44,7 +43,7 @@ Valid values for the `alignmentReducer` property are: none, mean, min, max, sum,
 For more information on aggregation, see [here](https://cloud.google.com/monitoring/api/v3/aggregation#aggr-intro).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 **Credential based authentication:**
 
@@ -83,7 +82,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: gcp-stackdriver-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---

--- a/content/docs/2.7/scalers/gcp-storage.md
+++ b/content/docs/2.7/scalers/gcp-storage.md
@@ -3,7 +3,6 @@ title = "Google Cloud Platform Storage"
 availability = "2.7+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given Google Cloud Storage (GCS) bucket."
-layout = "scaler"
 go_file = "gcp_storage_scaler"
 +++
 
@@ -29,14 +28,14 @@ triggers:
 - `maxBucketItemsToScan` - When to stop counting how many objects are in the bucket. (Default: `1000`, Optional)
 As counting the number of objects involves iterating over their metadata it is advised to set this number to the value of `targetObjectCount` * `maxReplicaCount`.
 
-The metric name will be generated automatically based on the trigger index and `bucketName`, for example: **s0-gcp-storage-bucketName**. 
+The metric name will be generated automatically based on the trigger index and `bucketName`, for example: **s0-gcp-storage-bucketName**.
 
 You can provide in the metadata either `credentialsFromEnv` or `credentialsFromEnvFile`.
 - `credentialsFromEnv` - Set to the name of the environment variable that holds the credential information.
 - `credentialsFromEnvFile` - Set to the name of a json file that holds the credential information.
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 **Credential based authentication:**
 
@@ -74,7 +73,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: gcp-storage-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---

--- a/content/docs/2.7/scalers/graphite.md
+++ b/content/docs/2.7/scalers/graphite.md
@@ -1,6 +1,5 @@
 +++
 title = "Graphite"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on metrics in Graphite."

--- a/content/docs/2.7/scalers/huawei-cloudeye.md
+++ b/content/docs/2.7/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -58,7 +57,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -68,7 +67,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.7/scalers/ibm-mq.md
+++ b/content/docs/2.7/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -78,7 +77,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.7/scalers/influxdb.md
+++ b/content/docs/2.7/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.7/scalers/kubernetes-workload.md
+++ b/content/docs/2.7/scalers/kubernetes-workload.md
@@ -1,6 +1,5 @@
 +++
 title = "Kubernetes Workload"
-layout = "scaler"
 availability = "v2.4+"
 maintainer = "Community"
 description = "Scale applications based on the count of running pods that match the given selectors."

--- a/content/docs/2.7/scalers/liiklus-topic.md
+++ b/content/docs/2.7/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.7/scalers/memory.md
+++ b/content/docs/2.7/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.7/scalers/metrics-api.md
+++ b/content/docs/2.7/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -32,8 +31,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -84,7 +83,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -112,7 +111,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -158,7 +157,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  token: "PlaceYourTokenHere" 
+  token: "PlaceYourTokenHere"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -169,7 +168,7 @@ spec:
   secretTargetRef:
     - parameter: token
       name: keda-metric-api-secret
-      key: token    
+      key: token
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -202,7 +201,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -251,7 +250,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.7/scalers/mongodb.md
+++ b/content/docs/2.7/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -85,7 +84,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.7/scalers/mssql.md
+++ b/content/docs/2.7/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.7/scalers/mysql.md
+++ b/content/docs/2.7/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.7/scalers/nats-streaming.md
+++ b/content/docs/2.7/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -92,7 +91,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.7/scalers/new-relic.md
+++ b/content/docs/2.7/scalers/new-relic.md
@@ -3,7 +3,6 @@ title = "New Relic"
 availability = "2.6+"
 maintainer = "Community"
 description = "Scale applications based on New Relic NRQL"
-layout = "scaler"
 go_file = "newrelic_scaler"
 +++
 

--- a/content/docs/2.7/scalers/openstack-metric.md
+++ b/content/docs/2.7/scalers/openstack-metric.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Metric"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on a threshold reached by a specific measure from OpenStack Metric API."
@@ -28,7 +27,7 @@ triggers:
 > Protocol (http or https) should always be provided when specifying URLs
 
 **Parameter list:**
-- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`. 
+- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`.
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
@@ -105,19 +104,19 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-      metricsURL: http://localhost:8041/v1/metric 
+      metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
-      threshold: 1250 
-      timeout: 30 
+      granularity: 300
+      threshold: 1250
+      timeout: 30
     authenticationRef:
         name: openstack-metric-password-trigger-authentication
 ```
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1
@@ -162,10 +161,10 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-       metricsURL: http://localhost:8041/v1/metric 
+       metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
+      granularity: 300
       threshold: 1250
     authenticationRef:
         name: openstack-metric-appcredentials-trigger-authentication

--- a/content/docs/2.7/scalers/openstack-swift.md
+++ b/content/docs/2.7/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -19,7 +18,7 @@ triggers:
     swiftURL: http://localhost:8080/v1/b161dc815cd24bda84d94d9a0e73cf78  # Optional
     objectCount: "2"  # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -125,7 +124,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.7/scalers/postgresql.md
+++ b/content/docs/2.7/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.7/scalers/predictkube.md
+++ b/content/docs/2.7/scalers/predictkube.md
@@ -3,7 +3,6 @@ title = "Predictkube"
 availability = "v2.6+"
 maintainer = "Dysnix"
 description = "AI-based predictive scaling based on Prometheus metrics & PredictKube SaaS."
-layout = "scaler"
 go_file = "predictkube_scaler"
 +++
 

--- a/content/docs/2.7/scalers/prometheus.md
+++ b/content/docs/2.7/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."
@@ -36,7 +35,7 @@ triggers:
 
 ### Authentication Parameters
 
-Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication. 
+Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. It is possible to specify multiple authentication types i.e. `authModes: "tls,basic"` Specify `authModes` and other trigger parameters along with secret credentials in `TriggerAuthentication` as mentioned below:
 
@@ -87,7 +86,7 @@ metadata:
   namespace: default
 data:
   bearerToken: "BEARER_TOKEN"
-  ca: "CUSTOM_CA_CERT" 
+  ca: "CUSTOM_CA_CERT"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -186,7 +185,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---
@@ -239,10 +238,10 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.7/scalers/rabbitmq-queue.md
+++ b/content/docs/2.7/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."

--- a/content/docs/2.7/scalers/redis-cluster-lists.md
+++ b/content/docs/2.7/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.7/scalers/redis-cluster-streams.md
+++ b/content/docs/2.7/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.7/scalers/redis-lists.md
+++ b/content/docs/2.7/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.7/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.7/scalers/redis-sentinel-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Sentinel topology"

--- a/content/docs/2.7/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.7/scalers/redis-sentinel-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Sentinel topology"

--- a/content/docs/2.7/scalers/redis-streams.md
+++ b/content/docs/2.7/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.7/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.7/scalers/selenium-grid-scaler.md
@@ -3,7 +3,6 @@ title = "Selenium Grid Scaler"
 availability = "v2.4+"
 maintainer = "Volvo Cars"
 description = "Scales Selenium browser nodes based on number of requests waiting in session queue"
-layout = "scaler"
 go_file = "selenium_grid_scaler"
 +++
 

--- a/content/docs/2.7/scalers/solace-pub-sub.md
+++ b/content/docs/2.7/scalers/solace-pub-sub.md
@@ -3,7 +3,6 @@ title = "Solace PubSub+ Event Broker"
 availability = "2.4+"
 maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
-layout = "scaler"
 go_file = "solace_scaler"
 +++
 

--- a/content/docs/2.8/scalers/activemq.md
+++ b/content/docs/2.8/scalers/activemq.md
@@ -3,7 +3,6 @@ title = "ActiveMQ"
 availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Queue."
-layout = "scaler"
 go_file = "activemq_scaler"
 +++
 
@@ -35,7 +34,7 @@ triggers:
 **Parameter Requirements:**
 
 - In case of `restAPITemplate` parameter is not used, parameters resolving the REST API Template are all **required**: `managementEndpoint`, `destinationName`, `brokerName`.
-- ActiveMQ Scaler polls the ActiveMQ REST API to monitor message count of target queue. Currently, the scaler supports basic authentication. `username` and `password` are **required**. See [Authentication Parameters](#authentication-parameters) below. 
+- ActiveMQ Scaler polls the ActiveMQ REST API to monitor message count of target queue. Currently, the scaler supports basic authentication. `username` and `password` are **required**. See [Authentication Parameters](#authentication-parameters) below.
 
 ### Authentication Parameters
 

--- a/content/docs/2.8/scalers/apache-kafka.md
+++ b/content/docs/2.8/scalers/apache-kafka.md
@@ -1,6 +1,5 @@
 +++
 title = "Apache Kafka"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an Apache Kafka topic or other services that support Kafka protocol."
@@ -83,7 +82,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `ca` - Certificate authority file for TLS client authentication. (Optional)
 - `cert` - Certificate for client authentication. (Optional)
 - `key` - Key for client authentication. (Optional)
-- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)  
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
 
 ### New Consumers and Offset Reset Policy
 

--- a/content/docs/2.8/scalers/artemis.md
+++ b/content/docs/2.8/scalers/artemis.md
@@ -1,6 +1,5 @@
 +++
 title = "ActiveMQ Artemis"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on ActiveMQ Artemis queues"
@@ -15,7 +14,7 @@ This specification describes the `artemis-queue` trigger for ActiveMQ Artemis qu
 triggers:
 - type: artemis-queue
   metadata:
-    managementEndpoint: "artemis-activemq.artemis:8161" 
+    managementEndpoint: "artemis-activemq.artemis:8161"
     queueName: "test"
     brokerName: "artemis-activemq"
     brokerAddress: "test"
@@ -36,7 +35,7 @@ triggers:
 - `activationQueueLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
 - `restApiTemplate` - Template to build REST API url to get queue size. (Default: `"http://<<managementEndpoint>>/console/jolokia/read/org.apache.activemq.artemis:broker=\"<<brokerName>>\",component=addresses,address=\"<<brokerAddress>>\",subcomponent=queues,routing-type=\"anycast\",queue=\"<<queueName>>\"/MessageCount"`, Optional)
 - `corsHeader` - Value to populate the Origin header field for CORS filtering. (Default: `"http://<<managmentEndpoint>>"`, Optional)
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the `username` and `password` to connect to the management endpoint.

--- a/content/docs/2.8/scalers/aws-cloudwatch.md
+++ b/content/docs/2.8/scalers/aws-cloudwatch.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS CloudWatch"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS CloudWatch."
@@ -42,7 +41,7 @@ triggers:
     # Optional: Metric Unit
     metricUnit: "Count" # default ""
     # Optional: Metric EndTime Offset
-    metricEndTimeOffset: "60" # default 0    
+    metricEndTimeOffset: "60" # default 0
 ```
 
 **Parameter list:**

--- a/content/docs/2.8/scalers/aws-dynamodb-streams.md
+++ b/content/docs/2.8/scalers/aws-dynamodb-streams.md
@@ -3,7 +3,6 @@ title = "AWS DynamoDB Streams"
 availability = "v2.8+"
 maintainer = "Community"
 description = "Scale applications based on AWS DynamoDB Streams"
-layout = "scaler"
 go_file = "aws_dynamodb_streams_scaler"
 +++
 
@@ -22,7 +21,7 @@ triggers:
     # Optional targetValue
     shardCount: "2"
     # Optional. Default: pod
-    identityOwner: pod | operator 
+    identityOwner: pod | operator
 ```
 
 **Parameter list:**

--- a/content/docs/2.8/scalers/aws-dynamodb.md
+++ b/content/docs/2.8/scalers/aws-dynamodb.md
@@ -3,7 +3,6 @@ title = "AWS DynamoDB"
 availability = "v2.7+"
 maintainer = "Community"
 description = "Scale applications based on the records count in AWS DynamoDB"
-layout = "scaler"
 go_file = "aws_dynamodb_scaler"
 +++
 
@@ -28,7 +27,7 @@ triggers:
     # Required: expressionAttributeValues
     expressionAttributeValues: '{ ":key" : {"S":"partition_key_target_value"}}'
     # Optional. Default: pod
-    identityOwner: pod | operator 
+    identityOwner: pod | operator
 ```
 
 **Parameter list:**

--- a/content/docs/2.8/scalers/aws-kinesis.md
+++ b/content/docs/2.8/scalers/aws-kinesis.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS Kinesis Stream"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on AWS Kinesis Stream."
@@ -36,7 +35,7 @@ triggers:
 
 ### Authentication Parameters
 
-> These parameters are relevant only when `identityOwner` is set to `pod`. 
+> These parameters are relevant only when `identityOwner` is set to `pod`.
 
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
 
@@ -66,7 +65,7 @@ data:
   AWS_ACCESS_KEY_ID: <encoded-user-id> # Required.
   AWS_SECRET_ACCESS_KEY: <encoded-key> # Required.
   AWS_SESSION_TOKEN: <encoded-session-token> # Required when using temporary credentials.
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.8/scalers/aws-sqs.md
+++ b/content/docs/2.8/scalers/aws-sqs.md
@@ -1,6 +1,5 @@
 +++
 title = "AWS SQS Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on AWS SQS Queue."

--- a/content/docs/2.8/scalers/azure-app-insights.md
+++ b/content/docs/2.8/scalers/azure-app-insights.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Application Insights"
-layout = "scaler"
 availability = "v2.6+"
 maintainer = "Community"
 description = "Scale applications based on Azure Application Insights metrics."

--- a/content/docs/2.8/scalers/azure-data-explorer.md
+++ b/content/docs/2.8/scalers/azure-data-explorer.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Data Explorer"
-layout = "scaler"
 availability = "v2.7+"
 maintainer = "Community"
 description = "Scale applications based on Azure Data Explorer query result."

--- a/content/docs/2.8/scalers/azure-event-hub.md
+++ b/content/docs/2.8/scalers/azure-event-hub.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Event Hubs"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Event Hubs."

--- a/content/docs/2.8/scalers/azure-log-analytics.md
+++ b/content/docs/2.8/scalers/azure-log-analytics.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Log Analytics"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on Azure Log Analytics query result"
@@ -31,7 +30,7 @@ triggers:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -114,7 +113,7 @@ Perf
 | where TimeGenerated > AvgDuration
 | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
 | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-| join (Perf 
+| join (Perf
         | where InstanceName contains AppName
         | where InstanceName contains ClusterName
         | where CounterName == "cpuLimitNanoCores"
@@ -133,7 +132,7 @@ Example result:
 ### Scaler Limitations
 
 - As it was mentioned before, you can define a threshold using query (2d cell of query result will be interpret as threshold). Be aware! Threshold from query result will be set only once, during scaler creation. So, if your query will return different threshold values during runtime, they will not be propagated to Horizontal Pod Autoscaler target.
-  
+
 ### Authentication Parameters
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing a set of Azure Active Directory credentials and resource identifiers.
@@ -218,7 +217,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"
@@ -276,7 +275,7 @@ spec:
         | where TimeGenerated > AvgDuration
         | extend AppName = substring(InstanceName, indexof((InstanceName), "/", 0, -1, 10) + 1)
         | summarize MetricValue=round(avg(CounterValue)) by CounterName, AppName
-        | join (Perf 
+        | join (Perf
                 | where InstanceName contains AppName
                 | where InstanceName contains ClusterName
                 | where CounterName == "cpuLimitNanoCores"

--- a/content/docs/2.8/scalers/azure-monitor.md
+++ b/content/docs/2.8/scalers/azure-monitor.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Monitor"
-layout = "scaler"
 availability = "v1.3+"
 maintainer = "Community"
 description = "Scale applications based on Azure Monitor metrics."

--- a/content/docs/2.8/scalers/azure-pipelines.md
+++ b/content/docs/2.8/scalers/azure-pipelines.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Pipelines"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on agent pool queues for Azure Pipelines."
@@ -53,7 +52,7 @@ As an alternative to using environment variables, you can authenticate with Azur
 
 ### How to determine your pool ID
 
-There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`. 
+There are several ways to get the `poolID`. The easiest could be using `az cli` to get it using the command `az pipelines pool list --pool-name {agentPoolName} --organization {organizationURL} --query [0].id`.
 
 It is also possible to get the pool ID using the UI by browsing to the agent pool from the organization (Organization settings -> Agent pools -> `{agentPoolName}`) and getting it from the URL.
 The URL should be similar to `https://dev.azure.com/{organization}/_settings/agentpools?poolId={poolID}&view=jobs`
@@ -93,7 +92,7 @@ spec:
   scaleTargetRef:
     name: azdevops-deployment
   minReplicaCount: 1
-  maxReplicaCount: 5 
+  maxReplicaCount: 5
   triggers:
   - type: azure-pipelines
     metadata:

--- a/content/docs/2.8/scalers/azure-service-bus.md
+++ b/content/docs/2.8/scalers/azure-service-bus.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Service Bus"
-layout = "scaler"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Service Bus Queues or Topics."
 availability = "v1.0+"

--- a/content/docs/2.8/scalers/azure-storage-blob.md
+++ b/content/docs/2.8/scalers/azure-storage-blob.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Blob Storage"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of blobs in a given Azure Blob Storage container."

--- a/content/docs/2.8/scalers/azure-storage-queue.md
+++ b/content/docs/2.8/scalers/azure-storage-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "Azure Storage Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on Azure Storage Queues."

--- a/content/docs/2.8/scalers/cassandra.md
+++ b/content/docs/2.8/scalers/cassandra.md
@@ -3,7 +3,6 @@ title = "Cassandra"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on Cassandra query results."
-layout = "scaler"
 go_file = "cassandra_scaler"
 +++
 
@@ -88,5 +87,5 @@ spec:
       targetQueryValue: "1"
       metricName: "test_keyspace"
     authenticationRef:
-      name: keda-trigger-auth-cassandra-secret      
+      name: keda-trigger-auth-cassandra-secret
 ```

--- a/content/docs/2.8/scalers/cpu.md
+++ b/content/docs/2.8/scalers/cpu.md
@@ -1,13 +1,12 @@
 +++
 title = "CPU"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on cpu metrics."
 go_file = "cpu_memory_scaler"
 +++
 
-> **Notice:** 
+> **Notice:**
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 

--- a/content/docs/2.8/scalers/cron.md
+++ b/content/docs/2.8/scalers/cron.md
@@ -1,6 +1,5 @@
 +++
 title = "Cron"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on a cron schedule."

--- a/content/docs/2.8/scalers/datadog.md
+++ b/content/docs/2.8/scalers/datadog.md
@@ -1,6 +1,5 @@
 +++
 title = "Datadog"
-layout = "scaler"
 availability = "v2.6+"
 maintainer = "Datadog"
 description = "Scale applications based on Datadog."
@@ -36,7 +35,7 @@ triggers:
 - `queryValue` - Value to reach to start scaling (This value can be a float).
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 - `type` - Whether to start scaling based on the value or the average between pods. (Values: `average`, `global`, Default:`average`, Optional)
-- `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional) 
+- `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional)
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.

--- a/content/docs/2.8/scalers/elasticsearch.md
+++ b/content/docs/2.8/scalers/elasticsearch.md
@@ -3,7 +3,6 @@ title = "Elasticsearch"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on elasticsearch search template query result."
-layout = "scaler"
 go_file = "elasticsearch_scaler"
 +++
 
@@ -92,4 +91,4 @@ spec:
         params: "dummy_value:1"
       authenticationRef:
         name: keda-trigger-auth-elasticsearch-secret
-``` 
+```

--- a/content/docs/2.8/scalers/external-push.md
+++ b/content/docs/2.8/scalers/external-push.md
@@ -1,6 +1,5 @@
 +++
 title = "External Push"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external push scaler."

--- a/content/docs/2.8/scalers/external.md
+++ b/content/docs/2.8/scalers/external.md
@@ -1,6 +1,5 @@
 +++
 title = "External"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on an external scaler."

--- a/content/docs/2.8/scalers/gcp-pub-sub.md
+++ b/content/docs/2.8/scalers/gcp-pub-sub.md
@@ -1,6 +1,5 @@
 +++
 title = "Google Cloud Platform‎ Pub/Sub"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Google Cloud Platform‎ Pub/Sub."
@@ -23,7 +22,7 @@ triggers:
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```
 
-The Google Cloud Platform‎ (GCP) Pub/Sub trigger allows you to scale based on the number of messages or oldest unacked message age in your Pub/Sub subscription. 
+The Google Cloud Platform‎ (GCP) Pub/Sub trigger allows you to scale based on the number of messages or oldest unacked message age in your Pub/Sub subscription.
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the required stack driver metrics in order to read the number of messages in the Pub/Sub subscription.
 
@@ -32,23 +31,23 @@ The `credentialsFromEnv` property maps to the name of an environment variable in
 `subscriptionName` defines the subscription that should be monitored. You can use different formulas:
 
 - Just the subscription name, in which case you will reference a subscription from the current project or the one specified in the credentials file used.
-- Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`. 
+- Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`.
 
 You can use either `subscriptionSize` to define the target average which the deployment will be scaled on or `mode` and `value` fields. `subscriptionSize` field is deprecated, it is recommended to use `mode` and `value` fields instead. Scaler will not work if you define both `subscriptionSize` and at least one of `mode` or `value`.
-The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`. 
+The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`.
 The `value` determines the target average which the deployment will be scaled on. The default value is 5 for `SubscriptionSize` and 10 for `OldestUnackedMessageAge`.
 
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 
 **Credential based authentication:**
 
 - `GoogleApplicationCredentials` - Service account credentials in JSON.
 
-### Example 
+### Example
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -77,7 +76,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: pubsub-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---
@@ -93,7 +92,7 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-gcp-credentials
     metadata:
-      subscriptionName: "input" # Required  
+      subscriptionName: "input" # Required
 ```
 
 **Identity based authentication:**

--- a/content/docs/2.8/scalers/gcp-stackdriver.md
+++ b/content/docs/2.8/scalers/gcp-stackdriver.md
@@ -3,7 +3,6 @@ title = "Google Cloud Platform Stackdriver"
 availability = "2.7+"
 maintainer = "Community"
 description = "Scale applications based on a metric obtained from Stackdriver."
-layout = "scaler"
 go_file = "gcp_stackdriver_scaler"
 +++
 
@@ -32,7 +31,7 @@ triggers:
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the configured stack driver metrics.
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 **Credential based authentication:**
 
@@ -71,7 +70,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: gcp-stackdriver-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---

--- a/content/docs/2.8/scalers/gcp-storage.md
+++ b/content/docs/2.8/scalers/gcp-storage.md
@@ -3,7 +3,6 @@ title = "Google Cloud Platform Storage"
 availability = "2.7+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given Google Cloud Storage (GCS) bucket."
-layout = "scaler"
 go_file = "gcp_storage_scaler"
 +++
 
@@ -31,14 +30,14 @@ triggers:
 - `maxBucketItemsToScan` - When to stop counting how many objects are in the bucket. (Default: `1000`, Optional)
 As counting the number of objects involves iterating over their metadata it is advised to set this number to the value of `targetObjectCount` * `maxReplicaCount`.
 
-The metric name will be generated automatically based on the trigger index and `bucketName`, for example: **s0-gcp-storage-bucketName**. 
+The metric name will be generated automatically based on the trigger index and `bucketName`, for example: **s0-gcp-storage-bucketName**.
 
 You can provide in the metadata either `credentialsFromEnv` or `credentialsFromEnvFile`.
 - `credentialsFromEnv` - Set to the name of the environment variable that holds the credential information.
 - `credentialsFromEnvFile` - Set to the name of a json file that holds the credential information.
 
 ### Authentication Parameters
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON. 
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.
 
 **Credential based authentication:**
 
@@ -76,7 +75,7 @@ metadata:
   name: keda-trigger-auth-gcp-credentials
 spec:
   secretTargetRef:
-  - parameter: GoogleApplicationCredentials 
+  - parameter: GoogleApplicationCredentials
     name: gcp-storage-secret        # Required. Refers to the name of the secret
     key: GOOGLE_APPLICATION_CREDENTIALS_JSON       # Required.
 ---

--- a/content/docs/2.8/scalers/graphite.md
+++ b/content/docs/2.8/scalers/graphite.md
@@ -1,6 +1,5 @@
 +++
 title = "Graphite"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Scale applications based on metrics in Graphite."

--- a/content/docs/2.8/scalers/huawei-cloudeye.md
+++ b/content/docs/2.8/scalers/huawei-cloudeye.md
@@ -1,6 +1,5 @@
 +++
 title = "Huawei Cloudeye"
-layout = "scaler"
 availability = "v1.1+"
 maintainer = "Community"
 description = "Scale applications based on a Huawei Cloudeye."
@@ -60,7 +59,7 @@ The user will need access to read data from Huawei Cloudeye.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keda-huawei-secrets 
+  name: keda-huawei-secrets
   namespace: keda-test
 data:
   IdentityEndpoint: <IdentityEndpoint>
@@ -70,7 +69,7 @@ data:
   Domain: <Domain>
   AccessKey: <AccessKey>
   SecretKey: <SecretKey>
---- 
+---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/content/docs/2.8/scalers/ibm-mq.md
+++ b/content/docs/2.8/scalers/ibm-mq.md
@@ -1,6 +1,5 @@
 +++
 title = "IBM MQ"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on IBM MQ Queue"
@@ -80,7 +79,7 @@ spec:
         tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
         queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
         usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret 
+        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---

--- a/content/docs/2.8/scalers/influxdb.md
+++ b/content/docs/2.8/scalers/influxdb.md
@@ -1,6 +1,5 @@
 +++
 title = "InfluxDB"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on InfluxDB queries"
@@ -30,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server. 
+- `authToken` - Authentication token needed for the InfluxDB client to communicate with an associated server.
 - `authTokenFromEnv` - Defines the authorization token, similar to `authToken`, but reads it from an environment variable on the scale target.
 - `organizationName` - Organization name needed for the client to locate all information contained in that [organization](https://docs.influxdata.com/influxdb/v2.0/organizations/) such as buckets, tasks, etc.
 - `organizationNameFromEnv` - Defines the organization name, similar to `organizationName`, but reads it from an environment variable on the scale target.

--- a/content/docs/2.8/scalers/kubernetes-workload.md
+++ b/content/docs/2.8/scalers/kubernetes-workload.md
@@ -1,6 +1,5 @@
 +++
 title = "Kubernetes Workload"
-layout = "scaler"
 availability = "v2.4+"
 maintainer = "Community"
 description = "Scale applications based on the count of running pods that match the given selectors."

--- a/content/docs/2.8/scalers/liiklus-topic.md
+++ b/content/docs/2.8/scalers/liiklus-topic.md
@@ -1,6 +1,5 @@
 +++
 title = "Liiklus Topic"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Liiklus Topic."

--- a/content/docs/2.8/scalers/memory.md
+++ b/content/docs/2.8/scalers/memory.md
@@ -1,6 +1,5 @@
 +++
 title = "Memory"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on memory metrics."

--- a/content/docs/2.8/scalers/metrics-api.md
+++ b/content/docs/2.8/scalers/metrics-api.md
@@ -1,6 +1,5 @@
 +++
 title = "Metrics API"
-layout = "scaler"
 availability = "v2.0+"
 maintainer = "Community"
 description = "Scale applications based on a metric provided by an API"
@@ -9,9 +8,9 @@ go_file = "metrics_api_scaler"
 
 ### Trigger Specification
 
-This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API. 
+This specification describes the `metrics-api` trigger that scales based on a metric value provided by an API.
 
-This scaler allows users to utilize **any existing APIs** as a metric provider.  
+This scaler allows users to utilize **any existing APIs** as a metric provider.
 
 Here is an example of trigger configuration using metrics-api scaler:
 
@@ -34,8 +33,8 @@ triggers:
 
 ### Authentication Parameters
 
-Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS 
-authentication. 
+Metrics Scaler API supported three types of authentication - API Key based authentication, basic authentication and TLS
+authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. Specify `authMode` and other trigger parameters
  along with secret credentials in `TriggerAuthentication` as mentioned below:
@@ -86,7 +85,7 @@ spec:
 ```
 
 When checking current metric Metrics API scaler sends GET request to provided `url` and then uses `valueLocation`
-to access the value in response's payload. 
+to access the value in response's payload.
 
 The above example expects that the API endpoint will return response similar to this one:
 ```json
@@ -114,7 +113,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  apiKey: "APIKEY" 
+  apiKey: "APIKEY"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -160,7 +159,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  token: "PlaceYourTokenHere" 
+  token: "PlaceYourTokenHere"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -171,7 +170,7 @@ spec:
   secretTargetRef:
     - parameter: token
       name: keda-metric-api-secret
-      key: token    
+      key: token
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -204,7 +203,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1
@@ -253,7 +252,7 @@ metadata:
   name: keda-metric-api-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---

--- a/content/docs/2.8/scalers/mongodb.md
+++ b/content/docs/2.8/scalers/mongodb.md
@@ -1,6 +1,5 @@
 +++
 title = "MongoDB"
-layout = "scaler"
 maintainer = "Community"
 description = "Scale applications based on MongoDB queries."
 availability = "v2.1+"
@@ -90,7 +89,7 @@ mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/
 
 You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` .
 
-### Authentication Parameters 
+### Authentication Parameters
 
 As an alternative to environment variables, You can authenticate with the MongoDB server by using connection string or password authentication via `TriggerAuthentication` or `ClusterTriggerAuthentication` configuration.
 

--- a/content/docs/2.8/scalers/mssql.md
+++ b/content/docs/2.8/scalers/mssql.md
@@ -1,6 +1,5 @@
 +++
 title = "MSSQL"
-layout = "scaler"
 availability = "v2.2+"
 maintainer = "Microsoft"
 description = "Scale applications based on Microsoft SQL Server (MSSQL) query results."

--- a/content/docs/2.8/scalers/mysql.md
+++ b/content/docs/2.8/scalers/mysql.md
@@ -1,6 +1,5 @@
 +++
 title = "MySQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on MySQL query result."

--- a/content/docs/2.8/scalers/nats-streaming.md
+++ b/content/docs/2.8/scalers/nats-streaming.md
@@ -1,6 +1,5 @@
 +++
 title = "NATS Streaming"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on NATS Streaming."
@@ -94,7 +93,7 @@ spec:
   pollingInterval: 10   # Optional. Default: 30 seconds
   cooldownPeriod: 30   # Optional. Default: 300 seconds
   minReplicaCount: 0   # Optional. Default: 0
-  maxReplicaCount: 30  # Optional. Default: 100  
+  maxReplicaCount: 30  # Optional. Default: 100
   scaleTargetRef:
     name: gonuts-sub
   triggers:

--- a/content/docs/2.8/scalers/new-relic.md
+++ b/content/docs/2.8/scalers/new-relic.md
@@ -3,7 +3,6 @@ title = "New Relic"
 availability = "2.6+"
 maintainer = "Community"
 description = "Scale applications based on New Relic NRQL"
-layout = "scaler"
 go_file = "newrelic_scaler"
 +++
 

--- a/content/docs/2.8/scalers/openstack-metric.md
+++ b/content/docs/2.8/scalers/openstack-metric.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Metric"
-layout = "scaler"
 availability = "v2.3+"
 maintainer = "Community"
 description = "Scale applications based on a threshold reached by a specific measure from OpenStack Metric API."
@@ -29,7 +28,7 @@ triggers:
 > Protocol (http or https) should always be provided when specifying URLs
 
 **Parameter list:**
-- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`. 
+- `metricsURL` - The URL to check for the metrics API, based. It must contain the hostname, the metric port, the API version, and the resource ID. The pattern is: `http://<host>:<metric_port>/<openstack_metric_api_version>/<resource_id>/metric`.
 - `metricID` - The Id of the intendend metric.
 - `aggregationMethod` - The aggregation method that will be used to calculate metrics, it must follows the configured possible metrics derived from gnocchi API like: `mean`, `min`, `max`, `std`, `sum`, `count`, the complete aggregation methods list can be found [here](https://gnocchi.xyz/rest.html#archive-policy).
 - `granularity` - The configured granularity from metric collection in seconds. it must follow the same value configured in OpenStack, but it must be coutned in seconds. Sample: If you have a 5 minutes time window granularity defined, so you must input a value of 300 seconds (5*60).
@@ -107,19 +106,19 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-      metricsURL: http://localhost:8041/v1/metric 
+      metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
-      threshold: 1250 
-      timeout: 30 
+      granularity: 300
+      threshold: 1250
+      timeout: 30
     authenticationRef:
         name: openstack-metric-password-trigger-authentication
 ```
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1
@@ -164,10 +163,10 @@ spec:
   triggers:
   - type: openstack-metric
     metadata:
-       metricsURL: http://localhost:8041/v1/metric 
+       metricsURL: http://localhost:8041/v1/metric
       metricID: faf01aa5-da88-4929-905d-b83fbab46771
       aggregationMethod: "mean"
-      granularity: 300 
+      granularity: 300
       threshold: 1250
     authenticationRef:
         name: openstack-metric-appcredentials-trigger-authentication

--- a/content/docs/2.8/scalers/openstack-swift.md
+++ b/content/docs/2.8/scalers/openstack-swift.md
@@ -1,6 +1,5 @@
 +++
 title = "OpenStack Swift"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Scale applications based on the count of objects in a given OpenStack Swift container."
@@ -20,7 +19,7 @@ triggers:
     objectCount: "2"  # Optional
     activationObjectCount: "5" # Optional
     objectPrefix: "my-prefix" # Optional
-    objectDelimiter: "/"  # Optional 
+    objectDelimiter: "/"  # Optional
     objectLimit: "10" # Optional
     onlyFiles: "true" # Optional
     timeout: "2"  # Optional
@@ -127,7 +126,7 @@ spec:
 
 #### Application Credentials method
 
-You can also use the Application Credentials method. 
+You can also use the Application Credentials method.
 
 ```yaml
 apiVersion: v1

--- a/content/docs/2.8/scalers/postgresql.md
+++ b/content/docs/2.8/scalers/postgresql.md
@@ -1,6 +1,5 @@
 +++
 title = "PostgreSQL"
-layout = "scaler"
 availability = "v1.2+"
 maintainer = "Community"
 description = "Scale applications based on a PostgreSQL query."

--- a/content/docs/2.8/scalers/predictkube.md
+++ b/content/docs/2.8/scalers/predictkube.md
@@ -3,7 +3,6 @@ title = "Predictkube"
 availability = "v2.6+"
 maintainer = "Dysnix"
 description = "AI-based predictive scaling based on Prometheus metrics & PredictKube SaaS."
-layout = "scaler"
 go_file = "predictkube_scaler"
 +++
 

--- a/content/docs/2.8/scalers/prometheus.md
+++ b/content/docs/2.8/scalers/prometheus.md
@@ -1,6 +1,5 @@
 +++
 title = "Prometheus"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Prometheus."
@@ -24,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgId: my-org # Optional. X-Scope-OrgID header for Cortex.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost 
+    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
 ```
 
 **Parameter list:**
@@ -40,7 +39,7 @@ triggers:
 
 ### Authentication Parameters
 
-Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication. 
+Prometheus Scaler supports three types of authentication - bearer authentication, basic authentication and TLS authentication.
 
 You can use `TriggerAuthentication` CRD to configure the authentication. It is possible to specify multiple authentication types i.e. `authModes: "tls,basic"` Specify `authModes` and other trigger parameters along with secret credentials in `TriggerAuthentication` as mentioned below:
 
@@ -91,7 +90,7 @@ metadata:
   namespace: default
 data:
   bearerToken: "BEARER_TOKEN"
-  ca: "CUSTOM_CA_CERT" 
+  ca: "CUSTOM_CA_CERT"
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -190,7 +189,7 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
 ---
@@ -243,10 +242,10 @@ metadata:
   name: keda-prom-secret
   namespace: default
 data:
-  cert: "cert" 
+  cert: "cert"
   key: "key"
   ca: "ca"
-  username: "username" 
+  username: "username"
   password: "password"
 ---
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.8/scalers/rabbitmq-queue.md
+++ b/content/docs/2.8/scalers/rabbitmq-queue.md
@@ -1,6 +1,5 @@
 +++
 title = "RabbitMQ Queue"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Microsoft"
 description = "Scale applications based on RabbitMQ Queue."
@@ -19,7 +18,7 @@ triggers:
     protocol: auto # Optional. Specifies protocol to use, either amqp or http, or auto to autodetect based on the `host` value. Default value is auto.
     mode: QueueLength # QueueLength or MessageRate
     value: "100.50" # message backlog or publish/sec. target per instance
-    activationValue: "10.5" # Optional. Activation threshold 
+    activationValue: "10.5" # Optional. Activation threshold
     queueName: testqueue
     vhostName: / # Optional. If not specified, use the vhost in the `host` connection string.
     # Alternatively, you can use existing environment variables to read configuration from:

--- a/content/docs/2.8/scalers/redis-cluster-lists.md
+++ b/content/docs/2.8/scalers/redis-cluster-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Cluster topology"

--- a/content/docs/2.8/scalers/redis-cluster-streams.md
+++ b/content/docs/2.8/scalers/redis-cluster-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Cluster)"
-layout = "scaler"
 availability = "v2.1+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Cluster topology"

--- a/content/docs/2.8/scalers/redis-lists.md
+++ b/content/docs/2.8/scalers/redis-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists"
-layout = "scaler"
 availability = "v1.0+"
 maintainer = "Community"
 description = "Scale applications based on Redis Lists."

--- a/content/docs/2.8/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.8/scalers/redis-sentinel-lists.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Lists (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Lists scaler with support for Redis Sentinel topology"

--- a/content/docs/2.8/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.8/scalers/redis-sentinel-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams (supports Redis Sentinel)"
-layout = "scaler"
 availability = "v2.5+"
 maintainer = "Community"
 description = "Redis Streams scaler with support for Redis Sentinel topology"

--- a/content/docs/2.8/scalers/redis-streams.md
+++ b/content/docs/2.8/scalers/redis-streams.md
@@ -1,6 +1,5 @@
 +++
 title = "Redis Streams"
-layout = "scaler"
 availability = "v1.5+"
 maintainer = "Community"
 description = "Scale applications based on Redis Streams."

--- a/content/docs/2.8/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.8/scalers/selenium-grid-scaler.md
@@ -3,7 +3,6 @@ title = "Selenium Grid Scaler"
 availability = "v2.4+"
 maintainer = "Volvo Cars"
 description = "Scales Selenium browser nodes based on number of requests waiting in session queue"
-layout = "scaler"
 go_file = "selenium_grid_scaler"
 +++
 

--- a/content/docs/2.8/scalers/solace-pub-sub.md
+++ b/content/docs/2.8/scalers/solace-pub-sub.md
@@ -3,7 +3,6 @@ title = "Solace PubSub+ Event Broker"
 availability = "2.4+"
 maintainer = "Community"
 description = "Scale applications based on Solace PubSub+ Event Broker Queues"
-layout = "scaler"
 go_file = "solace_scaler"
 +++
 

--- a/layouts/_default/scaler.html
+++ b/layouts/_default/scaler.html
@@ -1,7 +1,0 @@
-{{ define "title" }}
-KEDA Scaler | {{ .Title }}
-{{ end }}
-
-{{ define "main" }}
-{{ partial "article.html" . }}
-{{ end }}


### PR DESCRIPTION
- This PR reduces technical debt by eliminating scaler-related code that is no longer relevant.
- Best viewed by ignoring whitespace changes
- No change in generated site files (other than differences in whitespace):
  ```console
  $ pwd
  .../keda-docs
  $ npm run check-links
  ...
  $ (cd public && git diff -bw --ignore-blank-lines)  
  $
  ```

Preview, see for example:

- 

