### PR TITLE
feat: List all scalers in side-navigation

### DIFF
--- a/assets/sass/nav.sass
+++ b/assets/sass/nav.sass
@@ -10,6 +10,7 @@
   justify-content: space-between
 
 .nav
+  padding-top: 5rem
   padding-bottom: 2rem
 
   &-subsection

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,7 +3,7 @@
 {{ $currentSection := .CurrentSection }}
 {{ $root           := .FirstSection }}
 {{ $thisVersion    := index (split .File.Path "/") 1 }}
-<div class="nav is-sticky">
+<div class="nav">
   {{ range $docs }}
   {{ range .Sections }}
   {{ $version := index (split .File.Path "/") 1 }}
@@ -49,7 +49,7 @@
   {{ with .Sections }}
   {{ range . }}
   {{ $isThisSection := eq .CurrentSection.Title $currentSection.Title }}
-  {{ $regularPages := cond (eq .CurrentSection.Title "Scalers") "" .RegularPages -}}
+  {{ $regularPages := .RegularPages -}}
   <div class="nav-subsection" x-data="{ open: {{ $isThisSection }} }">
     <div class="nav-section-title is-size-5 is-size-6-mobile{{ if $isHere }} is-active{{ end }}" href="{{ .RelPermalink }}">
       <a href="{{ .RelPermalink }}">


### PR DESCRIPTION
- Fixes #860

Preview: unfold the **Scalers** menu entry and you'll see that you can scroll up and down. For example, try:

- https://deploy-preview-893--keda.netlify.app/docs/2.8/scalers/
- https://deploy-preview-893--keda.netlify.app/docs/2.8/
- https://deploy-preview-893--keda.netlify.app/docs/2.8/concepts/troubleshooting/

/cc @thisisobate @nate-double-u