### PR TITLE
chore: Bring auth providers to v2.9 and rename Azure identity providers

### DIFF
--- a/content/docs/2.7/authentication-providers/azure-ad-pod-identity.md
+++ b/content/docs/2.7/authentication-providers/azure-ad-pod-identity.md
@@ -1,5 +1,5 @@
 +++
-title = "Azure Pod Identity"
+title = "Azure AD Pod Identity"
 +++
 
 Azure Pod Identity is an implementation of [**Azure AD Pod Identity**](https://github.com/Azure/aad-pod-identity) which lets you bind an [**Azure Managed Identity**](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/) to a Pod in a Kubernetes cluster as delegated access - *Don't manage secrets, let Azure AD do the hard work*.

--- a/content/docs/2.8/authentication-providers/azure-ad-pod-identity.md
+++ b/content/docs/2.8/authentication-providers/azure-ad-pod-identity.md
@@ -1,5 +1,5 @@
 +++
-title = "Azure Pod Identity"
+title = "Azure AD Pod Identity"
 +++
 
 Azure Pod Identity is an implementation of [**Azure AD Pod Identity**](https://github.com/Azure/aad-pod-identity) which lets you bind an [**Azure Managed Identity**](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/) to a Pod in a Kubernetes cluster as delegated access - *Don't manage secrets, let Azure AD do the hard work*.

--- a/content/docs/2.8/authentication-providers/azure-ad-workload-identity.md
+++ b/content/docs/2.8/authentication-providers/azure-ad-workload-identity.md
@@ -1,5 +1,5 @@
 +++
-title = "Azure Workload Identity"
+title = "Azure AD Workload Identity"
 +++
 
 [**Azure AD Workload Identity**](https://github.com/Azure/azure-workload-identity) is the newer version of [**Azure AD Pod Identity**](https://github.com/Azure/aad-pod-identity). It lets your Kubernetes workloads access Azure resources using an

--- a/content/docs/2.9/authentication-providers/_index.md
+++ b/content/docs/2.9/authentication-providers/_index.md
@@ -1,0 +1,8 @@
++++
+title = "Authentication Providers"
+weight = 5
++++
+
+Available authentication providers for KEDA:
+
+{{< authentication-providers >}}

--- a/content/docs/2.9/authentication-providers/aws-eks.md
+++ b/content/docs/2.9/authentication-providers/aws-eks.md
@@ -1,0 +1,12 @@
++++
+title = "EKS Pod Identity Webhook for AWS"
++++
+
+[**EKS Pod Identity Webhook**](https://github.com/aws/amazon-eks-pod-identity-webhook), which is described more in depth [here](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/), allows you to provide the role name using an annotation on a service account associated with your pod.
+
+You can tell KEDA to use EKS Pod Identity Webhook via `podIdentity.provider`.
+
+```yaml
+podIdentity:
+  provider: aws-eks # Optional. Default: none
+```

--- a/content/docs/2.9/authentication-providers/aws-kiam.md
+++ b/content/docs/2.9/authentication-providers/aws-kiam.md
@@ -1,0 +1,12 @@
++++
+title = "Kiam Pod Identity for AWS"
++++
+
+[**Kiam**](https://github.com/uswitch/kiam/) lets you bind an AWS IAM Role to a pod using an annotation on the pod.
+
+You can tell KEDA to use Kiam via `podIdentity.provider`.
+
+```yaml
+podIdentity:
+  provider: aws-kiam # Optional. Default: none
+```

--- a/content/docs/2.9/authentication-providers/azure-ad-pod-identity.md
+++ b/content/docs/2.9/authentication-providers/azure-ad-pod-identity.md
@@ -1,0 +1,17 @@
++++
+title = "Azure AD Pod Identity"
++++
+
+Azure Pod Identity is an implementation of [**Azure AD Pod Identity**](https://github.com/Azure/aad-pod-identity) which lets you bind an [**Azure Managed Identity**](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/) to a Pod in a Kubernetes cluster as delegated access - *Don't manage secrets, let Azure AD do the hard work*.
+
+You can tell KEDA to use Azure AD Pod Identity via `podIdentity.provider`.
+
+```yaml
+podIdentity:
+  provider: azure           # Optional. Default: none
+  identityId: <identity-id> # Optional. Default: Identity linked with the label set when installing KEDA.
+```
+
+Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set podIdentity.activeDirectory.identity={your-label-name}`.
+
+You can override the identity that was assigned to KEDA during installation, by specifying an `identityId` parameter under the `podIdentity` field. This allows end-users to use different identities to access various resources which is more secure than using a single identity that has access to multiple resources.

--- a/content/docs/2.9/authentication-providers/azure-ad-workload-identity.md
+++ b/content/docs/2.9/authentication-providers/azure-ad-workload-identity.md
@@ -1,0 +1,25 @@
++++
+title = "Azure AD Workload Identity"
++++
+
+[**Azure AD Workload Identity**](https://github.com/Azure/azure-workload-identity) is the newer version of [**Azure AD Pod Identity**](https://github.com/Azure/aad-pod-identity). It lets your Kubernetes workloads access Azure resources using an
+[**Azure AD Application**](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals)
+without having to specify secrets, using [federated identity credentials](https://azure.github.io/azure-workload-identity/docs/topics/federated-identity-credential.html) - *Don't manage secrets, let Azure AD do the hard work*.
+
+You can tell KEDA to use Azure AD Workload Identity via `podIdentity.provider`.
+
+```yaml
+podIdentity:
+  provider: azure-workload  # Optional. Default: none
+  identityId: <identity-id> # Optional. Default: ClientId From annotation on service-account.
+```
+
+Azure AD Workload Identity will give access to pods with service accounts having appropriate labels and annotations. Refer
+to these [docs](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html) for more information. You can set these labels and annotations on the KEDA Operator service account. This can be done for you during deployment with Helm with the
+following flags -
+
+1. `--set podIdentity.azureWorkload.enabled=true`
+2. `--set podIdentity.azureWorkload.clientId={azure-ad-client-id}`
+3. `--set podIdentity.azureWorkload.tenantId={azure-ad-tenant-id}`
+
+You can override the identity that was assigned to KEDA during installation, by specifying an `identityId` parameter under the `podIdentity` field. This allows end-users to use different identities to access various resources which is more secure than using a single identity that has access to multiple resources.

--- a/content/docs/2.9/authentication-providers/azure-key-vault.md
+++ b/content/docs/2.9/authentication-providers/azure-key-vault.md
@@ -1,0 +1,38 @@
++++
+title = "Azure Key Vault secret"
++++
+
+
+You can pull secrets from Azure Key Vault into the trigger by using the `azureKeyVault` key.
+
+The `secrets` list defines the mapping between the key vault secret and the authentication parameter.
+
+Currently pod identity providers are not supported for key vault.
+
+You need to register an [application](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) with Azure Active Directory and specify its credentials. The `clientId` and `tenantId` for the application are to be provided as part of the spec. The `clientSecret` for the application is expected to be within a kubernetes secret in the same namespace as the authentication resource.
+
+Ensure that "read secret" permissions have been granted to the Azure AD application on the Azure Key Vault. Learn more in the Azure Key Vault [documentation](https://docs.microsoft.com/en-us/azure/key-vault/general/assign-access-policy?tabs=azure-portal).
+
+The `cloud` parameter can be used to specify cloud environments besides `Azure Public Cloud`, such as known Azure clouds like
+`Azure China Cloud`, etc. and even Azure Stack Hub or Air Gapped clouds.
+
+```yaml
+azureKeyVault:                                          # Optional.
+  vaultURI: {key-vault-address}                         # Required.
+  credentials:                                          # Required.
+    clientId: {azure-ad-client-id}                      # Required.
+    clientSecret:                                       # Required.
+      valueFrom:                                        # Required.
+        secretKeyRef:                                   # Required.
+          name: {k8s-secret-with-azure-ad-secret}       # Required.
+          key: {key-within-the-secret}                  # Required.
+    tenantId: {azure-ad-tenant-id}                      # Required.
+  cloud:                                                # Optional.
+    type: AzurePublicCloud | AzureUSGovernmentCloud | AzureChinaCloud | AzureGermanCloud | Private # Required.
+    keyVaultResourceURL: {key-vault-resource-url-for-cloud}           # Required when type = Private.
+    activeDirectoryEndpoint: {active-directory-endpoint-for-cloud}    # Required when type = Private.
+  secrets:                                              # Required.
+  - parameter: {param-name-used-for-auth}               # Required.
+    name: {key-vault-secret-name}                       # Required.
+    version: {key-vault-secret-version}                 # Optional.
+```

--- a/content/docs/2.9/authentication-providers/environment-variable.md
+++ b/content/docs/2.9/authentication-providers/environment-variable.md
@@ -1,0 +1,14 @@
++++
+title = "Environment variable"
++++
+
+You can pull information via one or more environment variables by providing the `name` of the variable for a given `containerName`.
+
+```yaml
+env:                              # Optional.
+  - parameter: region             # Required - Defined by the scale trigger
+    name: my-env-var              # Required.
+    containerName: my-container   # Optional. Default: scaleTargetRef.envSourceContainerName of ScaledObject
+```
+
+**Assumptions:** `containerName` is in the same resource as referenced by `scaleTargetRef.name` in the ScaledObject, unless specified otherwise.

--- a/content/docs/2.9/authentication-providers/hashicorp-vault.md
+++ b/content/docs/2.9/authentication-providers/hashicorp-vault.md
@@ -1,0 +1,25 @@
++++
+title = "Hashicorp Vault secret"
++++
+
+
+You can pull one or more Hashicorp Vault secrets into the trigger by defining the authentication metadata such as Vault `address` and the `authentication` method (token | kubernetes). If you choose kubernetes auth method you should provide `role` and `mount` as well.
+`credential` defines the Hashicorp Vault credentials depending on the authentication method, for kubernetes you should provide path to service account token (/var/run/secrets/kubernetes.io/serviceaccount/token) and for token auth method provide the token.
+`secrets` list defines the mapping between the path and the key of the secret in Vault to the parameter.
+`namespace` may be used to target a given Vault Enterprise namespace.
+
+```yaml
+hashiCorpVault:                                     # Optional.
+  address: {hashicorp-vault-address}                # Required.
+  namespace: {hashicorp-vault-namespace}            # Optional. Default is root namespace. Useful for Vault Enterprise
+  authentication: token | kubernetes                # Required.
+  role: {hashicorp-vault-role}                      # Optional.
+  mount: {hashicorp-vault-mount}                    # Optional.
+  credential:                                       # Optional.
+    token: {hashicorp-vault-token}                  # Optional.
+    serviceAccount: {path-to-service-account-file}  # Optional.
+  secrets:                                          # Required.
+  - parameter: {scaledObject-parameter-name}        # Required.
+    key: {hasicorp-vault-secret-key-name}           # Required.
+    path: {hasicorp-vault-secret-path}              # Required.
+```

--- a/content/docs/2.9/authentication-providers/secret.md
+++ b/content/docs/2.9/authentication-providers/secret.md
@@ -1,0 +1,14 @@
++++
+title = "Secret"
++++
+
+You can pull one or more secrets into the trigger by defining the `name` of the Kubernetes Secret and the `key` to use.
+
+```yaml
+secretTargetRef:                          # Optional.
+  - parameter: connectionString           # Required - Defined by the scale trigger
+    name: my-keda-secret-entity           # Required.
+    key: azure-storage-connectionstring   # Required.
+```
+
+**Assumptions:** `namespace` is in the same resource as referenced by `scaleTargetRef.name` in the ScaledObject, unless specified otherwise.


### PR DESCRIPTION
Bring auth providers to v2.9 and rename Azure identity providers

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/keda-docs/issues/711
