### PR TITLE
CPU/Memory scaler prerequisites, examples

### DIFF
--- a/content/docs/2.0/scalers/cpu.md
+++ b/content/docs/2.0/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
-> - This scaler will never scale to 0 and even when user define multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
+> - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.0/scalers/memory.md
+++ b/content/docs/2.0/scalers/memory.md
@@ -7,20 +7,27 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
-> - This scaler will never scale to 0 and even when user define multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
+> - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
 
-### Trigger Specification
+### Prerequisites
 
-This specification describes the `memory` trigger that scales based on memory metrics.
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
 
-```yaml
-triggers:
-- type: memory
-  metadata:
-    # Required
-    type: Utilization/ AverageValue
-    value: "60"
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
 ```
 
 **Parameter list:**
@@ -44,6 +51,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.1/scalers/cpu.md
+++ b/content/docs/2.1/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.1/scalers/memory.md
+++ b/content/docs/2.1/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.2/scalers/cpu.md
+++ b/content/docs/2.2/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.2/scalers/memory.md
+++ b/content/docs/2.2/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.3/scalers/cpu.md
+++ b/content/docs/2.3/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.3/scalers/memory.md
+++ b/content/docs/2.3/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.4/scalers/cpu.md
+++ b/content/docs/2.4/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.4/scalers/memory.md
+++ b/content/docs/2.4/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.5/scalers/cpu.md
+++ b/content/docs/2.5/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.5/scalers/memory.md
+++ b/content/docs/2.5/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.6/scalers/cpu.md
+++ b/content/docs/2.6/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: cpu
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: cpu
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.6/scalers/memory.md
+++ b/content/docs/2.6/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -19,7 +39,7 @@ triggers:
 - type: memory
   metadata:
     # Required
-    type: Utilization/ AverageValue
+    type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -44,6 +64,6 @@ spec:
   triggers:
   - type: memory
     metadata:
-      type: Utilization
+      type: Utilization # Allowed types are 'Utilization' or 'AverageValue'
       value: "50"
 ```

--- a/content/docs/2.7/scalers/cpu.md
+++ b/content/docs/2.7/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -17,9 +37,9 @@ This specification describes the `cpu` trigger that scales based on cpu metrics.
 ```yaml
 triggers:
 - type: cpu
-  metricType: Utilization/ AverageValue
+  metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization/ AverageValue # Deprecated in favor of trigger.metricType
+    type: Utilization # Deprecated in favor of trigger.metricType; Allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -45,7 +65,7 @@ spec:
     name: my-deployment
   triggers:
   - type: cpu
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
 ```

--- a/content/docs/2.7/scalers/memory.md
+++ b/content/docs/2.7/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -17,9 +37,9 @@ This specification describes the `memory` trigger that scales based on memory me
 ```yaml
 triggers:
 - type: memory
-  metricType: Utilization/ AverageValue
+  metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization/ AverageValue # Deprecated in favor of trigger.metricType
+    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
 ```
 
@@ -45,7 +65,7 @@ spec:
     name: my-deployment
   triggers:
   - type: memory
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
 ```

--- a/content/docs/2.8/scalers/cpu.md
+++ b/content/docs/2.8/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -17,9 +37,9 @@ This specification describes the `cpu` trigger that scales based on cpu metrics.
 ```yaml
 triggers:
 - type: cpu
-  metricType: Utilization/ AverageValue
+  metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization/ AverageValue # Deprecated in favor of trigger.metricType
+    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
     containerName: "" # Optional. You can use this to target a specific container in a pod
 ```
@@ -51,7 +71,7 @@ spec:
     name: my-deployment
   triggers:
   - type: cpu
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
 ```
@@ -69,7 +89,7 @@ spec:
     name: my-deployment
   triggers:
   - type: cpu
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
     containerName: "api"

--- a/content/docs/2.8/scalers/memory.md
+++ b/content/docs/2.8/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -17,9 +37,9 @@ This specification describes the `memory` trigger that scales based on memory me
 ```yaml
 triggers:
 - type: memory
-  metricType: Utilization/ AverageValue
+  metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization/ AverageValue # Deprecated in favor of trigger.metricType
+    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
     containerName: "" # Optional. You can use this to target a specific container in a pod
 ```
@@ -51,7 +71,7 @@ spec:
     name: my-deployment
   triggers:
   - type: memory
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
 ```
@@ -69,7 +89,7 @@ spec:
     name: my-deployment
   triggers:
   - type: memory
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
     containerName: "api"

--- a/content/docs/2.9/scalers/cpu.md
+++ b/content/docs/2.9/scalers/cpu.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -17,9 +37,9 @@ This specification describes the `cpu` trigger that scales based on cpu metrics.
 ```yaml
 triggers:
 - type: cpu
-  metricType: Utilization/ AverageValue
+  metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization/ AverageValue # Deprecated in favor of trigger.metricType
+    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
     containerName: "" # Optional. You can use this to target a specific container in a pod
 ```
@@ -51,7 +71,7 @@ spec:
     name: my-deployment
   triggers:
   - type: cpu
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
 ```
@@ -69,7 +89,7 @@ spec:
     name: my-deployment
   triggers:
   - type: cpu
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
     containerName: "api"

--- a/content/docs/2.9/scalers/memory.md
+++ b/content/docs/2.9/scalers/memory.md
@@ -7,8 +7,28 @@ go_file = "cpu_memory_scaler"
 +++
 
 > **Notice:**
+> - This scaler **requires prerequisites**. See the 'Prerequisites' section.
 > - This scaler will never scale to 0 and even when user defines multiple scaler types (eg. Kafka + cpu/memory, or Prometheus + cpu/memory), the deployment will never scale to 0.
 > - This scaler only applies to ScaledObject, not to Scaling Jobs.
+
+### Prerequisites
+
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+
+- The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+
+```
+# a working example of resources with specified limits
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+```
 
 ### Trigger Specification
 
@@ -17,9 +37,9 @@ This specification describes the `memory` trigger that scales based on memory me
 ```yaml
 triggers:
 - type: memory
-  metricType: Utilization/ AverageValue
+  metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization/ AverageValue # Deprecated in favor of trigger.metricType
+    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
     containerName: "" # Optional. You can use this to target a specific container in a pod
 ```
@@ -51,7 +71,7 @@ spec:
     name: my-deployment
   triggers:
   - type: memory
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
 ```
@@ -69,7 +89,7 @@ spec:
     name: my-deployment
   triggers:
   - type: memory
-    metricType: Utilization
+    metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
     metadata:
       value: "50"
     containerName: "api"


### PR DESCRIPTION
The scaler documentation for CPU and memory is updated to add the Kubernetes Metric Server prerequisite, links to the resources/requests/limits Kubernetes documentation, and updates the 'Utilization/ AverageValue' examples to be usable without modification while still containing notes about valid values

Signed-off-by: Byron Lagrone <byron.lagrone@seqster.com>

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
