### PR TITLE
Make clear where the password should be in the connectionstring

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -205,12 +205,6 @@ name = "Troubleshooting"
 parent = "docs"
 weight = 8
 
-[[menu.docs]]
-url = "/support/"
-name = "Support"
-parent = "docs"
-weight = 9
-
 [[menu.main]]
 url = "/blog"
 name = "Blog"
@@ -291,6 +285,12 @@ url = "https://github.com/kedacore/keda/blob/main/LICENSE"
 name = "License"
 parent = "project"
 weight = 9
+
+[[menu.main]]
+url = "/support/"
+name = "Support"
+parent = "project"
+weight = 10
 
 [[menu.main]]
 url = "https://store.cncf.io/collections/keda"

--- a/content/docs/2.0/scalers/mysql.md
+++ b/content/docs/2.0/scalers/mysql.md
@@ -57,7 +57,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.1/scalers/mysql.md
+++ b/content/docs/2.1/scalers/mysql.md
@@ -57,7 +57,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.2/scalers/mysql.md
+++ b/content/docs/2.2/scalers/mysql.md
@@ -57,7 +57,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.3/scalers/mysql.md
+++ b/content/docs/2.3/scalers/mysql.md
@@ -57,7 +57,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.4/scalers/mysql.md
+++ b/content/docs/2.4/scalers/mysql.md
@@ -57,7 +57,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.5/scalers/mysql.md
+++ b/content/docs/2.5/scalers/mysql.md
@@ -61,7 +61,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.6/scalers/mysql.md
+++ b/content/docs/2.6/scalers/mysql.md
@@ -61,7 +61,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.7/scalers/mysql.md
+++ b/content/docs/2.7/scalers/mysql.md
@@ -61,7 +61,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.8/scalers/mysql.md
+++ b/content/docs/2.8/scalers/mysql.md
@@ -62,7 +62,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.9/operate/cluster.md
+++ b/content/docs/2.9/operate/cluster.md
@@ -6,9 +6,14 @@ weight = 100
 
 ## Requirements
 
-### Kubernetes
+### Kubernetes Compatibility
 
-KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+The supported window of Kubernetes versions with KEDA is known as "N-2" which means that KEDA will provide support for running on N-2 at least.
+
+However, maintainers can decide to extend this by supporting more minor versions based on the required CRDs being used; but there is no guarantee.
+
+> Example - At time of writing, Kubernetes 1.25 is the latest minor version so KEDA can only use new features that were introduced in 1.23
+You can learn more about the currently supported Kubernetes version in our [FAQ](https://keda.sh/docs/latest/faq/).
 
 ### Cluster Capacity
 

--- a/content/docs/2.9/scalers/mysql.md
+++ b/content/docs/2.9/scalers/mysql.md
@@ -62,7 +62,7 @@ metadata:
   namespace: my-project
 type: Opaque
 data:
-  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user@tcp(mysql:3306)/stats_db
+  mysql_conn_str: dXNlckB0Y3AobXlzcWw6MzMwNikvc3RhdHNfZGI= # base64 encoded value of mysql connectionString of format user:password@tcp(mysql:3306)/stats_db
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/support.md
+++ b/content/support.md
@@ -10,16 +10,9 @@ Want to contribute a feature or fix? We are more than happy to review requests a
 
 Learn more in our [support policy](https://github.com/kedacore/governance/blob/main/SUPPORT.md).
 
+Kubernetes compatibility is described in the [documentation](https://keda.sh/docs/latest/operate/cluster/#kubernetes-compatibility).
+
 ## Commercial support
 Here's an overview of all vendors that provide KEDA as part of their offering/product and provide support for it: 
 
 {{< support >}}
-
-## Kubernetes support
-The supported window of Kubernetes versions with KEDA is known as "N-2" which means that KEDA will provide support for running on N-2 at least.
-
-However, maintainers can decide to extend this by supporting more minor versions based on the required CRDs being used; but there is no guarantee.
-
-> Example - At time of writing, Kubernetes 1.25 is the latest minor version so KEDA can only use new features that were introduced in 1.23
-
-You can learn more about the currently supported Kubernetes version in our [FAQ](https://keda.sh/docs/latest/faq/).


### PR DESCRIPTION
It is not clear in the documentation where the password should be in the connection string. This PR makes this clear.

Signed-off-by: Simon Rondelez <simonrondelez@me.com>


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related GH issue https://github.com/kedacore/keda/issues/1277
