### PR TITLE
Do not merge - Docs when KEDA became a CNCF Incubation project

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://keda.sh"
 languageCode = "en-us"
-title = "KEDA"
+title = "KEDA (CNCF Incubation)"
 enableGitInfo = true
 disableKinds = ["taxonomy", "taxonomyTerm"]
 


### PR DESCRIPTION
This should be the docs with end-users when we became CNCF Incubation project which I'm using to gather information in Netlify preview.