### PR TITLE
fix: Identity segregation is not supported in KEDA v2.7

### DIFF
--- a/content/docs/2.7/authentication-providers/azure-ad-pod-identity.md
+++ b/content/docs/2.7/authentication-providers/azure-ad-pod-identity.md
@@ -9,9 +9,6 @@ You can tell KEDA to use Azure AD Pod Identity via `podIdentity.provider`.
 ```yaml
 podIdentity:
   provider: azure           # Optional. Default: none
-  identityId: <identity-id> # Optional. Default: Identity linked with the label set when installing KEDA.
 ```
 
 Azure AD Pod Identity will give access to containers with a defined label for `aadpodidbinding`.  You can set this label on the KEDA operator deployment.  This can be done for you during deployment with Helm with `--set podIdentity.activeDirectory.identity={your-label-name}`.
-
-You can override the identity that was assigned to KEDA during installation, by specifying an `identityId` parameter under the `podIdentity` field. This allows end-users to use different identities to access various resources which is more secure than using a single identity that has access to multiple resources.


### PR DESCRIPTION
Identity segregation is not supported in KEDA v2.7

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/keda/issues/2656
