### PR TITLE
docs: kubernetes client parameters for keda operator

### DIFF
--- a/content/docs/2.9/operate/cluster.md
+++ b/content/docs/2.9/operate/cluster.md
@@ -88,7 +88,7 @@ Some scalers issue HTTP requests to external servers (i.e. cloud services). As c
 
 ## Kubernetes Client Parameters
 
-The Kubernetes client config used within KEDA Metrics Adapter can be adjusted by passing the following command-line flags to the binary:
+The Kubernetes client config used within KEDA Operator and KEDA Metrics Adapter can be adjusted by passing the following command-line flags to the binary:
 
 | Adapter Flag   | Client Config Setting   | Default Value | Description                                                    |
 | -------------- | ----------------------- | ------------- | -------------------------------------------------------------- |


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Mention that the Kubernetes client config can be adjust for both KEDA Operator and KEDA Metrics Adapter.
Previously to https://github.com/kedacore/keda/pull/3731 only KEDA Metrics Adapter had these parameters.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

<!-- Fixes # -->
Relates to https://github.com/kedacore/keda/pull/3731
Relates to https://github.com/kedacore/keda/issues/3730