### PR TITLE
chore: remove scaler catalog at the end of the individual scaler page

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,5 +1,6 @@
 {{ $notice   := .Params.notice }}
 {{ $isScaler := eq .CurrentSection.Title "Scalers" }}
+{{ $index := eq .File.LogicalName "_index.md"}}
 <section class="section">
   <div class="container">
     <div class="content is-medium is-constrained has-bottom-margin">
@@ -18,7 +19,7 @@
 
       {{ .Content | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" `${1} <a class="headline-hash" href="#${2}"><span class="icon hashlink"><i class="fas fa-hashtag"></i></span></a>${3}` | safeHTML }}
 
-      {{ if $isScaler }}
+      {{ if and ($isScaler) ($index) }}
       {{ partial "scaler-layout" . }}
       {{ end }}
     </div>


### PR DESCRIPTION


<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
Since we decided to [list all scalers at the side nav](https://github.com/kedacore/keda-docs/pull/893), it makes sense to remove the catalog at the end of the individual scaler page.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #869
