### PR TITLE
fix: Corrected Typographical Error in Prometheus Scaler Docs

### DIFF
--- a/content/docs/2.3/scalers/prometheus.md
+++ b/content/docs/2.3/scalers/prometheus.md
@@ -39,17 +39,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 

--- a/content/docs/2.4/scalers/prometheus.md
+++ b/content/docs/2.4/scalers/prometheus.md
@@ -39,17 +39,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 

--- a/content/docs/2.5/scalers/prometheus.md
+++ b/content/docs/2.5/scalers/prometheus.md
@@ -39,17 +39,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 

--- a/content/docs/2.6/scalers/prometheus.md
+++ b/content/docs/2.6/scalers/prometheus.md
@@ -42,17 +42,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 

--- a/content/docs/2.7/scalers/prometheus.md
+++ b/content/docs/2.7/scalers/prometheus.md
@@ -44,17 +44,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 

--- a/content/docs/2.8/scalers/prometheus.md
+++ b/content/docs/2.8/scalers/prometheus.md
@@ -48,17 +48,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 

--- a/content/docs/2.9/scalers/prometheus.md
+++ b/content/docs/2.9/scalers/prometheus.md
@@ -50,17 +50,17 @@ You can use `TriggerAuthentication` CRD to configure the authentication. It is p
 - `bearerToken`: The token needed for authentication. This is a required field.
 
 **Basic authentication:**
-- `authMode`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `basic` in case of Basic Authentication. Specify this in trigger configuration.
 - `username` - This is a required field. Provide the username to be used for basic authentication.
 - `password` - Provide the password to be used for authentication. For convenience, this has been marked optional, because many applications implement basic auth with a username as apikey and password as empty.
 
 **TLS authentication:**
-- `authMode`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
+- `authModes`: It must contain `tls` in case of TLS Authentication. Specify this in trigger configuration.
 - `ca` - Certificate authority file for TLS client authentication.
 - `cert` - Certificate for client authentication. This is a required field.
 - `key` - Key for client authentication. Optional. This is a required field.
 
-> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authMode` (also without any authentication). This might be useful if you are using an enterprise CA.
+> 💡 **NOTE:**It's also possible to set the CA certificate regardless of the selected `authModes` (also without any authentication). This might be useful if you are using an enterprise CA.
 
 ### Example
 


### PR DESCRIPTION
Signed-off-by: Reynaldi Hartono <me@reynhartono.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

- Corrected typographical error in prometheus scaler docs: `authMode` -> `authModes`

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
