### PR TITLE
Metrics api unsafessl

### DIFF
--- a/content/docs/2.9/scalers/metrics-api.md
+++ b/content/docs/2.9/scalers/metrics-api.md
@@ -30,6 +30,8 @@ triggers:
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
+- `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
+
 
 ### Authentication Parameters
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added docs on unsafeSsl parameter for the metrics_api scaler. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

[Relates to #3728](https://github.com/kedacore/keda/discussions/3728)
[Relates to #3823](https://github.com/kedacore/keda/pull/3823)
