### PR TITLE
Add docs for https support in nats scalers

### DIFF
--- a/content/docs/2.9/scalers/nats-jetstream.md
+++ b/content/docs/2.9/scalers/nats-jetstream.md
@@ -21,6 +21,7 @@ triggers:
     consumer: "pull_consumer"
     lagThreshold: "10"
     activationLagThreshold: "15"
+    useHttps: "false"
 ```
 
 **Parameter list:**
@@ -31,6 +32,7 @@ triggers:
 - `consumer` - Name of the consumer for a given stream.
 - `lagThreshold` - Average target value to trigger scaling actions.
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
+- `useHttps` - Specifies if the NATS server monitoring endpoint is using HTTPS. Default value is false.
 
 ### Authentication Parameters
 
@@ -60,4 +62,5 @@ spec:
       consumer: "pull_consumer"
       lagThreshold: "10"
       activationLagThreshold: "15"
+      useHttps: "false"
 ```

--- a/content/docs/2.9/scalers/nats-streaming.md
+++ b/content/docs/2.9/scalers/nats-streaming.md
@@ -20,6 +20,7 @@ triggers:
     subject: "Test"
     lagThreshold: "10"
     activationLagThreshold: "5"
+    useHttps: "false"
 ```
 
 **Parameter list:**
@@ -30,6 +31,7 @@ triggers:
 - `subject` - Name of the channel.
 - `lagThreshold` - Average target value to trigger scaling actions.
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
+- `useHttps` - Specifies if the NATS Streaming monitoring endpoint is using HTTPS. Default value is false.
 
 ### Authentication Parameters
 
@@ -60,6 +62,7 @@ spec:
       durableName: "ImDurable"
       subject: "Test"
       lagThreshold: "10"
+      useHttps: "false"
 ```
 #### Example with TriggerAuthentication:
 


### PR DESCRIPTION
Signed-off-by: Manuel Cañete <manuel.canete@docplanner.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add docs for https support in nats endpoints -> [PR](https://github.com/kedacore/keda/pull/3815)

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
