### PR TITLE
feat: Provide updated Kubernetes support overview

### DIFF
--- a/content/docs/2.6/operate/cluster.md
+++ b/content/docs/2.6/operate/cluster.md
@@ -8,7 +8,7 @@ weight = 100
 
 ### Kubernetes
 
-KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above until v1.25.0 (incl).
 
 ### Cluster Capacity
 

--- a/content/docs/2.7/operate/cluster.md
+++ b/content/docs/2.7/operate/cluster.md
@@ -8,7 +8,7 @@ weight = 100
 
 ### Kubernetes
 
-KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above until v1.25.0 (incl).
 
 ### Cluster Capacity
 

--- a/content/docs/2.8/operate/cluster.md
+++ b/content/docs/2.8/operate/cluster.md
@@ -8,7 +8,7 @@ weight = 100
 
 ### Kubernetes
 
-KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above.
+KEDA is designed, tested and supported to be run on any Kubernetes cluster that runs Kubernetes v1.17.0 or above until v1.25.0 (incl).
 
 ### Cluster Capacity
 

--- a/content/docs/2.9/operate/cluster.md
+++ b/content/docs/2.9/operate/cluster.md
@@ -17,8 +17,8 @@ As a reference, this compatibility matrix shows supported k8s versions per KEDA 
 |   KEDA    |   Kubernetes  |
 |-----------|---------------|
 |   v2.9    | v1.23 - v1.25 |
-|   v2.8    | v1.17 - v1.24 |
-|   v2.7    | v1.17 - v1.24 |
+|   v2.8    | v1.17 - v1.25 |
+|   v2.7    | v1.17 - v1.25 |
 
 ### Cluster Capacity
 


### PR DESCRIPTION
Provide updated Kubernetes support overview as KEDA <= 2.8 supports up to Kubernetes 1.25 but not above due to API version breaking change for HPA.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
