### PR TITLE
Apache Pulsar: Document support for new auth modes

### DIFF
--- a/content/docs/2.9/scalers/pulsar.md
+++ b/content/docs/2.9/scalers/pulsar.md
@@ -29,7 +29,7 @@ triggers:
 - `subscription` - Name of the topic subscription
 - `msgBacklogThreshold` - Average target value to trigger scaling actions. (default: 10)
 - `activationMsgBacklogThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
-- `authModes` - a comma separated list of authentication modes to use. Default `""`. Valid options are `bearer`, `tls`, and `basic`. Note that `tls,bearer` or `tls,basic` are valid combinations and would indicate mutual TLS to secure the connection and then `bearer` or `basic` headers should be added to the HTTP request.
+- `authModes` - a comma separated list of authentication modes to use. (Values: `bearer`, `tls`,`basic`, Default: `""`, Optional, `tls,bearer` or `tls,basic` are valid combinations and would indicate mutual TLS to secure the connection and then `bearer` or `basic` headers should be added to the HTTP request)
 
 ### Authentication Parameters
 

--- a/content/docs/2.9/scalers/pulsar.md
+++ b/content/docs/2.9/scalers/pulsar.md
@@ -33,7 +33,7 @@ triggers:
 
 ### Authentication Parameters
 
-  The `authModes` are specified on the `metadata` field of the `ScaledObject`, as shown above. The associated configuration parameters are specified in the `TriggerAuthentication` spec.  
+The authentication is defined in `authModes`. The associated configuration parameters are specified in the `TriggerAuthentication` spec.  
 
 **Bearer Auth**
 

--- a/content/docs/2.9/scalers/pulsar.md
+++ b/content/docs/2.9/scalers/pulsar.md
@@ -19,6 +19,7 @@ triggers:
     subscription: sub1
     msgBacklogThreshold: '5'
     activationMsgBacklogThreshold: '2'
+    authModes: ""
 ```
 
 **Parameter list:**
@@ -28,22 +29,42 @@ triggers:
 - `subscription` - Name of the topic subscription
 - `msgBacklogThreshold` - Average target value to trigger scaling actions. (default: 10)
 - `activationMsgBacklogThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
+- `authModes` - a comma separated list of authentication modes to use. Default `""`. Valid options are `bearer`, `tls`, and `basic`. Note that `tls,bearer` or `tls,basic` are valid combinations and would indicate mutual TLS to secure the connection and then `bearer` or `basic` headers should be added to the HTTP request.
 
 ### Authentication Parameters
 
-  If TLS is required you should set `tls` to `enable`. If required for your Pulsar configuration, you may also provide a `ca`, `cert` and `key`. `ca`, `cert` and `key` must be specified together.
+  The `authModes` are specified on the `metadata` field of the `ScaledObject`, as shown above. The associated configuration parameters are specified in the `TriggerAuthentication` spec.  
 
+**Bearer Auth**
+
+When configuring Bearer Authentication (Token Auth), configure the following:
+
+- `bearerToken`: This token will be sent as a header in the form `Authorization: Bearer <token>`. 
+
+**Basic Auth**
+When configuring Basic Authentication, configure the following:
+
+- `username`: the username
+- `password`: the password (optional)
 
 **TLS:**
 
-- `tls`: Optional. To enable SSL auth for Pulsar, set this to `enable`. If not set, TLS for Pulsar is not used, Your shoule set this key to trigger metadata.
-- `ca`: Certificate authority file for TLS client authentication. 
+When configuring mutual TLS authentication, configure the following:
+
+- `ca`: The trusted root Certificate authority used to validate the server's certificate.
 - `cert`: Certificate for client authentication.
 - `key`: Key for client authentication. 
 
-### Example
 
-Your pulsar cluster no TLS auth:
+### TLS with custom CA Certificates
+
+When configuring a trusted root CA that is not well known, it is sufficient to specify the `ca` field on the `TriggerAuthentication` resource. See [Bearer Token with TLS via custom trusted CA Certificate](#bearer-token-with-tls-via-custom-trusted-ca-certificate) for an example.
+
+Before 2.9.0, it was necessary to configure `tls: enable` on the `ScaledObject`. That was removed in a backwards compatible way, so you can remove that field now.
+
+### Examples
+
+#### No Authentication and No TLS
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -64,7 +85,7 @@ spec:
       msgBacklogThreshold: '5'
 ```
 
-Your pulsar cluster turn on TLS auth:
+#### Only Mutual TLS Authentication
 
 ```yaml
 apiVersion: v1
@@ -106,8 +127,110 @@ spec:
   triggers:
   - type: pulsar
     metadata:
-      tls: "enable"
+      authModes: "tls"
       adminURL: https://localhost:8443
+      topic: persistent://public/default/my-topic
+      subscription: sub1
+      msgBacklogThreshold: '5'
+    authenticationRef:
+      name:  keda-trigger-auth-pulsar-credential
+```
+
+#### Bearer Token with TLS via custom trusted CA Certificate
+
+In order to enable Pulsar's Token Authentication feature, you can use the following example. Note that this example
+also utilizes a custom CA Certificate for TLS support. Because TLS Authentication is not used in this example, the
+`authModes` field only has `bearer`.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-pulsar-secrets
+  namespace: default
+data:
+  ca: <your self signed root CA>
+  token: <your token>
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-pulsar-credential
+  namespace: default
+spec:
+  secretTargetRef:
+  - parameter: ca
+    name: keda-pulsar-secrets
+    key: ca
+  - parameter: bearerToken
+    name: keda-pulsar-secrets
+    key: token
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: pulsar-scaledobject
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: pulsar-consumer
+  pollingInterval: 30
+  triggers:
+  - type: pulsar
+    metadata:
+      authModes: "bearer"
+      adminURL: https://localhost:8443
+      topic: persistent://public/default/my-topic
+      subscription: sub1
+      msgBacklogThreshold: '5'
+    authenticationRef:
+      name:  keda-trigger-auth-pulsar-credential
+```
+
+#### Basic Auth with TLS Relying on Well Known Root CA
+
+In order to enable Pulsar's Token Authentication feature, you can use the following example. Note that this example
+also utilizes a custom CA Certificate for TLS support. Because TLS Authentication is not used in this example, the
+`authModes` field only has `bearer`.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-pulsar-secrets
+  namespace: default
+data:
+  username: <your username>
+  password: <your password>
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-pulsar-credential
+  namespace: default
+spec:
+  secretTargetRef:
+  - parameter: username
+    name: keda-pulsar-secrets
+    key: admin
+  - parameter: password
+    name: keda-pulsar-secrets
+    key: password
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: pulsar-scaledobject
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: pulsar-consumer
+  pollingInterval: 30
+  triggers:
+  - type: pulsar
+    metadata:
+      authModes: "bearer"
+      adminURL: https://pulsar.com:8443
       topic: persistent://public/default/my-topic
       subscription: sub1
       msgBacklogThreshold: '5'


### PR DESCRIPTION
Document the new support for Bearer Token and Basic Auth Authentication methods.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda/issues/3844
Relates to https://github.com/kedacore/keda/pull/3845