### PR TITLE
fixing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Make sure to update the following metadata fields:
 * `description`
 
 ## Writing documentation for a new authentication provider
-To add documentation for a new [provider](https://keda.sh/docs/concept/authentication):
+To add documentation for a new [provider](https://keda.sh/docs/concepts/authentication):
 
 ```console
 $ hugo new --kind provider docs/<VERSION>/providers/my-new-provider.md


### PR DESCRIPTION
Signed-off-by: Adarsh-verma-14 <t_adarsh.verma@india.nec.com>

 wrong url for authentication providers.
The link should direct to -https://keda.sh/docs/concepts/authentication

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #991 
