### PR TITLE
Update documents to reference float64 for GCP pub sub and stackdriver

### DIFF
--- a/content/docs/2.9/scalers/gcp-pub-sub.md
+++ b/content/docs/2.9/scalers/gcp-pub-sub.md
@@ -26,7 +26,7 @@ The Google Cloud Platform‎ (GCP) Pub/Sub trigger allows you to scale based on 
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the required stack driver metrics in order to read the number of messages in the Pub/Sub subscription.
 
-- `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
+- `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
 `subscriptionName` defines the subscription that should be monitored. You can use different formulas:
 

--- a/content/docs/2.9/scalers/gcp-pub-sub.md
+++ b/content/docs/2.9/scalers/gcp-pub-sub.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     subscriptionSize: "5" # Deprecated, use mode and value fields instead
     mode: "SubscriptionSize" # Optional - Default is SubscriptionSize - SubscriptionSize or OldestUnackedMessageAge
-    value: "5" # Optional - Default is 5 for SubscriptionSize | Default is 10 for OldestUnackedMessageAge
-    activationValue: "10" # Optional - Default is 0
+    value: "5.5" # Optional - Default is 5 for SubscriptionSize | Default is 10 for OldestUnackedMessageAge
+    activationValue: "10.5" # Optional - Default is 0
     subscriptionName: "mysubscription" # Required
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
 ```

--- a/content/docs/2.9/scalers/gcp-stackdriver.md
+++ b/content/docs/2.9/scalers/gcp-stackdriver.md
@@ -16,8 +16,8 @@ triggers:
   metadata:
     projectId: my-project-id
     filter: 'metric.type="storage.googleapis.com/network/received_bytes_count" AND resource.type="gcs_bucket" AND metric.label.method="WriteObject" AND resource.label.bucket_name="my-gcp-bucket"'
-    targetValue: '100'
-    activationTargetValue: "10" # Optional - Default is 0
+    targetValue: '100.50'
+    activationTargetValue: "10.5" # Optional - Default is 0
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON
 ```
 
@@ -25,8 +25,8 @@ triggers:
 
 - `projectId` - GCP project Id that contains the metric.
 - `filter` - The stackdriver query filter for obtaining the metric. The metric is for the last minute and if multiple values are returned, the first one is used.
-- `targetValue` - Average target value to trigger scaling actions. (Default: `5`, Optional)
-- `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
+- `targetValue` - Average target value to trigger scaling actions. (Default: `5`, Optional, This value can be a float)
+- `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the configured stack driver metrics.
 


### PR DESCRIPTION
Signed-off-by: Eric Takemoto <24865872+octothorped@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Documentation of kedacore/keda#3788. `targetValue` and `activationTargetValue` can now be floats. The changes here are based on the Prometheus scalar documentation for its float values.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to kedacore/keda#3777