### PR TITLE
Fix identation error on ScaledObject definition

### DIFF
--- a/content/docs/2.8/scalers/new-relic.md
+++ b/content/docs/2.8/scalers/new-relic.md
@@ -99,6 +99,6 @@ spec:
         nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
         noDataError: "true"
         threshold: 1000
-        authenticationRef:
-          name: keda-trigger-auth-new-relic
+      authenticationRef:
+        name: keda-trigger-auth-new-relic
 ```


### PR DESCRIPTION
The authenticationRef parameter was wrongly configured as a child of metadata and causing the following error: error validating data: ValidationError(ScaledObject.spec.triggers[0].metadata.authenticationRef): invalid type for sh.keda.v1alpha1.ScaledObject.spec.triggers.metadata: got "map", expected "string"; if you choose to ignore these errors, turn validation off with --validate=false.

This new identation should fix the problem.

Signed-off-by: AJPG <85803236+1nvk3r@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
