### PR TITLE
Prometheus scaler: add more detail to clear about serverAddress field in case using VictoriaMetrics cluster version

### DIFF
--- a/content/docs/1.4/scalers/prometheus.md
+++ b/content/docs/1.4/scalers/prometheus.md
@@ -21,7 +21,7 @@ triggers:
     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m])) # Note: query must return a vector/scalar single element response
 ```
 
-The `serverAddress` indicates where Prometheus is running which contains the configured metric defined in `metricName` or `query`.
+The `serverAddress` indicates where Prometheus is running which contains the configured metric defined in `metricName` or `query`. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 
 ### Authentication Parameters
 

--- a/content/docs/1.5/scalers/prometheus.md
+++ b/content/docs/1.5/scalers/prometheus.md
@@ -21,7 +21,7 @@ triggers:
     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m])) # Note: query must return a vector/scalar single element response
 ```
 
-The `serverAddress` indicates where Prometheus is running which contains the configured metric defined in `metricName` or `query`.
+The `serverAddress` indicates where Prometheus is running which contains the configured metric defined in `metricName` or `query`. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 
 ### Authentication Parameters
 

--- a/content/docs/2.0/scalers/prometheus.md
+++ b/content/docs/2.0/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus.
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Metric name to use.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.1/scalers/prometheus.md
+++ b/content/docs/2.1/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus.
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Metric name to use.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.10/scalers/prometheus.md
+++ b/content/docs/2.10/scalers/prometheus.md
@@ -29,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus. server
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for. (This value can be a float)

--- a/content/docs/2.2/scalers/prometheus.md
+++ b/content/docs/2.2/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus.
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Metric name to use.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.3/scalers/prometheus.md
+++ b/content/docs/2.3/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus.
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Metric name to use.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.4/scalers/prometheus.md
+++ b/content/docs/2.4/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus.
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Metric name to use.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.5/scalers/prometheus.md
+++ b/content/docs/2.5/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus. server
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.6/scalers/prometheus.md
+++ b/content/docs/2.6/scalers/prometheus.md
@@ -25,7 +25,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus. server
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.7/scalers/prometheus.md
+++ b/content/docs/2.7/scalers/prometheus.md
@@ -26,7 +26,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus. server
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for.

--- a/content/docs/2.8/scalers/prometheus.md
+++ b/content/docs/2.8/scalers/prometheus.md
@@ -28,7 +28,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus. server
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for. (This value can be a float)

--- a/content/docs/2.9/scalers/prometheus.md
+++ b/content/docs/2.9/scalers/prometheus.md
@@ -29,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `serverAddress` - Address of Prometheus. server
+- `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
 - `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
 - `query` - Query to run.
 - `threshold` - Value to start scaling for. (This value can be a float)


### PR DESCRIPTION
Signed-off-by: Khanh Pham <mrpk1906@gmail.com>

This PR add more detail to clear about `serverAddress` field in case using VictoriaMetrics cluster version.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes [#4078](https://github.com/kedacore/keda/issues/4078)
