### PR TITLE
Add tls auth doc for rabbitmq scaler (#967)

### DIFF
--- a/content/docs/2.10/scalers/rabbitmq-queue.md
+++ b/content/docs/2.10/scalers/rabbitmq-queue.md
@@ -68,7 +68,7 @@ TriggerAuthentication CRD is used to connect and authenticate to RabbitMQ:
 
 > See the [RabbitMQ Ports](https://www.rabbitmq.com/networking.html#ports) section for more details on how to configure the ports.
 
-**TLS:**
+**TLS authentication:**
 
 - `tls` - To enable SSL auth for RabbitMQ, set this to `enable`. If not set, TLS for RabbitMQ is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
 - `ca` - Certificate authority file for TLS client authentication. (Optional)


### PR DESCRIPTION
Signed-off-by: Abhishek Mohite <b518004@iiit-bh.ac.in>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added tls parameters like tls, ca, cert etc. in rabbitmq-queue.md to support the new tls support for the keda issue [967](https://github.com/kedacore/keda/issues/967).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
