### PR TITLE
Include platformName to selenium-grid scaler documentation 

### DIFF
--- a/content/docs/2.10/scalers/selenium-grid-scaler.md
+++ b/content/docs/2.10/scalers/selenium-grid-scaler.md
@@ -23,6 +23,7 @@ triggers:
       browserVersion: '91.0' # Optional. Only required when supporting multiple versions of browser in your Selenium Grid.
       unsafeSsl : 'true' # Optional
       activationThreshold: 5 # Optional
+      platformName: 'Linux' # Optional
 ```
 
 **Parameter list:**
@@ -33,6 +34,7 @@ triggers:
 - `browserVersion` - Version of browser that usually gets passed in the browser capability. Refer to the [Selenium Grid's](https://www.selenium.dev/documentation/en/getting_started_with_webdriver/browsers/) and [WebdriverIO's](https://webdriver.io/docs/options/#capabilities) documentation for more info. (Optional)
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
+- `platformName` - Name of the browser platform. Refer to the [Selenium Grid's](https://www.selenium.dev/documentation/en/getting_started_with_webdriver/browsers/) and [WebdriverIO's](https://webdriver.io/docs/options/#capabilities) documentation for more info. (Default: `Linux`, Optional)
 
 ### Example
 


### PR DESCRIPTION
Included the description of the newly added selenium grid scaler metadata property: platformName.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to [kedacore/keda#4038](https://github.com/kedacore/keda/pull/4038)
