### PR TITLE
2.9: expose `keda_scaled_object_errors` metric from the operator

### DIFF
--- a/content/docs/2.9/operate/prometheus.md
+++ b/content/docs/2.9/operate/prometheus.md
@@ -13,7 +13,7 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.
 - `keda_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_scaler_error_totals` - The total number of errors encountered for all scalers.
-- `keda_scaled_object_error_totals`- The number of errors that have occurred for each ScaledObejct.
+- `keda_scaled_object_errors`- The number of errors that have occurred for each ScaledObejct.
 - `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD).
 - `keda_trigger_totals` - Total number of triggers per trigger type.
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates https://github.com/kedacore/keda/issues/4116
