### PR TITLE
Update troubleshooting section for (EKS) cluster to keda server timeout

### DIFF
--- a/content/troubleshooting/proxy-network.md
+++ b/content/troubleshooting/proxy-network.md
@@ -11,7 +11,7 @@ If while setting up KEDA, you get an error: `(v1beta1.external.metrics.k8s.io) s
 
 - Make sure no network policies are blocking traffic
 
-### Check the status:
+### Check the status
 
 Find the api service name for the service `keda/keda-metrics-apiserver`:
 
@@ -33,7 +33,7 @@ kubectl get apiservice v1beta1.external.metrics.k8s.io -o yaml
 
 If the status is `False`, then there seems to be an issue and proxy network might be the primary reason for it.
 
-### Solution for self-managed Kubernetes cluster:
+### Solution for self-managed Kubernetes cluster
 
 Find the cluster IP for the `keda-metrics-apiserver` and `keda-operator-metrics`:
 
@@ -57,8 +57,32 @@ sudo systemctl restart kubelet
 
 Check the API service status and the pods now. Should work!
 
-### Solution for managed Kubernetes services:
+### Solution for managed Kubernetes services
 
-In managed Kubernetes services you might solve the issue by updating firewall rules in your cluster. 
+In managed Kubernetes services you might solve the issue by updating firewall rules in your cluster.
+
+#### GKE
 
 E.g. in GKE private cluster [add](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules) port 6443 (kube-apiserver) to allowed ports in master node firewall rules.
+
+#### EKS
+
+E.g. Make sure the Cluster Security group can reach the Nodegroups on TCP 6443. For example, using the [terraform eks module](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest), this is achievable through the addtional nodegroup rules
+
+```terraform
+module "eks" {
+  source                               = "terraform-aws-modules/eks/aws"
+  version                              = "19.5.1"
+  ...
+  create_node_security_group = true
+  node_security_group_additional_rules = {
+    keda_metrics_server_access = {
+      description                   = "Cluster access to keda metrics"
+      protocol                      = "tcp"
+      from_port                     = 6443
+      to_port                       = 6443
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }
+```

--- a/content/troubleshooting/proxy-network.md
+++ b/content/troubleshooting/proxy-network.md
@@ -65,7 +65,7 @@ In managed Kubernetes services you might solve the issue by updating firewall ru
 
 E.g. in GKE private cluster [add](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules) port 6443 (kube-apiserver) to allowed ports in master node firewall rules.
 
-#### EKS
+#### Amazon Elastic Kubernetes Service (EKS)
 
 E.g. Make sure the Cluster Security group can reach the Nodegroups on TCP 6443. For example, using the [terraform eks module](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest), this is achievable through the addtional nodegroup rules
 

--- a/content/troubleshooting/proxy-network.md
+++ b/content/troubleshooting/proxy-network.md
@@ -61,7 +61,7 @@ Check the API service status and the pods now. Should work!
 
 In managed Kubernetes services you might solve the issue by updating firewall rules in your cluster.
 
-#### GKE
+#### Google Kubernetes Engine (GKE)
 
 E.g. in GKE private cluster [add](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules) port 6443 (kube-apiserver) to allowed ports in master node firewall rules.
 


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #

 - Adding EKS security group troubleshooting section
 - Structuring different cloud providers by a heading 

Signed-off-by: Stephen Attard <stephenattard86@gmail.com>
