### PR TITLE
Add note about vault secrets backend version support

### DIFF
--- a/content/docs/2.10/authentication-providers/hashicorp-vault.md
+++ b/content/docs/2.10/authentication-providers/hashicorp-vault.md
@@ -8,6 +8,9 @@ You can pull one or more Hashicorp Vault secrets into the trigger by defining th
 `secrets` list defines the mapping between the path and the key of the secret in Vault to the parameter.
 `namespace` may be used to target a given Vault Enterprise namespace.
 
+> Since version `1.5.0` Vault secrets backend **version 2** is supported. 
+> The support for Vault secrets backend **version 1** was added on version `2.10`.
+
 ```yaml
 hashiCorpVault:                                     # Optional.
   address: {hashicorp-vault-address}                # Required.


### PR DESCRIPTION
Added a note about Hashicorp vault secrets backend version support.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to kedacore/keda#4152

Have a wonderful day,
Best reguards.
