### PR TITLE
fix: Prometheus metric is `scaler_errors_total` and not `scaler_error_totals`

### DIFF
--- a/content/docs/2.0/operate/prometheus.md
+++ b/content/docs/2.0/operate/prometheus.md
@@ -10,7 +10,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.1/operate/prometheus.md
+++ b/content/docs/2.1/operate/prometheus.md
@@ -10,7 +10,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.10/operate/prometheus.md
+++ b/content/docs/2.10/operate/prometheus.md
@@ -14,7 +14,7 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_scaler_metrics_value` - The current value for each scaler's metric that would be used by the HPA in computing the target average.
 - `keda_scaler_metrics_latency` - The latency of retrieving current metric from each scaler.
 - `keda_scaler_errors` - The number of errors that have occurred for each scaler.
-- `keda_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_scaled_object_errors` - The number of errors that have occurred for each ScaledObejct.
 - `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD).
 - `keda_trigger_totals` - Total number of triggers per trigger type.
@@ -35,7 +35,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.2/operate/prometheus.md
+++ b/content/docs/2.2/operate/prometheus.md
@@ -10,7 +10,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.3/operate/prometheus.md
+++ b/content/docs/2.3/operate/prometheus.md
@@ -10,7 +10,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.4/operate/prometheus.md
+++ b/content/docs/2.4/operate/prometheus.md
@@ -10,7 +10,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.5/operate/prometheus.md
+++ b/content/docs/2.5/operate/prometheus.md
@@ -18,7 +18,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.6/operate/prometheus.md
+++ b/content/docs/2.6/operate/prometheus.md
@@ -18,7 +18,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.7/operate/prometheus.md
+++ b/content/docs/2.7/operate/prometheus.md
@@ -18,7 +18,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.8/operate/prometheus.md
+++ b/content/docs/2.8/operate/prometheus.md
@@ -18,7 +18,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.

--- a/content/docs/2.9/operate/prometheus.md
+++ b/content/docs/2.9/operate/prometheus.md
@@ -12,7 +12,7 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 - `keda_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.
 - `keda_scaler_errors` - The number of errors that have occurred for each scaler.
-- `keda_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_scaled_object_errors`- The number of errors that have occurred for each ScaledObejct.
 - `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD).
 - `keda_trigger_totals` - Total number of triggers per trigger type.
@@ -26,7 +26,7 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 The following metrics are being gathered:
 
-- `keda_metrics_adapter_scaler_error_totals` - The total number of errors encountered for all scalers.
+- `keda_metrics_adapter_scaler_errors_total` - The total number of errors encountered for all scalers.
 - `keda_metrics_adapter_scaled_object_error_totals`- The number of errors that have occurred for each scaled object.
 - `keda_metrics_adapter_scaler_errors` - The number of errors that have occurred for each scaler.
 - `keda_metrics_adapter_scaler_metrics_value`- The current value for each scaler's metric that would be used by the HPA in computing the target average.


### PR DESCRIPTION
I have noticed that the `*_scaler_error_totals` isn't correct because in the code (for all the versions) is `*_scaler_errors_total`
For example, in [v2.0](https://github.com/kedacore/keda/blob/v2.0.0/pkg/metrics/prometheus_metrics.go#L18) or [v2.10](https://github.com/kedacore/keda/blob/main/pkg/prommetrics/prommetrics.go#L44)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


