### PR TITLE
chore: link the new section for using certificates in ms

### DIFF
--- a/content/docs/2.10/operate/cluster.md
+++ b/content/docs/2.10/operate/cluster.md
@@ -149,7 +149,7 @@ To specify values other than their defaults, you can set the following environme
 
 ## Certificates used by KEDA Metrics Server
 
-This information has been moved to [security section](./security#use-your-own-tls-certificates)
+To learn more please refer to [security section](./security#use-your-own-tls-certificates)
 
 ## Restrict Secret Access
 

--- a/content/docs/2.10/operate/cluster.md
+++ b/content/docs/2.10/operate/cluster.md
@@ -149,38 +149,7 @@ To specify values other than their defaults, you can set the following environme
 
 ## Certificates used by KEDA Metrics Server
 
-By default KEDA Metrics Server uses self signed certificates while communicating with Kubernetes API Server. It is recommended to provide own (trusted) certificates instead.
-
-Certificates and CA bundle can be referenced in `args` section in KEDA Metrics Server Deployment:
-
-```yaml
-...
-args:
-  - '--client-ca-file=/cabundle/service-ca.crt'
-  - '--tls-cert-file=/certs/tls.crt'
-  - '--tls-private-key-file=/certs/tls.key'
-...
-```
-
-The custom CA bundle should be also referenced in the `v1beta1.external.metrics.k8s.io` [APIService](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/api-service-v1/#APIServiceSpec) resource (which is created during the installation of KEDA). 
-
-You should also make sure that `insecureSkipTLSVerify` is not set to `true`.
-
-```yaml
-...
-spec:
-  service:
-    namespace: keda
-    name: keda-metrics-apiserver
-    port: 443
-  group: external.metrics.k8s.io
-  version: v1beta1
-  caBundle: >-
-    YOURCABUNDLE...
-  groupPriorityMinimum: 100
-  versionPriority: 100
-...
-```
+This information has been moved to [security section](./security#use-your-own-tls-certificates)
 
 ## Restrict Secret Access
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

I have noticed that the certificate information is also in cluster section. As we have created a specific section for security where it's explained how to manage certificates, I think that adding a link to there is better than explaining how to do it in both places.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

