### PR TITLE
Fix elastic docs "params" to "parametrs"

### DIFF
--- a/content/docs/2.10/scalers/elasticsearch.md
+++ b/content/docs/2.10/scalers/elasticsearch.md
@@ -21,7 +21,7 @@ triggers:
       passwordFromEnv: "ELASTIC_PASSWORD"
       index: "my-index"
       searchTemplateName: "my-search-template-name"
-      params: "param1:value1;param2:value2"
+      parameters: "param1:value1;param2:value2"
       valueLocation: "hits.total.value"
       targetValue: "1.1"
       activationTargetValue: "5.5"

--- a/content/docs/2.5/scalers/elasticsearch.md
+++ b/content/docs/2.5/scalers/elasticsearch.md
@@ -21,7 +21,7 @@ triggers:
       passwordFromEnv: "ELASTIC_PASSWORD"
       index: "my-index"
       searchTemplateName: "my-search-template-name"
-      params: "param1:value1;param2:value2"
+      parameters: "param1:value1;param2:value2"
       valueLocation: "hits.total.value"
       targetValue: "1"
 ```

--- a/content/docs/2.6/scalers/elasticsearch.md
+++ b/content/docs/2.6/scalers/elasticsearch.md
@@ -21,7 +21,7 @@ triggers:
       passwordFromEnv: "ELASTIC_PASSWORD"
       index: "my-index"
       searchTemplateName: "my-search-template-name"
-      params: "param1:value1;param2:value2"
+      parameters: "param1:value1;param2:value2"
       valueLocation: "hits.total.value"
       targetValue: "1"
 ```

--- a/content/docs/2.7/scalers/elasticsearch.md
+++ b/content/docs/2.7/scalers/elasticsearch.md
@@ -21,7 +21,7 @@ triggers:
       passwordFromEnv: "ELASTIC_PASSWORD"
       index: "my-index"
       searchTemplateName: "my-search-template-name"
-      params: "param1:value1;param2:value2"
+      parameters: "param1:value1;param2:value2"
       valueLocation: "hits.total.value"
       targetValue: "1"
 ```

--- a/content/docs/2.8/scalers/elasticsearch.md
+++ b/content/docs/2.8/scalers/elasticsearch.md
@@ -21,7 +21,7 @@ triggers:
       passwordFromEnv: "ELASTIC_PASSWORD"
       index: "my-index"
       searchTemplateName: "my-search-template-name"
-      params: "param1:value1;param2:value2"
+      parameters: "param1:value1;param2:value2"
       valueLocation: "hits.total.value"
       targetValue: "1.1"
       activationTargetValue: "5.5"

--- a/content/docs/2.9/scalers/elasticsearch.md
+++ b/content/docs/2.9/scalers/elasticsearch.md
@@ -21,7 +21,7 @@ triggers:
       passwordFromEnv: "ELASTIC_PASSWORD"
       index: "my-index"
       searchTemplateName: "my-search-template-name"
-      params: "param1:value1;param2:value2"
+      parameters: "param1:value1;param2:value2"
       valueLocation: "hits.total.value"
       targetValue: "1.1"
       activationTargetValue: "5.5"


### PR DESCRIPTION
Fix Elasticsearch scaler yaml examlple.
there was field "params" which should be "parameters".
Fixed in all version that support elasticsearch scaler
Thanks #[JorTurFer](https://github.com/JorTurFer)


