### PR TITLE
Provide the minimal IAM policy needed for AWS SQS

### DIFF
--- a/content/docs/2.9/scalers/aws-sqs.md
+++ b/content/docs/2.9/scalers/aws-sqs.md
@@ -65,6 +65,21 @@ You can use `TriggerAuthentication` CRD to configure the authenticate by providi
 
 The user will need access to read properties from the specified AWS SQS queue.
 
+This is the minimal policy needed by the operator to read properties of a specific SQS queue :
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "sqs:GetQueueAttributes",
+            "Resource": "<SQS_QUEUE_ARN>"
+        }
+    ]
+}
+```
+
 ### Example
 
 #### Scaling a deployment using podIdentity providers


### PR DESCRIPTION
Signed-off-by: Guillaume Dupin <gdupin@gmail.com>

When we wanted to test KEDA scaling with AWS SQS queue, we did not find immedeately the necessary IAM policy. 
This PR adds to the documentation the minimal IAM policy needed by keda operator (and metrics-server ?) to scale applications based on AWS SQS Queue.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
