### PR TITLE
Deprecate explicitly setting `metricName` for all scalers

### DIFF
--- a/content/docs/2.10/scalers/azure-log-analytics.md
+++ b/content/docs/2.10/scalers/azure-log-analytics.md
@@ -67,7 +67,7 @@ triggers:
 - `query` - Log Analytics [kusto](https://docs.microsoft.com/en-us/azure/azure-monitor/log-query/get-started-queries) query, JSON escaped. You can use [this](https://www.freeformatter.com/json-escape.html) tool to convert your query from Log Analytics query editor to JSON escaped string, and then review YAML specific escapes.
 - `threshold` - Value that is used as a threshold to calculate # of pods for scale target. (This value can be a float)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `metricName` - Name to assign to the metric. (Optional, if not set KEDA will generate a name based on the workspaceId)
+- `metricName` - Name to assign to the metric. (Optional, if not set KEDA will generate a name based on the workspaceId. DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 - `cloud` - Name of the cloud environment that the Azure Log Analytics workspace belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `logAnalyticsResourceURL` - Log Analytics REST API URL of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `https://api.loganalytics.azure.cn/` for `AzureChinaCloud`).
 - `activeDirectoryEndpoint` - Active Directory endpoint of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `https://login.chinacloudapi.cn/` for `AzureChinaCloud`).

--- a/content/docs/2.10/scalers/azure-log-analytics.md
+++ b/content/docs/2.10/scalers/azure-log-analytics.md
@@ -67,7 +67,7 @@ triggers:
 - `query` - Log Analytics [kusto](https://docs.microsoft.com/en-us/azure/azure-monitor/log-query/get-started-queries) query, JSON escaped. You can use [this](https://www.freeformatter.com/json-escape.html) tool to convert your query from Log Analytics query editor to JSON escaped string, and then review YAML specific escapes.
 - `threshold` - Value that is used as a threshold to calculate # of pods for scale target. (This value can be a float)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `metricName` - Name to assign to the metric. (Optional, if not set KEDA will generate a name based on the workspaceId. DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name to assign to the metric. (Optional, if not set KEDA will generate a name based on the workspaceId. DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 - `cloud` - Name of the cloud environment that the Azure Log Analytics workspace belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `logAnalyticsResourceURL` - Log Analytics REST API URL of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `https://api.loganalytics.azure.cn/` for `AzureChinaCloud`).
 - `activeDirectoryEndpoint` - Active Directory endpoint of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `https://login.chinacloudapi.cn/` for `AzureChinaCloud`).

--- a/content/docs/2.10/scalers/azure-monitor.md
+++ b/content/docs/2.10/scalers/azure-monitor.md
@@ -18,7 +18,7 @@ triggers:
     tenantId: xxx-xxx-xxx-xxx-xxx
     subscriptionId: yyy-yyy-yyy-yyy-yyy
     resourceGroupName: azureMonitor
-    metricName: kube_pod_status_ready # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+    metricName: kube_pod_status_ready # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
     metricFilter: namespace eq 'default'
     metricAggregationInterval: "0:1:0"
     targetValue: "0.5"
@@ -40,7 +40,7 @@ triggers:
 - `tenantId` - Id of the tenant that contains the Azure resource. This is used for authentication.
 - `subscriptionId` - Id of Azure subscription that contains the Azure resource. This is used for determining the full resource URI.
 - `resourceGroupName` - Name of the resource group for the Azure resource.
-- `metricName` - Name of the metric to query. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name of the metric to query. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
   - Azure metrics are available as a list in the [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported).
   - Custom metric name when querying Azure Monitor [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-custom-overview).
 - `metricNamespace` - Name of the metric namespace.
@@ -117,7 +117,7 @@ spec:
       tenantId: xxx-xxx-xxx-xxx-xxx
       subscriptionId: yyy-yyy-yyy-yyy-yyy
       resourceGroupName: azureMonitor
-      metricName: pod_custom_metric # DEPRECATED: This parameter will be removed in version `2.12`, don't set it
+      metricName: pod_custom_metric # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`
       metricNamespace: pod_custom_metrics_namespace
       metricFilter: namespace eq 'default'
       metricAggregationInterval: "0:1:0"

--- a/content/docs/2.10/scalers/azure-monitor.md
+++ b/content/docs/2.10/scalers/azure-monitor.md
@@ -18,7 +18,7 @@ triggers:
     tenantId: xxx-xxx-xxx-xxx-xxx
     subscriptionId: yyy-yyy-yyy-yyy-yyy
     resourceGroupName: azureMonitor
-    metricName: kube_pod_status_ready
+    metricName: kube_pod_status_ready # DEPRECATED: This parameter will be removed in version 2.12, don't set it
     metricFilter: namespace eq 'default'
     metricAggregationInterval: "0:1:0"
     targetValue: "0.5"
@@ -40,10 +40,10 @@ triggers:
 - `tenantId` - Id of the tenant that contains the Azure resource. This is used for authentication.
 - `subscriptionId` - Id of Azure subscription that contains the Azure resource. This is used for determining the full resource URI.
 - `resourceGroupName` - Name of the resource group for the Azure resource.
-- `metricName` - Name of the metric to query.
+- `metricName` - Name of the metric to query. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
   - Azure metrics are available as a list in the [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported).
   - Custom metric name when querying Azure Monitor [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-custom-overview).
-- `metricNamespace` - Name of the metric namespace. Required when `metricName` is a custom metric.
+- `metricNamespace` - Name of the metric namespace.
 - `targetValue` - Target value to trigger scaling actions. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 - `metricAggregationType` - Aggregation method of the Azure Monitor metric. Options include `Average`, `Total`, `Maximum` with a full list in the [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported).
@@ -117,8 +117,8 @@ spec:
       tenantId: xxx-xxx-xxx-xxx-xxx
       subscriptionId: yyy-yyy-yyy-yyy-yyy
       resourceGroupName: azureMonitor
-      metricName: pod_custom_metric
-      metricNamespace: pod_custom_metrics_namespace # required when monitoring custom metrics
+      metricName: pod_custom_metric # DEPRECATED: This parameter will be removed in version `2.12`, don't set it
+      metricNamespace: pod_custom_metrics_namespace
       metricFilter: namespace eq 'default'
       metricAggregationInterval: "0:1:0"
       metricAggregationType: Average

--- a/content/docs/2.10/scalers/azure-storage-blob.md
+++ b/content/docs/2.10/scalers/azure-storage-blob.md
@@ -44,7 +44,7 @@ as metric value. (Default: `""`, Optional, The `blobPrefix`, `blobDelimiter` and
 
 When `cloud` is set to `Private`, the `endpointSuffix` parameter is required. Otherwise, it is automatically generated based on the cloud environment. `endpointSuffix` represents the storage blob endpoint suffix of the cloud environment that the blob belongs to, e.g. `blob.core.cloudapi.de` for `AzureGermanCloud`.
 
-You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on the trigger index and `blobContainerName`. For example: **s0-azure-blob-blobContainerName**. The value will be prefixed with `s{triggerIndex}-azure-blob-`.
+You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on the trigger index and `blobContainerName`. For example: **s0-azure-blob-blobContainerName**. The value will be prefixed with `s{triggerIndex}-azure-blob-`. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 
 ### Authentication Parameters
 

--- a/content/docs/2.10/scalers/azure-storage-blob.md
+++ b/content/docs/2.10/scalers/azure-storage-blob.md
@@ -44,7 +44,7 @@ as metric value. (Default: `""`, Optional, The `blobPrefix`, `blobDelimiter` and
 
 When `cloud` is set to `Private`, the `endpointSuffix` parameter is required. Otherwise, it is automatically generated based on the cloud environment. `endpointSuffix` represents the storage blob endpoint suffix of the cloud environment that the blob belongs to, e.g. `blob.core.cloudapi.de` for `AzureGermanCloud`.
 
-You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on the trigger index and `blobContainerName`. For example: **s0-azure-blob-blobContainerName**. The value will be prefixed with `s{triggerIndex}-azure-blob-`. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on the trigger index and `blobContainerName`. For example: **s0-azure-blob-blobContainerName**. The value will be prefixed with `s{triggerIndex}-azure-blob-`. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 
 ### Authentication Parameters
 

--- a/content/docs/2.10/scalers/cassandra.md
+++ b/content/docs/2.10/scalers/cassandra.md
@@ -23,7 +23,7 @@ triggers:
       query: "SELECT COUNT(*) FROM test_keyspace.test_table;"
       targetQueryValue: "1"
       activationTargetQueryValue: "10"
-      metricName: "test_keyspace"
+      metricName: "test_keyspace" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
 ```
 
 **Parameter list:**
@@ -37,7 +37,7 @@ triggers:
 - `query` - A Cassandra query that should return single numeric value.
 - `targetQueryValue` - The threshold value that is provided by the user and used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA).
 - `activationTargetQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
-- `metricName` - Name to assign to the metric. (Default: `s<X>-cassandra-<KEYSPACE>`, Optional, In case of `metricName` is specified, it will be used to generate the `metricName` like this: `s<X>-cassandra-<METRICNAME>`, where `<X>` is the index of the trigger in a ScaledObject)
+- `metricName` - Name to assign to the metric. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it. Default: `s<X>-cassandra-<KEYSPACE>`, Optional, In case of `metricName` is specified, it will be used to generate the `metricName` like this: `s<X>-cassandra-<METRICNAME>`, where `<X>` is the index of the trigger in a ScaledObject)
 
 ### Authentication Parameters
 
@@ -85,7 +85,7 @@ spec:
       protocolVersion: "4"
       query: "SELECT COUNT(*) FROM test_keyspace.test_table;"
       targetQueryValue: "1"
-      metricName: "test_keyspace"
+      metricName: "test_keyspace" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
     authenticationRef:
       name: keda-trigger-auth-cassandra-secret
 ```

--- a/content/docs/2.10/scalers/cassandra.md
+++ b/content/docs/2.10/scalers/cassandra.md
@@ -23,7 +23,7 @@ triggers:
       query: "SELECT COUNT(*) FROM test_keyspace.test_table;"
       targetQueryValue: "1"
       activationTargetQueryValue: "10"
-      metricName: "test_keyspace" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+      metricName: "test_keyspace" # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
 ```
 
 **Parameter list:**
@@ -37,7 +37,7 @@ triggers:
 - `query` - A Cassandra query that should return single numeric value.
 - `targetQueryValue` - The threshold value that is provided by the user and used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA).
 - `activationTargetQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
-- `metricName` - Name to assign to the metric. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it. Default: `s<X>-cassandra-<KEYSPACE>`, Optional, In case of `metricName` is specified, it will be used to generate the `metricName` like this: `s<X>-cassandra-<METRICNAME>`, where `<X>` is the index of the trigger in a ScaledObject)
+- `metricName` - Name to assign to the metric. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. Default: `s<X>-cassandra-<KEYSPACE>`, Optional, In case of `metricName` is specified, it will be used to generate the `metricName` like this: `s<X>-cassandra-<METRICNAME>`, where `<X>` is the index of the trigger in a ScaledObject)
 
 ### Authentication Parameters
 
@@ -85,7 +85,7 @@ spec:
       protocolVersion: "4"
       query: "SELECT COUNT(*) FROM test_keyspace.test_table;"
       targetQueryValue: "1"
-      metricName: "test_keyspace" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+      metricName: "test_keyspace" # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
     authenticationRef:
       name: keda-trigger-auth-cassandra-secret
 ```

--- a/content/docs/2.10/scalers/couchdb.md
+++ b/content/docs/2.10/scalers/couchdb.md
@@ -88,7 +88,7 @@ spec:
       queryValue: "1"
       query: '{ "selector": { "feet": { "$gt": 0 } }, "fields": ["_id", "feet", "greeting"] }'
       activationQueryValue: "1"
-      metricName: "global-metric"
+      metricName: "global-metric" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
     authenticationRef:
       name: keda-trigger-auth-couchdb-secret
 ```

--- a/content/docs/2.10/scalers/couchdb.md
+++ b/content/docs/2.10/scalers/couchdb.md
@@ -88,7 +88,7 @@ spec:
       queryValue: "1"
       query: '{ "selector": { "feet": { "$gt": 0 } }, "fields": ["_id", "feet", "greeting"] }'
       activationQueryValue: "1"
-      metricName: "global-metric" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+      metricName: "global-metric" # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
     authenticationRef:
       name: keda-trigger-auth-couchdb-secret
 ```

--- a/content/docs/2.10/scalers/graphite.md
+++ b/content/docs/2.10/scalers/graphite.md
@@ -16,7 +16,7 @@ triggers:
   metadata:
     # Required
     serverAddress: http://<graphite-host>:81
-    metricName: request-count # Note: name to identify the metric, DEPRECATED: This parameter will be removed in version 2.12, don't set it
+    metricName: request-count # Note: name to identify the metric, DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
     query: stats.counters.http.hello-world.request.count.count # Note: query must return a vector/scalar single element response
     threshold: '10.5'
     activationThreshold: '5'
@@ -25,7 +25,7 @@ triggers:
 **Parameter list:**
 
 - `serverAddress` - Address of Graphite
-- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 - `query` - Query to run.
 - `threshold` - Target value to trigger scaling actions. (Default: 100, Optional, This value can be a float)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
@@ -55,7 +55,7 @@ spec:
   - type: graphite
     metadata:
       serverAddress: http://<graphite-host>:81
-      metricName: LagMetric # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+      metricName: LagMetric # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
       threshold: '100'
       query: maxSeries(keepLastValue(reportd.*.gauge.detect.latest_max_time.value, 1))
       queryTime: '-1Minutes'
@@ -105,7 +105,7 @@ spec:
   - type: graphite
     metadata:
       authMode: "basic"
-      metricName: https_metric # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+      metricName: https_metric # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
       query: https_metric
       queryTime: -1Hours
       serverAddress: http://<graphite server>:81

--- a/content/docs/2.10/scalers/graphite.md
+++ b/content/docs/2.10/scalers/graphite.md
@@ -16,7 +16,7 @@ triggers:
   metadata:
     # Required
     serverAddress: http://<graphite-host>:81
-    metricName: request-count # Note: name to identify the metric
+    metricName: request-count # Note: name to identify the metric, DEPRECATED: This parameter will be removed in version 2.12, don't set it
     query: stats.counters.http.hello-world.request.count.count # Note: query must return a vector/scalar single element response
     threshold: '10.5'
     activationThreshold: '5'
@@ -25,7 +25,7 @@ triggers:
 **Parameter list:**
 
 - `serverAddress` - Address of Graphite
-- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique
+- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 - `query` - Query to run.
 - `threshold` - Target value to trigger scaling actions. (Default: 100, Optional, This value can be a float)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
@@ -55,7 +55,7 @@ spec:
   - type: graphite
     metadata:
       serverAddress: http://<graphite-host>:81
-      metricName: LagMetric
+      metricName: LagMetric # DEPRECATED: This parameter will be removed in version 2.12, don't set it
       threshold: '100'
       query: maxSeries(keepLastValue(reportd.*.gauge.detect.latest_max_time.value, 1))
       queryTime: '-1Minutes'
@@ -105,7 +105,7 @@ spec:
   - type: graphite
     metadata:
       authMode: "basic"
-      metricName: https_metric
+      metricName: https_metric # DEPRECATED: This parameter will be removed in version 2.12, don't set it
       query: https_metric
       queryTime: -1Hours
       serverAddress: http://<graphite server>:81

--- a/content/docs/2.10/scalers/influxdb.md
+++ b/content/docs/2.10/scalers/influxdb.md
@@ -25,7 +25,7 @@ triggers:
         |> filter(fn: (r) => r._measurement == "stat")
       authToken: some-auth-token
       authTokenFromEnv: INFLUXDB_AUTH_TOKEN # Optional: You can use this instead of `authToken` parameter. See details in "Parameter List" section
-      metricName: influx-metric # Optional: This value will default to organization name if not set by the user (metrics name value would be then `influxdb-influx_org`)
+      metricName: influx-metric # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. Optional: This value will default to organization name if not set by the user (metrics name value would be then `influxdb-influx_org`)
 ```
 
 **Parameter list:**
@@ -38,7 +38,7 @@ triggers:
 - `thresholdValue` - Provided by the user. This value can vary from use case to use case depending on the data of interest, and is needed to trigger the scaling in/out depending on what value comes back from the query. (This value can be a float)
 - `activationThresholdValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 - `query` - Flux query that will yield the value for the scaler to compare the `thresholdValue` against.
-- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based organization name. If using more than one trigger it is required that all `metricName`(s) be unique. (Optional)
+- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based organization name. If using more than one trigger it is required that all `metricName`(s) be unique. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 
 ### Authentication Parameters

--- a/content/docs/2.10/scalers/influxdb.md
+++ b/content/docs/2.10/scalers/influxdb.md
@@ -25,7 +25,7 @@ triggers:
         |> filter(fn: (r) => r._measurement == "stat")
       authToken: some-auth-token
       authTokenFromEnv: INFLUXDB_AUTH_TOKEN # Optional: You can use this instead of `authToken` parameter. See details in "Parameter List" section
-      metricName: influx-metric # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. Optional: This value will default to organization name if not set by the user (metrics name value would be then `influxdb-influx_org`)
+      metricName: influx-metric # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. Optional: This value will default to organization name if not set by the user (metrics name value would be then `influxdb-influx_org`)
 ```
 
 **Parameter list:**
@@ -38,7 +38,7 @@ triggers:
 - `thresholdValue` - Provided by the user. This value can vary from use case to use case depending on the data of interest, and is needed to trigger the scaling in/out depending on what value comes back from the query. (This value can be a float)
 - `activationThresholdValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 - `query` - Flux query that will yield the value for the scaler to compare the `thresholdValue` against.
-- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based organization name. If using more than one trigger it is required that all `metricName`(s) be unique. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based organization name. If using more than one trigger it is required that all `metricName`(s) be unique. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 
 ### Authentication Parameters

--- a/content/docs/2.10/scalers/mongodb.md
+++ b/content/docs/2.10/scalers/mongodb.md
@@ -26,7 +26,7 @@ triggers:
       queryValue: "1"
       # Optional: according to the number of query result, the scaler is active
       activationQueryValue: "1"
-      # Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name
+      # DEPRECATED: This parameter will be removed in version 2.12, don't set it. Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name
       metricName: "global-metric"
 ```
 
@@ -54,7 +54,7 @@ triggers:
       queryValue: "1"
       # Optional: according to the number of query result, the scaler is active
       activationQueryValue: "1"
-      # Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name.
+      # DEPRECATED: This parameter will be removed in version 2.12, don't set it. Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name.
       metricName: "global-metric"
 ```
 
@@ -87,7 +87,7 @@ When configuring with a connection string, you can use this URL format:
 mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/<database_name>
 ```
 
-You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` .
+You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` . (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 
 ### Authentication Parameters
 
@@ -139,7 +139,7 @@ spec:
         collection: "test_collection"
         query: '{"region":"eu-1","state":"running","plan":"planA"}'
         queryValue: "1"
-        metricName: "global-metric"
+        metricName: "global-metric" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
       authenticationRef:
         name: mongodb-trigger
 ---

--- a/content/docs/2.10/scalers/mongodb.md
+++ b/content/docs/2.10/scalers/mongodb.md
@@ -26,7 +26,7 @@ triggers:
       queryValue: "1"
       # Optional: according to the number of query result, the scaler is active
       activationQueryValue: "1"
-      # DEPRECATED: This parameter will be removed in version 2.12, don't set it. Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name
+      # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name
       metricName: "global-metric"
 ```
 
@@ -54,7 +54,7 @@ triggers:
       queryValue: "1"
       # Optional: according to the number of query result, the scaler is active
       activationQueryValue: "1"
-      # DEPRECATED: This parameter will be removed in version 2.12, don't set it. Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name.
+      # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. Optional: The generated metric name would be mongodb-global-metric. Here mongodb- use as a prefix for metric name.
       metricName: "global-metric"
 ```
 
@@ -87,7 +87,7 @@ When configuring with a connection string, you can use this URL format:
 mongodb://<username>:<password>@mongodb-svc.<namespace>.svc.cluster.local:27017/<database_name>
 ```
 
-You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` . (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and collection name. For example: **s1-mongodb-test_collection**. The value will be prefixed with `s{triggerIndex}-mongodb-` . (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 
 ### Authentication Parameters
 
@@ -139,7 +139,7 @@ spec:
         collection: "test_collection"
         query: '{"region":"eu-1","state":"running","plan":"planA"}'
         queryValue: "1"
-        metricName: "global-metric" # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+        metricName: "global-metric" # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
       authenticationRef:
         name: mongodb-trigger
 ---

--- a/content/docs/2.10/scalers/mssql.md
+++ b/content/docs/2.10/scalers/mssql.md
@@ -18,7 +18,7 @@ triggers:
     query: "SELECT COUNT(*) FROM backlog WHERE state='running' OR state='queued'"
     targetValue: "5.5"
     activationTargetValue: '5'
-    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional - the generated value would be `mssql-{sha256hash}`
+    metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. optional - the generated value would be `mssql-{sha256hash}`
 ```
 
 > 💡 **NOTE:** The connection string format supported by this scaler has some incompatibilities with connection string formats supported by other platforms, like .NET. For example, the MSSQL instance's port number must be separated into its own `Port` property instead of adding it to the `Server` property. You can learn more about all the supported connection string formats for this mssql scaler [here](https://github.com/denisenkom/go-mssqldb#the-connection-string-can-be-specified-in-one-of-three-formats).
@@ -36,7 +36,7 @@ triggers:
     database: test_db_name
     query: "SELECT COUNT(*) FROM backlog WHERE state='running' OR state='queued'"
     targetValue: 1
-    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version 2.12, don't set it. optional - the generated value would be `mssql-test_db_name`
+    metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. optional - the generated value would be `mssql-test_db_name`
 ```
 
 The `mssql` trigger always requires the following information:
@@ -69,7 +69,7 @@ Or the more traditional ADO format:
 Server=example.database.windows.net;Port=1433;Database=AdventureWorks;Persist Security Info=False;User ID=user1;Password=Password#1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
 ```
 
-You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and the `database` value (if specified), or the `host` value, or will be in the form `s{triggerIndex}-mssql-{sha256hash}` where `{sha256hash}` is a SHA-256 hash of the connection string. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and the `database` value (if specified), or the `host` value, or will be in the form `s{triggerIndex}-mssql-{sha256hash}` where `{sha256hash}` is a SHA-256 hash of the connection string. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 
 ### Authentication parameters
 

--- a/content/docs/2.10/scalers/mssql.md
+++ b/content/docs/2.10/scalers/mssql.md
@@ -18,7 +18,7 @@ triggers:
     query: "SELECT COUNT(*) FROM backlog WHERE state='running' OR state='queued'"
     targetValue: "5.5"
     activationTargetValue: '5'
-    metricName: backlog_process_count # optional - the generated value would be `mssql-{sha256hash}`
+    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional - the generated value would be `mssql-{sha256hash}`
 ```
 
 > 💡 **NOTE:** The connection string format supported by this scaler has some incompatibilities with connection string formats supported by other platforms, like .NET. For example, the MSSQL instance's port number must be separated into its own `Port` property instead of adding it to the `Server` property. You can learn more about all the supported connection string formats for this mssql scaler [here](https://github.com/denisenkom/go-mssqldb#the-connection-string-can-be-specified-in-one-of-three-formats).
@@ -36,7 +36,7 @@ triggers:
     database: test_db_name
     query: "SELECT COUNT(*) FROM backlog WHERE state='running' OR state='queued'"
     targetValue: 1
-    metricName: backlog_process_count # optional - the generated value would be `mssql-test_db_name`
+    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version 2.12, don't set it. optional - the generated value would be `mssql-test_db_name`
 ```
 
 The `mssql` trigger always requires the following information:
@@ -69,7 +69,7 @@ Or the more traditional ADO format:
 Server=example.database.windows.net;Port=1433;Database=AdventureWorks;Persist Security Info=False;User ID=user1;Password=Password#1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
 ```
 
-You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and the `database` value (if specified), or the `host` value, or will be in the form `s{triggerIndex}-mssql-{sha256hash}` where `{sha256hash}` is a SHA-256 hash of the connection string.
+You can also optionally assign a name to the metric using the `metricName` value. If not specified, the `metricName` will be generated automatically based on trigger index and the `database` value (if specified), or the `host` value, or will be in the form `s{triggerIndex}-mssql-{sha256hash}` where `{sha256hash}` is a SHA-256 hash of the connection string. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 
 ### Authentication parameters
 

--- a/content/docs/2.10/scalers/postgresql.md
+++ b/content/docs/2.10/scalers/postgresql.md
@@ -33,7 +33,7 @@ Finally, a user inserts a query that returns the desired value.
 - `query` - What query to poll postgresql with. Query must return an integer.
 - `targetQueryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationTargetQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on either the connection string if set or the db name. If using more than one trigger it is required that all metricNames be unique. (Optional)
+- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on either the connection string if set or the db name. If using more than one trigger it is required that all metricNames be unique. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 
 This is an example of using a full connection string with `AIRFLOW_CONN_AIRFLOW_DB` set as `postgresql://test@localhost`:
 
@@ -45,7 +45,7 @@ triggers:
     query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
-    metricName: backlog_process_count #optional. Generated value would be `postgresql-postgresql---test@localhost`
+    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version 2.12, don't set it. optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
 
 While this is an example of specifying each parameter:
@@ -63,7 +63,7 @@ triggers:
     sslmode: disable
     query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
     targetQueryValue: "2.2"
-    metricName: backlog_process_count #optional. Generated value would be `postgresql-test_db_name`
+    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional. Generated value would be `postgresql-test_db_name`
 ```
 
 ### Authentication Parameters

--- a/content/docs/2.10/scalers/postgresql.md
+++ b/content/docs/2.10/scalers/postgresql.md
@@ -33,7 +33,7 @@ Finally, a user inserts a query that returns the desired value.
 - `query` - What query to poll postgresql with. Query must return an integer.
 - `targetQueryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationTargetQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on either the connection string if set or the db name. If using more than one trigger it is required that all metricNames be unique. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on either the connection string if set or the db name. If using more than one trigger it is required that all metricNames be unique. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 
 This is an example of using a full connection string with `AIRFLOW_CONN_AIRFLOW_DB` set as `postgresql://test@localhost`:
 
@@ -45,7 +45,7 @@ triggers:
     query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
     targetQueryValue: "1.1"
     activationTargetQueryValue: "5"
-    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version 2.12, don't set it. optional. Generated value would be `postgresql-postgresql---test@localhost`
+    metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. optional. Generated value would be `postgresql-postgresql---test@localhost`
 ```
 
 While this is an example of specifying each parameter:
@@ -63,7 +63,7 @@ triggers:
     sslmode: disable
     query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
     targetQueryValue: "2.2"
-    metricName: backlog_process_count # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional. Generated value would be `postgresql-test_db_name`
+    metricName: backlog_process_count # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. optional. Generated value would be `postgresql-test_db_name`
 ```
 
 ### Authentication Parameters

--- a/content/docs/2.10/scalers/prometheus.md
+++ b/content/docs/2.10/scalers/prometheus.md
@@ -16,7 +16,7 @@ triggers:
   metadata:
     # Required fields:
     serverAddress: http://<prometheus-host>:9090
-    metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it. Note: name to identify the metric, generated value would be `prometheus-http_requests_total`
+    metricName: http_requests_total # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12. Note: name to identify the metric, generated value would be `prometheus-http_requests_total`
     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m])) # Note: query must return a vector/scalar single element response
     threshold: '100.50'
     activationThreshold: '5.5'
@@ -30,7 +30,7 @@ triggers:
 **Parameter list:**
 
 - `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
-- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 - `query` - Query to run.
 - `threshold` - Value to start scaling for. (This value can be a float)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
@@ -77,7 +77,7 @@ spec:
   - type: prometheus
     metadata:
       serverAddress: http://<prometheus-host>:9090
-      metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+      metricName: http_requests_total # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
       threshold: '100'
       query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
 ```
@@ -124,7 +124,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+        metricName: http_requests_total # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "bearer"
@@ -173,7 +173,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+        metricName: http_requests_total # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "basic"
@@ -227,7 +227,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+        metricName: http_requests_total # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "tls"
@@ -288,7 +288,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
+        metricName: http_requests_total # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version 2.12
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "tls,basic"

--- a/content/docs/2.10/scalers/prometheus.md
+++ b/content/docs/2.10/scalers/prometheus.md
@@ -16,7 +16,7 @@ triggers:
   metadata:
     # Required fields:
     serverAddress: http://<prometheus-host>:9090
-    metricName: http_requests_total # Note: name to identify the metric, generated value would be `prometheus-http_requests_total`
+    metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it. Note: name to identify the metric, generated value would be `prometheus-http_requests_total`
     query: sum(rate(http_requests_total{deployment="my-deployment"}[2m])) # Note: query must return a vector/scalar single element response
     threshold: '100.50'
     activationThreshold: '5.5'
@@ -30,7 +30,7 @@ triggers:
 **Parameter list:**
 
 - `serverAddress` - Address of Prometheus server. If using VictoriaMetrics cluster version, set full URL to Prometheus querying API, e.g. `http://<vmselect>:8481/select/0/prometheus`
-- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. If using more than one trigger it is required that all `metricName`(s) be unique.
+- `metricName` - Name to identify the Metric in the external.metrics.k8s.io API. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 - `query` - Query to run.
 - `threshold` - Value to start scaling for. (This value can be a float)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
@@ -77,7 +77,7 @@ spec:
   - type: prometheus
     metadata:
       serverAddress: http://<prometheus-host>:9090
-      metricName: http_requests_total
+      metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
       threshold: '100'
       query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
 ```
@@ -124,7 +124,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total
+        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "bearer"
@@ -173,7 +173,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total
+        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "basic"
@@ -227,7 +227,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total
+        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "tls"
@@ -288,7 +288,7 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total
+        metricName: http_requests_total # DEPRECATED: This parameter will be removed in version 2.12, don't set it
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "tls,basic"

--- a/content/docs/2.10/scalers/rabbitmq-queue.md
+++ b/content/docs/2.10/scalers/rabbitmq-queue.md
@@ -39,7 +39,7 @@ triggers:
 - `useRegex` - This parameter allows to use regex (in `queueName` parameter) to select queue instead of full name. (Values: `true`, `false`, Default: `false`, Optional, Only applies to hosts that use the `http` protocol)
 - `pageSize` - This parameter allows setting page size. (Default: `100`, Optional, Only applies when `useRegex` is `true`)
 - `operation` - Operation that will be applied to compute the number of messages in case of `useRegex` enabled. Either `sum` (default),`max`, or `avg`. (Optional)
-- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on the queue name. If using more than one trigger it is required that all metricNames be unique. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
+- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on the queue name. If using more than one trigger it is required that all metricNames be unique. (DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`)
 - `timeout` - Timeout **for this specific trigger**. This value will override the value defined in `KEDA_HTTP_DEFAULT_TIMEOUT`. (Optional, Only applies to hosts that use the `http` protocol)
 - `excludeUnacknowledged` - Set to `true` to specify that the `QueueLength` value should exclude unacknowledged messages (Ready messages only). (Values: `true`, `false`, Default: `false`, Optional, Only applies to hosts that use the `http` protocol)
 
@@ -115,7 +115,7 @@ spec:
       queueName: testqueue
       mode: QueueLength
       value: "20"
-      metricName: custom-testqueue # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional. Generated value would be `rabbitmq-custom-testqueue`
+      metricName: custom-testqueue # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. optional. Generated value would be `rabbitmq-custom-testqueue`
     authenticationRef:
       name: keda-trigger-auth-rabbitmq-conn
 ```
@@ -172,7 +172,7 @@ spec:
       queueName: testqueue
       mode: QueueLength
       value: "20"
-      metricName: custom-testqueue # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional. Generated value would be `rabbitmq-custom-testqueue`
+      metricName: custom-testqueue # DEPRECATED: This parameter is deprecated as of KEDA v2.10 and will be removed in version `2.12`. optional. Generated value would be `rabbitmq-custom-testqueue`
     authenticationRef:
       name: keda-trigger-auth-rabbitmq-conn
 ```

--- a/content/docs/2.10/scalers/rabbitmq-queue.md
+++ b/content/docs/2.10/scalers/rabbitmq-queue.md
@@ -39,7 +39,7 @@ triggers:
 - `useRegex` - This parameter allows to use regex (in `queueName` parameter) to select queue instead of full name. (Values: `true`, `false`, Default: `false`, Optional, Only applies to hosts that use the `http` protocol)
 - `pageSize` - This parameter allows setting page size. (Default: `100`, Optional, Only applies when `useRegex` is `true`)
 - `operation` - Operation that will be applied to compute the number of messages in case of `useRegex` enabled. Either `sum` (default),`max`, or `avg`. (Optional)
-- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on the queue name. If using more than one trigger it is required that all metricNames be unique. (Optional)
+- `metricName` - Name to assign to the metric. If not set KEDA will generate a name based on the queue name. If using more than one trigger it is required that all metricNames be unique. (DEPRECATED: This parameter will be removed in version `2.12`, don't set it)
 - `timeout` - Timeout **for this specific trigger**. This value will override the value defined in `KEDA_HTTP_DEFAULT_TIMEOUT`. (Optional, Only applies to hosts that use the `http` protocol)
 - `excludeUnacknowledged` - Set to `true` to specify that the `QueueLength` value should exclude unacknowledged messages (Ready messages only). (Values: `true`, `false`, Default: `false`, Optional, Only applies to hosts that use the `http` protocol)
 
@@ -115,7 +115,7 @@ spec:
       queueName: testqueue
       mode: QueueLength
       value: "20"
-      metricName: custom-testqueue #optional. Generated value would be `rabbitmq-custom-testqueue`
+      metricName: custom-testqueue # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional. Generated value would be `rabbitmq-custom-testqueue`
     authenticationRef:
       name: keda-trigger-auth-rabbitmq-conn
 ```
@@ -172,7 +172,7 @@ spec:
       queueName: testqueue
       mode: QueueLength
       value: "20"
-      metricName: custom-testqueue #optional. Generated value would be `rabbitmq-custom-testqueue`
+      metricName: custom-testqueue # DEPRECATED: This parameter will be removed in version `2.12`, don't set it. optional. Generated value would be `rabbitmq-custom-testqueue`
     authenticationRef:
       name: keda-trigger-auth-rabbitmq-conn
 ```


### PR DESCRIPTION
In v2.12 this setting will be internalized and should not be set by users
### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Docs part of https://github.com/kedacore/keda/pull/4235
Relates to https://github.com/kedacore/keda/issues/4220