### PR TITLE
Use External Scaler Artifact Hub URL for Links

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -190,7 +190,7 @@
               result.display_name;
             element
               .querySelector(".scaler-title")
-              .setAttribute("href", `https://artifacthub.io/packages/keda-scaler/${result.repository.name}/${result.name}`);
+              .setAttribute("href", `https://artifacthub.io/packages/keda-scaler/${result.repository.name}/${result.normalized_name}`);
             result.description &&
               (element.querySelector(".description").textContent =
                 result.description);

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -190,7 +190,7 @@
               result.display_name;
             element
               .querySelector(".scaler-title")
-              .setAttribute("href", result.repository.url);
+              .setAttribute("href", `https://artifacthub.io/packages/keda-scaler/${result.repository.name}/${result.name}`);
             result.description &&
               (element.querySelector(".description").textContent =
                 result.description);
@@ -260,7 +260,7 @@
         // show all scalers by default
         let queryString = index.search("");
 
-        /* By default, Lunr can only match words stored in the records/index. We want to be able to match both words and characters. 
+        /* By default, Lunr can only match words stored in the records/index. We want to be able to match both words and characters.
         To be able to perform character matching, we do wildcard search. */
         if (keywords.length > 0) {
           queryString = index.search(keywords);

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -190,7 +190,7 @@
               result.display_name;
             element
               .querySelector(".scaler-title")
-              .setAttribute("href", `https://artifacthub.io/packages/keda-scaler/${result.repository.name}/${result.normalized_name}`);
+              .setAttribute("href", "https://artifacthub.io/packages/keda-scaler/" + result.repository.name + "/" + result.normalized_name);
             result.description &&
               (element.querySelector(".description").textContent =
                 result.description);


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This Pull Request fixes the URL used when exploring [KEDA external scalers](https://keda.sh/docs/2.9/scalers/). Today, the URLs use the "repository url" which may often be an invalid destination based on the format specified in the [Artifact Hub docs](https://artifacthub.io/docs/topics/repositories/keda-scalers/). Instead, this PR changes the URL to point to the scaler's page on Artifact Hub.

For example, the URL for my scaler `https://artifacthub.io/packages/keda-scaler/wsugarman-keda-scalers/durabletask-azurestorage-scaler` is created by:
1. Fetching the search results from Artifact Hub: `https://artifacthub.io/api/v1/packages/search?kind=8&sort=relevance`
2. Parsing the element:
```json
{
  "package_id": "fc1de730-37bc-4375-b0e1-a032c67f2537",
  "name": "durabletask-azurestorage-scaler",
  "normalized_name": "durabletask-azurestorage-scaler",
  "logo_image_id": "4727dfc7-c877-4b5c-81b5-0c8115d54e81",
  "stars": 1,
  "display_name": "Durable Task KEDA External Scaler",
  "description": "A KEDA external scaler for the Durable Task Azure Storage backend",
  "version": "1.0.0",
  "app_version": "1.0.0",
  "license": "MIT",
  "deprecated": false,
  "signed": false,
  "security_report_summary": {
    "low": 0,
    "high": 0,
    "medium": 5,
    "unknown": 0,
    "critical": 1
  },
  "all_containers_images_whitelisted": false,
  "production_organizations_count": 0,
  "ts": 1677898500,
  "repository": {
    "url": "https://github.com/wsugarman/charts/artifacthub",
    "kind": 8,
    "name": "wsugarman-keda-scalers",
    "official": false,
    "user_alias": "wsugarman",
    "display_name": "OSS KEDA External Scalers",
    "repository_id": "f9f33959-9a62-4648-bdc1-04e5e62518a7",
    "scanner_disabled": false,
    "verified_publisher": true
  }
}
```
3. Creating the URL based on `result.repository.name` and `result.normalized_name` -> ``https://artifacthub.io/packages/keda-scaler/${result.repository.name}/${result.normalized_name}``


### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #1021
