### PR TITLE
docs: fix minor typo in scaling-deployments main doc

### DIFF
--- a/content/docs/2.10/concepts/scaling-deployments.md
+++ b/content/docs/2.10/concepts/scaling-deployments.md
@@ -133,7 +133,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 #### fallback

--- a/content/docs/2.4/concepts/scaling-deployments.md
+++ b/content/docs/2.4/concepts/scaling-deployments.md
@@ -133,7 +133,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 

--- a/content/docs/2.5/concepts/scaling-deployments.md
+++ b/content/docs/2.5/concepts/scaling-deployments.md
@@ -134,7 +134,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 #### fallback

--- a/content/docs/2.6/concepts/scaling-deployments.md
+++ b/content/docs/2.6/concepts/scaling-deployments.md
@@ -134,7 +134,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 #### fallback

--- a/content/docs/2.7/concepts/scaling-deployments.md
+++ b/content/docs/2.7/concepts/scaling-deployments.md
@@ -132,7 +132,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 #### fallback

--- a/content/docs/2.8/concepts/scaling-deployments.md
+++ b/content/docs/2.8/concepts/scaling-deployments.md
@@ -133,7 +133,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 #### fallback

--- a/content/docs/2.9/concepts/scaling-deployments.md
+++ b/content/docs/2.9/concepts/scaling-deployments.md
@@ -133,7 +133,7 @@ Minimum number of replicas KEDA will scale the resource down to. By default it's
   maxReplicaCount: 100 # Optional. Default: 100
 ```
 
-This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resouce.
+This setting is passed to the HPA definition that KEDA will create for a given resource and holds the maximum number of replicas of the target resource.
 
 ---
 #### fallback


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Fix a minor typo inside of scaling-deployment main docs.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #

- Fix minor typo in [content/docs/2.9/concepts/scaling-deployments.md](https://github.com/kedacore/keda-docs/compare/main...EnriqueTejeda:keda-docs:fix-typo-scalers?expand=1#diff-b272fa4bd1dc40d5e2783a313f475a9d6decfccf63822797514cc65550a2e99c)
