### PR TITLE
chore: Unpublish v2.10 as current, for now

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,7 +29,7 @@ alpine_js_version = "2.2.1"
 favicon = "favicon.png"
 
 [params.versions]
-docs = ["2.10", "2.9", "2.8", "2.7", "2.6", "2.5", "2.4", "2.3", "2.2", "2.1", "2.0", "1.5", "1.4"]
+docs = ["2.9", "2.8", "2.7", "2.6", "2.5", "2.4", "2.3", "2.2", "2.1", "2.0", "1.5", "1.4"]
 
 # Site fonts. For more options see https://fonts.google.com.
 [[params.fonts]]


### PR DESCRIPTION
Unpublish v2.10 as current, for now

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
