### PR TITLE
chore: update answer about readOnlyRootFilesystem=true

### DIFF
--- a/data/faq20.toml
+++ b/data/faq20.toml
@@ -149,7 +149,9 @@ a = """KEDA client-go is exported as part of the KEDA repository."""
 [[qna]]
 q = "How do I run KEDA with `readOnlyRootFilesystem=true`?"
 a = """
-By default you can't run KEDA with `readOnlyRootFilesystem=true` because Metrics adapter generates self-signed certificates during deployment and stores them on the root file system.
+As default, KEDA v2.10 or above sets `readOnlyRootFilesystem=true` as default without any other manual intervention.
+
+If you are running KEDA v2.9 or below, you can't run KEDA with `readOnlyRootFilesystem=true` as default because Metrics adapter generates self-signed certificates during deployment and stores them on the root file system.
 To overcome this, you can create a secret/configmap with a valid CA, cert and key and then mount it to the Metrics Deployment.
 To use your certificate, you need to reference it in the container `args` section, e.g.:
 ```


### PR DESCRIPTION
In KEDA v2.10 we don't need to mount the extra volume for enabling `readOnlyRootFilesystem=true` because the cert is already mounted in the metrics server. Once [this PR](https://github.com/kedacore/charts/pull/412) is merged and released, we can merge this PR too

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/charts/pull/412
