### PR TITLE
doc: Add missing validation

### DIFF
--- a/content/docs/2.11/concepts/admission-webhooks.md
+++ b/content/docs/2.11/concepts/admission-webhooks.md
@@ -16,3 +16,4 @@ KEDA will block all incoming changes to `ScaledObject` that don't match these ru
 
 - The scaled workload (`scaledobject.spec.scaleTargetRef`) is already autoscaled by another other sources (other ScaledObject or HPA).
 - CPU and/or Memory trigger are used and the scaled workload doesn't have the requests defined. **This rule doesn't apply to all the workload types, only to `Deployment` and `StatefulSet`.**
+- CPU and/or Memory trigger are **the only used triggers** and the ScaledObject defines `minReplicaCount:0`. **This rule doesn't apply to all the workload types, only to `Deployment` and `StatefulSet`.**


### PR DESCRIPTION
[This PR](https://github.com/kedacore/keda/pull/4346)  adds an extra validation to the webhooks, but the doc wasn't updated

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/keda/issues/4269
