### PR TITLE
fix: provide correct prometheus metric names

### DIFF
--- a/content/docs/2.10/operate/prometheus.md
+++ b/content/docs/2.10/operate/prometheus.md
@@ -24,8 +24,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
-- `scaled_object_validation_total`- The current value for scaled object validations.
-- `scaled_object_validation_errors` - The number of validation errors.
+- `keda_webhook_scaled_object_validation_total`- The current value for scaled object validations.
+- `keda_webhook_scaled_object_validation_errors` - The number of validation errors.
 
 ### Metrics Server
 

--- a/content/docs/2.11/operate/prometheus.md
+++ b/content/docs/2.11/operate/prometheus.md
@@ -24,8 +24,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
-- `scaled_object_validation_total`- The current value for scaled object validations.
-- `scaled_object_validation_errors` - The number of validation errors.
+- `keda_webhook_scaled_object_validation_total`- The current value for scaled object validations.
+- `keda_webhook_scaled_object_validation_errors` - The number of validation errors.
 
 ### Metrics Server
 


### PR DESCRIPTION
The metrics are correctly generated but wrongly documented

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
