### PR TITLE
fix: use correct metric names (#1110

### DIFF
--- a/content/docs/2.10/operate/prometheus.md
+++ b/content/docs/2.10/operate/prometheus.md
@@ -24,8 +24,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
-- `scaled_object_validation_total`- The current value for scaled object validations.
-- `scaled_object_validation_errors` - The number of validation errors.
+- `keda_webhook_scaled_object_validation_total`- The current value for scaled object validations.
+- `keda_webhook_scaled_object_validation_errors` - The number of validation errors.
 
 ### Metrics Server
 

--- a/content/docs/2.11/operate/prometheus.md
+++ b/content/docs/2.11/operate/prometheus.md
@@ -24,8 +24,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
-- `scaled_object_validation_total`- The current value for scaled object validations.
-- `scaled_object_validation_errors` - The number of validation errors.
+- `keda_webhook_scaled_object_validation_total`- The current value for scaled object validations.
+- `keda_webhook_scaled_object_validation_errors` - The number of validation errors.
 
 ### Metrics Server
 

--- a/content/docs/2.11/scalers/gcp-pub-sub.md
+++ b/content/docs/2.11/scalers/gcp-pub-sub.md
@@ -16,7 +16,7 @@ triggers:
   metadata:
     subscriptionSize: "5" # Deprecated, use mode and value fields instead
     mode: "SubscriptionSize" # Optional - Default is SubscriptionSize - SubscriptionSize or OldestUnackedMessageAge
-    value: "5.5" # Optional - Default is 5 for SubscriptionSize | Default is 10 for OldestUnackedMessageAge
+    value: "5.5" # Optional - Default is 10
     activationValue: "10.5" # Optional - Default is 0
     subscriptionName: "mysubscription" # Required
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON # Required
@@ -26,16 +26,14 @@ The Google Cloud Platform‎ (GCP) Pub/Sub trigger allows you to scale based on 
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the required stack driver metrics in order to read the number of messages in the Pub/Sub subscription.
 
+- `mode` - The metric used to scale your workload. It's the camel case of the official metric name. For example, if you are going to leverage the metric `subscription/pull_request_count`, you will fill the value as `PullRequestCount`. Please refer to https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub. All metric starts with `subscription/` are supported. (Default: `SubscriptionSize`, aka `NumUndeliveredMessages`)
+
+
 - `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
-`subscriptionName` defines the subscription that should be monitored. You can use different formulas:
-
-- Just the subscription name, in which case you will reference a subscription from the current project or the one specified in the credentials file used.
-- Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`.
-
-You can use either `subscriptionSize` to define the target average which the deployment will be scaled on or `mode` and `value` fields. `subscriptionSize` field is deprecated, it is recommended to use `mode` and `value` fields instead. Scaler will not work if you define both `subscriptionSize` and at least one of `mode` or `value`.
-The mode chooses whether to scale using number of messages `SubscriptionSize` or using oldest unacked message age `OldestUnackedMessageAge`.
-The `value` determines the target average which the deployment will be scaled on. The default value is 5 for `SubscriptionSize` and 10 for `OldestUnackedMessageAge`.
+- `subscriptionName` defines the subscription that should be monitored. You can use different formulas:
+  - Just the subscription name, in which case you will reference a subscription from the current project or the one specified in the credentials file used.
+  - Use the full link provided by Google, so that you can reference a subscription that is hosted in another project Eg: `projects/myproject/subscriptions/mysubscription`.
 
 Here's an [example](https://github.com/kedacore/sample-go-gcppubsub).
 


### PR DESCRIPTION
The metrics are correctly generated but wrongly documented

<img width="682" alt="image" src="https://user-images.githubusercontent.com/36899226/233301629-3af28cef-0450-4cc7-9a84-33e74209c2bf.png">


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

