### PR TITLE
fix: Ensure .NET code sample for external scaler builds

### DIFF
--- a/content/docs/1.4/concepts/external-scalers.md
+++ b/content/docs/1.4/concepts/external-scalers.md
@@ -349,7 +349,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/1.5/concepts/external-scalers.md
+++ b/content/docs/1.5/concepts/external-scalers.md
@@ -349,7 +349,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.0/concepts/external-scalers.md
+++ b/content/docs/2.0/concepts/external-scalers.md
@@ -384,7 +384,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -467,7 +467,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.1/concepts/external-scalers.md
+++ b/content/docs/2.1/concepts/external-scalers.md
@@ -384,7 +384,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -467,7 +467,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.10/concepts/external-scalers.md
+++ b/content/docs/2.10/concepts/external-scalers.md
@@ -409,7 +409,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -498,7 +498,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.11/concepts/external-scalers.md
+++ b/content/docs/2.11/concepts/external-scalers.md
@@ -409,7 +409,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -498,7 +498,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.2/concepts/external-scalers.md
+++ b/content/docs/2.2/concepts/external-scalers.md
@@ -384,7 +384,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -467,7 +467,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.3/concepts/external-scalers.md
+++ b/content/docs/2.3/concepts/external-scalers.md
@@ -384,7 +384,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -467,7 +467,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.4/concepts/external-scalers.md
+++ b/content/docs/2.4/concepts/external-scalers.md
@@ -384,7 +384,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -467,7 +467,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 
 {{< collapsible "C#" >}}
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.5/concepts/external-scalers.md
+++ b/content/docs/2.5/concepts/external-scalers.md
@@ -409,7 +409,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -498,7 +498,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.6/concepts/external-scalers.md
+++ b/content/docs/2.6/concepts/external-scalers.md
@@ -409,7 +409,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -498,7 +498,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.7/concepts/external-scalers.md
+++ b/content/docs/2.7/concepts/external-scalers.md
@@ -409,7 +409,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -498,7 +498,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 

--- a/content/docs/2.8/concepts/external-scalers.md
+++ b/content/docs/2.8/concepts/external-scalers.md
@@ -409,7 +409,7 @@ func (e *ExternalScaler) StreamIsActive(scaledObject *pb.ScaledObjectRef, epsSer
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
+public override async Task StreamIsActive(ScaledObjectRef request, IServerStreamWriter<IsActiveResponse> responseStream, ServerCallContext context)
 {
   if (!request.ScalerMetadata.ContainsKey("latitude") ||
     !request.ScalerMetadata.ContainsKey("longitude"))
@@ -498,7 +498,7 @@ func (e *ExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef) (*p
 {{< collapsible "C#" >}}
 
 ```csharp
-public override Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
+public override async Task<GetMetricSpecResponse> GetMetricSpec(ScaledObjectRef request, ServerCallContext context)
 {
   var resp = new GetMetricSpecResponse();
 


### PR DESCRIPTION
Ensure .NET code sample for external scaler builds

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
