### PR TITLE
fix misleading doc that states cpu/mem scalers use limit

### DIFF
--- a/content/docs/2.0/scalers/cpu.md
+++ b/content/docs/2.0/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.0/scalers/memory.md
+++ b/content/docs/2.0/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.1/scalers/cpu.md
+++ b/content/docs/2.1/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.1/scalers/memory.md
+++ b/content/docs/2.1/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.10/scalers/cpu.md
+++ b/content/docs/2.10/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.10/scalers/memory.md
+++ b/content/docs/2.10/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.11/scalers/cpu.md
+++ b/content/docs/2.11/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.11/scalers/memory.md
+++ b/content/docs/2.11/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.2/scalers/cpu.md
+++ b/content/docs/2.2/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.2/scalers/memory.md
+++ b/content/docs/2.2/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.3/scalers/cpu.md
+++ b/content/docs/2.3/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.3/scalers/memory.md
+++ b/content/docs/2.3/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.4/scalers/cpu.md
+++ b/content/docs/2.4/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.4/scalers/memory.md
+++ b/content/docs/2.4/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.5/scalers/cpu.md
+++ b/content/docs/2.5/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.5/scalers/memory.md
+++ b/content/docs/2.5/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.6/scalers/cpu.md
+++ b/content/docs/2.6/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.6/scalers/memory.md
+++ b/content/docs/2.6/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.7/scalers/cpu.md
+++ b/content/docs/2.7/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.7/scalers/memory.md
+++ b/content/docs/2.7/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.8/scalers/cpu.md
+++ b/content/docs/2.8/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.8/scalers/memory.md
+++ b/content/docs/2.8/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.9/scalers/cpu.md
+++ b/content/docs/2.9/scalers/cpu.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```

--- a/content/docs/2.9/scalers/memory.md
+++ b/content/docs/2.9/scalers/memory.md
@@ -13,19 +13,19 @@ go_file = "cpu_memory_scaler"
 
 ### Prerequisites
 
-KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `limits` (at a minimum).
+KEDA uses standard `cpu` and `memory` metrics from the Kubernetes Metrics Server, which is not installed by default on certain Kubernetes deployments such as EKS on AWS. Additionally, the `resources` section of the relevant Kubernetes Pods must include `requests` (at a minimum).
 
 - The Kubernetes Metrics Server must be installed. Installation instructions vary based on your Kubernetes provider.
-- The configuration for your Kubernetes Pods must include a `resources` section with specified `limits`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
+- The configuration for your Kubernetes Pods must include a `resources` section with specified `requests`. See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If the resources section is empty (`resources: {}` or similar) the error `missing request for {cpu/memory}` occurs.
 
 ```
-# a working example of resources with specified limits
+# a working example of resources with specified requests
 spec:
   containers:
   - name: app
     image: images.my-company.example/app:v4
     resources:
-      limits:
+      requests:
         memory: "128Mi"
         cpu: "500m"
 ```


### PR DESCRIPTION
Signed-off-by: Adarsh-verma-14 <t_adarsh.verma@india.nec.com>

These scalers(cpu/mem) use resource requests not limits.
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #1028 
