### PR TITLE
fix: include missing parameters in the stackdriver adapter

### DIFF
--- a/content/docs/2.10/scalers/gcp-stackdriver.md
+++ b/content/docs/2.10/scalers/gcp-stackdriver.md
@@ -19,6 +19,9 @@ triggers:
     targetValue: '100.50'
     activationTargetValue: "10.5" # Optional - Default is 0
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON
+    alignmentPeriodSeconds: '60'
+    alignmentAligner: mean
+    alignmentReducer: none
 ```
 
 **Parameter list:**
@@ -29,6 +32,17 @@ triggers:
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the configured stack driver metrics.
+
+The `alignmentPeriodSeconds`, `alignmentAligner` and `alignmentReducer` properties controls time series aggregation before the metrics are returned. See below for more details.
+
+### Timeseries alignment properties
+It is much better to aggregate the time series values before they are returned from stackdriver instead of getting the raw values.
+For that, you must specify a value of 60 or more for the `alignmentPeriodSeconds` property as well as an alignment operation in the `alignmentAligner` property and/or a reducer in the `alignmentReducer` property.
+
+Valid values for the `alignmentAligner` property are: none, delta, interpolate, next_older, min, max, mean, count, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50, percentile_05 and percent_change.
+Valid values for the `alignmentReducer` property are: none, mean, min, max, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50 and percentile_05.
+
+For more information on aggregation, see [here](https://cloud.google.com/monitoring/api/v3/aggregation#aggr-intro).
 
 ### Authentication Parameters
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.

--- a/content/docs/2.11/scalers/gcp-stackdriver.md
+++ b/content/docs/2.11/scalers/gcp-stackdriver.md
@@ -19,6 +19,9 @@ triggers:
     targetValue: '100.50'
     activationTargetValue: "10.5" # Optional - Default is 0
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON
+    alignmentPeriodSeconds: '60'
+    alignmentAligner: mean
+    alignmentReducer: none
 ```
 
 **Parameter list:**
@@ -29,6 +32,17 @@ triggers:
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the configured stack driver metrics.
+
+The `alignmentPeriodSeconds`, `alignmentAligner` and `alignmentReducer` properties controls time series aggregation before the metrics are returned. See below for more details.
+
+### Timeseries alignment properties
+It is much better to aggregate the time series values before they are returned from stackdriver instead of getting the raw values.
+For that, you must specify a value of 60 or more for the `alignmentPeriodSeconds` property as well as an alignment operation in the `alignmentAligner` property and/or a reducer in the `alignmentReducer` property.
+
+Valid values for the `alignmentAligner` property are: none, delta, interpolate, next_older, min, max, mean, count, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50, percentile_05 and percent_change.
+Valid values for the `alignmentReducer` property are: none, mean, min, max, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50 and percentile_05.
+
+For more information on aggregation, see [here](https://cloud.google.com/monitoring/api/v3/aggregation#aggr-intro).
 
 ### Authentication Parameters
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.

--- a/content/docs/2.8/scalers/gcp-stackdriver.md
+++ b/content/docs/2.8/scalers/gcp-stackdriver.md
@@ -19,6 +19,9 @@ triggers:
     targetValue: '100'
     activationTargetValue: "10" # Optional - Default is 0
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON
+    alignmentPeriodSeconds: '60'
+    alignmentAligner: mean
+    alignmentReducer: none
 ```
 
 **Parameter list:**
@@ -29,6 +32,17 @@ triggers:
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the configured stack driver metrics.
+
+The `alignmentPeriodSeconds`, `alignmentAligner` and `alignmentReducer` properties controls time series aggregation before the metrics are returned. See below for more details.
+
+### Timeseries alignment properties
+It is much better to aggregate the time series values before they are returned from stackdriver instead of getting the raw values.
+For that, you must specify a value of 60 or more for the `alignmentPeriodSeconds` property as well as an alignment operation in the `alignmentAligner` property and/or a reducer in the `alignmentReducer` property.
+
+Valid values for the `alignmentAligner` property are: none, delta, interpolate, next_older, min, max, mean, count, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50, percentile_05 and percent_change.
+Valid values for the `alignmentReducer` property are: none, mean, min, max, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50 and percentile_05.
+
+For more information on aggregation, see [here](https://cloud.google.com/monitoring/api/v3/aggregation#aggr-intro).
 
 ### Authentication Parameters
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.

--- a/content/docs/2.9/scalers/gcp-stackdriver.md
+++ b/content/docs/2.9/scalers/gcp-stackdriver.md
@@ -19,6 +19,9 @@ triggers:
     targetValue: '100.50'
     activationTargetValue: "10.5" # Optional - Default is 0
     credentialsFromEnv: GOOGLE_APPLICATION_CREDENTIALS_JSON
+    alignmentPeriodSeconds: '60'
+    alignmentAligner: mean
+    alignmentReducer: none
 ```
 
 **Parameter list:**
@@ -29,6 +32,17 @@ triggers:
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
 The `credentialsFromEnv` property maps to the name of an environment variable in the scale target (`scaleTargetRef`) that contains the service account credentials (JSON). KEDA will use those to connect to Google Cloud Platform and collect the configured stack driver metrics.
+
+The `alignmentPeriodSeconds`, `alignmentAligner` and `alignmentReducer` properties controls time series aggregation before the metrics are returned. See below for more details.
+
+### Timeseries alignment properties
+It is much better to aggregate the time series values before they are returned from stackdriver instead of getting the raw values.
+For that, you must specify a value of 60 or more for the `alignmentPeriodSeconds` property as well as an alignment operation in the `alignmentAligner` property and/or a reducer in the `alignmentReducer` property.
+
+Valid values for the `alignmentAligner` property are: none, delta, interpolate, next_older, min, max, mean, count, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50, percentile_05 and percent_change.
+Valid values for the `alignmentReducer` property are: none, mean, min, max, sum, stddev, count_true, count_false, fraction_true, percentile_99, percentile_95, percentile_50 and percentile_05.
+
+For more information on aggregation, see [here](https://cloud.google.com/monitoring/api/v3/aggregation#aggr-intro).
 
 ### Authentication Parameters
 You can use `TriggerAuthentication` CRD to configure the authenticate by providing the service account credentials in JSON.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Include missing parameters for `stackdriver` scaler. These parameters were published in version `2.7`, but for some reason, they are missing in the latest.

```yaml
triggers:
- type: gcp-stackdriver
  metadata:
    ...
    alignmentPeriodSeconds: '60'
    alignmentAligner: mean
    alignmentReducer: none
```

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Fixes: #1129 
