### PR TITLE
docs: Add doc changes for tls argument in external scaler

### DIFF
--- a/content/docs/2.11/scalers/external-push.md
+++ b/content/docs/2.11/scalers/external-push.md
@@ -15,13 +15,19 @@ triggers:
 - type: external-push
   metadata:
     scalerAddress: external-scaler-service:8080
-    tlsCertFile: /path/to/tls/cert.pem # optional
+    caCert : /path/to/tls/ca.pem
+    tlsClientCert: /path/to/tls/cert.pem
+    tlsClientKey: /path/to/tls/key.pem
+    unsafeSsl: false
 ```
 
 **Parameter list:**
 
 - `scalerAddress` - Address of the external push scaler implementing `ExternalScaler.StreamIsActive` in externalscaler.proto. Format must be `host:port`.
-- `tlsCertFile` - Location of a certificate to use for the GRPC connection to authenticate with. (Optional)
+- `caCert` - Location of a Certificate Authority (CA) certificate to use for the GRPC connection to authenticate with. (Optional)
+- `tlsClientCert` - Location of a client certificate to use for the GRPC connection to authenticate with. (Optional)
+- `tlsClientKey` - Location of a client private key to use for the GRPC connection to authenticate with. (Optional)
+- `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 
 The entire metadata object is passed to the external scaler in `ScaledObjectRef.scalerMetadata`.
 
@@ -46,5 +52,8 @@ spec:
   - type: external-push
     metadata:
       scalerAddress: external-scaler-service:8080
-      tlsCertFile: /path/to/tls/cert.pem # optional
+      caCert : /path/to/tls/ca.pem
+      tlsClientCert: /path/to/tls/cert.pem
+      tlsClientKey: /path/to/tls/key.pem
+      unsafeSsl: false
 ```

--- a/content/docs/2.11/scalers/external-push.md
+++ b/content/docs/2.11/scalers/external-push.md
@@ -16,6 +16,7 @@ triggers:
   metadata:
     scalerAddress: external-scaler-service:8080
     caCert : /path/to/tls/ca.pem
+    tlsCertFile: /path/to/tls/cert.pem # Deprecated. https://github.com/kedacore/keda/issues/4549
     tlsClientCert: /path/to/tls/cert.pem
     tlsClientKey: /path/to/tls/key.pem
     unsafeSsl: false

--- a/content/docs/2.11/scalers/external.md
+++ b/content/docs/2.11/scalers/external.md
@@ -16,6 +16,7 @@ triggers:
   metadata:
     scalerAddress: external-scaler-service:8080
     caCert : /path/to/tls/ca.pem
+    tlsCertFile: /path/to/tls/cert.pem # Deprecated. https://github.com/kedacore/keda/issues/4549
     tlsClientCert: /path/to/tls/cert.pem
     tlsClientKey: /path/to/tls/key.pem
     unsafeSsl: false

--- a/content/docs/2.11/scalers/external.md
+++ b/content/docs/2.11/scalers/external.md
@@ -15,13 +15,19 @@ triggers:
 - type: external
   metadata:
     scalerAddress: external-scaler-service:8080
-    tlsCertFile : /path/to/tls/cert.pem
+    caCert : /path/to/tls/ca.pem
+    tlsClientCert: /path/to/tls/cert.pem
+    tlsClientKey: /path/to/tls/key.pem
+    unsafeSsl: false
 ```
 
 **Parameter list:**
 
 - `scalerAddress` - Address of the external scaler. Format must be `host:port`.
-- `tlsCertFile` - Location of a certificate to use for the GRPC connection to authenticate with. (Optional)
+- `caCert` - Location of a Certificate Authority (CA) certificate to use for the GRPC connection to authenticate with. (Optional)
+- `tlsClientCert` - Location of a client certificate to use for the GRPC connection to authenticate with. (Optional)
+- `tlsClientKey` - Location of a client private key to use for the GRPC connection to authenticate with. (Optional)
+- `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 
 > For implementing an external scaler, refer to [External Scalers Concept](../concepts/external-scalers.md).
 


### PR DESCRIPTION


Hi team,
This PR adds documentation update for the PR https://github.com/kedacore/keda/pull/4407

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

