### PR TITLE
Adding documentation for new Prometheus build info metric

### DIFF
--- a/content/docs/2.11/operate/prometheus.md
+++ b/content/docs/2.11/operate/prometheus.md
@@ -10,6 +10,7 @@ weight = 100
 
 The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
+- `keda_build_info` - Info metric, with static information about KEDA build like: version, git commit and Golang runtime info.
 - `keda_scaler_active` - This metric marks whether the particular scaler is active (value == 1) or in-active (value == 0).
 - `keda_scaler_metrics_value` - The current value for each scaler's metric that would be used by the HPA in computing the target average.
 - `keda_scaler_metrics_latency` - The latency of retrieving current metric from each scaler.


### PR DESCRIPTION
Adding newly created metric to list of available metrics in operation documentation.



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/keda/issues/4647
