### PR TITLE
Update scaling-jobs.md

### DIFF
--- a/content/docs/2.10/concepts/scaling-jobs.md
+++ b/content/docs/2.10/concepts/scaling-jobs.md
@@ -107,7 +107,9 @@ ___
   minReplicaCount: 10 # Optional. Default: 0
 ```
 
-The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount. 
+The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount.  
+  
+New messages may create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently. Using a targetValue of 1, if 3 new messages are sent, 2 of those messages will be processed on the already running jobs but another 3 jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
 ___
 
 ---

--- a/content/docs/2.11/concepts/scaling-jobs.md
+++ b/content/docs/2.11/concepts/scaling-jobs.md
@@ -107,7 +107,9 @@ ___
   minReplicaCount: 10 # Optional. Default: 0
 ```
 
-The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount. 
+The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount.  
+  
+New messages may create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently. Using a targetValue of 1, if 3 new messages are sent, 2 of those messages will be processed on the already running jobs but another 3 jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
 ___
 
 ---

--- a/content/docs/2.8/concepts/scaling-jobs.md
+++ b/content/docs/2.8/concepts/scaling-jobs.md
@@ -107,7 +107,9 @@ ___
   minReplicaCount: 10 # Optional. Default: 0
 ```
 
-The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount. 
+The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount.  
+  
+All messages will create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently.  If 3 new messages are sent, 2 of those messages will be processed on the already running jobs.  A minimum of 2 new jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
 ___
 
 ---

--- a/content/docs/2.8/concepts/scaling-jobs.md
+++ b/content/docs/2.8/concepts/scaling-jobs.md
@@ -109,7 +109,7 @@ ___
 
 The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount.  
   
-All messages will create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently.  If 3 new messages are sent, 2 of those messages will be processed on the already running jobs.  A minimum of 2 new jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
+All messages will create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently. Using a targetValue of 1, if 3 new messages are sent, 2 of those messages will be processed on the already running jobs but another 3 jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
 ___
 
 ---

--- a/content/docs/2.8/concepts/scaling-jobs.md
+++ b/content/docs/2.8/concepts/scaling-jobs.md
@@ -109,7 +109,7 @@ ___
 
 The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount.  
   
-All messages will create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently. Using a targetValue of 1, if 3 new messages are sent, 2 of those messages will be processed on the already running jobs but another 3 jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
+New messages may create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently. Using a targetValue of 1, if 3 new messages are sent, 2 of those messages will be processed on the already running jobs but another 3 jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
 ___
 
 ---

--- a/content/docs/2.9/concepts/scaling-jobs.md
+++ b/content/docs/2.9/concepts/scaling-jobs.md
@@ -107,7 +107,9 @@ ___
   minReplicaCount: 10 # Optional. Default: 0
 ```
 
-The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount. 
+The min number of jobs that is created by default. This can be useful to avoid bootstrapping time of new jobs. If minReplicaCount is greater than maxReplicaCount, minReplicaCount will be set to maxReplicaCount.  
+  
+New messages may create new jobs - within the limits imposed by maxReplicaCount - in order to reach the state where minReplicaCount jobs are always running.  For example, if one sets minReplicaCount to 2 then there will be 2 jobs running permanently. Using a targetValue of 1, if 3 new messages are sent, 2 of those messages will be processed on the already running jobs but another 3 jobs will be created in order to fulfill the desired state dictated by the minReplicaCount parameter that is set to 2.
 ___
 
 ---


### PR DESCRIPTION
Explained the minReplicaCount scale-out behavior in response to incoming events.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_I explained the minReplicaCount-dictated scale-out behavior in response to incoming events._

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
