### PR TITLE
added banner for old docs

### DIFF
--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -74,6 +74,17 @@
           </span>
         </a>
       </div>
+      {{ if not $isLatest }}
+      {{ $url := replaceRE $version $latest .RelPermalink }}
+      <article class="message is-warning">
+        <div class="message-header">
+          <p>Warning</p>  
+        </div>
+        <div class="message-body">
+          You are currently viewing Version "{{ $version }}" of the documentation and it is not the latest. For the most recent documentation, kindly <a href="{{ $url }}"> click here.</a>
+        </div>
+      </article>
+      {{ end }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

I have added in a banner to show on old docs to inform the reader they are reading old documentation

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #779 
