### PR TITLE
fix: Version warning has odd casing

### DIFF
--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -81,7 +81,7 @@
           <p>Warning</p>  
         </div>
         <div class="message-body">
-          You are currently viewing Version "{{ $version }}" of the documentation and it is not the latest. For the most recent documentation, kindly <a href="{{ $url }}"> click here.</a>
+          You are currently viewing v"{{ $version }}" of the documentation and it is not the latest. For the most recent documentation, kindly <a href="{{ $url }}"> click here.</a>
         </div>
       </article>
       {{ end }}


### PR DESCRIPTION
Version warning has odd casing so I improved it:

![image](https://github.com/kedacore/keda-docs/assets/4345663/bed9d832-cab3-4817-9874-a4afbf98ed2b)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

