### PR TITLE
docs: fixed typo on scaling deployments - caching metrics

### DIFF
--- a/content/docs/2.10/concepts/scaling-deployments.md
+++ b/content/docs/2.10/concepts/scaling-deployments.md
@@ -224,7 +224,7 @@ Trigger fields:
 
 ### Caching Metrics (Experimental)
 
- This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metris Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval. 
+ This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metrics Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval. 
  
  Enabling this feature can significantly reduce the load on the scaler service. 
  

--- a/content/docs/2.11/concepts/scaling-deployments.md
+++ b/content/docs/2.11/concepts/scaling-deployments.md
@@ -227,7 +227,7 @@ Trigger fields:
 
 ### Caching Metrics
 
-This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metris Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval.
+This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metrics Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval.
 
 Enabling this feature can significantly reduce the load on the scaler service.
 

--- a/content/docs/2.12/concepts/scaling-deployments.md
+++ b/content/docs/2.12/concepts/scaling-deployments.md
@@ -227,7 +227,7 @@ Trigger fields:
 
 ### Caching Metrics
 
-This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metris Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval.
+This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metrics Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval.
 
 Enabling this feature can significantly reduce the load on the scaler service.
 

--- a/content/docs/2.9/concepts/scaling-deployments.md
+++ b/content/docs/2.9/concepts/scaling-deployments.md
@@ -224,7 +224,7 @@ Trigger fields:
 
 ### Caching Metrics (Experimental)
 
- This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metris Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval. 
+ This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metrics Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval. 
  
  Enabling this feature can significantly reduce the load on the scaler service. 
  


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Fixed typo on scaling-deployments. Metris -> Metrics

### Checklist

- [ Done ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
