### PR TITLE
chore: remove plain text connection string from mongodb example

### DIFF
--- a/content/docs/2.1/scalers/mongodb.md
+++ b/content/docs/2.1/scalers/mongodb.md
@@ -113,7 +113,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.10/scalers/mongodb.md
+++ b/content/docs/2.10/scalers/mongodb.md
@@ -122,7 +122,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.11/scalers/mongodb.md
+++ b/content/docs/2.11/scalers/mongodb.md
@@ -122,7 +122,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.12/scalers/mongodb.md
+++ b/content/docs/2.12/scalers/mongodb.md
@@ -122,7 +122,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.2/scalers/mongodb.md
+++ b/content/docs/2.2/scalers/mongodb.md
@@ -113,7 +113,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.3/scalers/mongodb.md
+++ b/content/docs/2.3/scalers/mongodb.md
@@ -113,7 +113,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.4/scalers/mongodb.md
+++ b/content/docs/2.4/scalers/mongodb.md
@@ -113,7 +113,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.5/scalers/mongodb.md
+++ b/content/docs/2.5/scalers/mongodb.md
@@ -117,7 +117,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.6/scalers/mongodb.md
+++ b/content/docs/2.6/scalers/mongodb.md
@@ -117,7 +117,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.7/scalers/mongodb.md
+++ b/content/docs/2.7/scalers/mongodb.md
@@ -117,7 +117,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.8/scalers/mongodb.md
+++ b/content/docs/2.8/scalers/mongodb.md
@@ -122,7 +122,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent

--- a/content/docs/2.9/scalers/mongodb.md
+++ b/content/docs/2.9/scalers/mongodb.md
@@ -122,7 +122,6 @@ spec:
           - name: mongodb-update
             image: 1314520999/mongodb-update:latest
             args:
-            - --connectStr=mongodb://test_user:test_password@mongoDB-svc.mongoDB.svc.cluster.local:27017/test
             - --dataBase=test
             - --collection=test_collection
             imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This connection string in plain text doesn't add any value to the example and could induce to users the idea that they can/should store the data using plain text, something that it's not supported by KEDA at all

