### PR TITLE
fix: update v2.12 instead of v2.11 with RabbitMQ changes

### DIFF
--- a/content/docs/2.11/scalers/rabbitmq-queue.md
+++ b/content/docs/2.11/scalers/rabbitmq-queue.md
@@ -29,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `host` - Host of RabbitMQ with format `<protocol>://<host>:<port>/vhost`. If the protocol is HTTP than the host may follow this format `http://<host>:<port>/<path>/<vhost>`. In example the resolved host value could be `amqp://guest:password@localhost:5672/vhost` or `http://guest:password@localhost:15672/path/vhost`. If the host doesn't contain vhost than the trailing slash is required in this case like `http://guest:password@localhost:5672/`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
+- `host` - Host of RabbitMQ with format `<protocol>://<host>:<port>/vhost`. The resolved host should follow a format like `amqp://guest:password@localhost:5672/vhost` or `http://guest:password@localhost:15672/vhost`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 - `queueName` - Name of the queue to read message from.
 - `mode` - QueueLength to trigger on number of messages in the queue. MessageRate to trigger on the published rate into the queue. (Values: `QueueLength`, `MessageRate`)
 - `value` - Message backlog or Publish/sec. rate to trigger on. (This value can be a float when `mode: MessageRate`)
@@ -66,7 +66,7 @@ Some parameters could be provided using environmental variables, instead of sett
 TriggerAuthentication CRD is used to connect and authenticate to RabbitMQ:
 
 - For AMQP, the URI should look similar to `amqp://guest:password@localhost:5672/vhost`.
-- For HTTP, the URI should look similar to `http://guest:password@localhost:15672/path/vhost`.
+- For HTTP, the URI should look similar to `http://guest:password@localhost:15672/vhost`.
 
 > See the [RabbitMQ Ports](https://www.rabbitmq.com/networking.html#ports) section for more details on how to configure the ports.
 
@@ -191,7 +191,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/path/vhost
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -231,7 +231,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/path/vhost
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -279,7 +279,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/path/vhost
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/content/docs/2.12/scalers/rabbitmq-queue.md
+++ b/content/docs/2.12/scalers/rabbitmq-queue.md
@@ -29,7 +29,7 @@ triggers:
 
 **Parameter list:**
 
-- `host` - Host of RabbitMQ with format `<protocol>://<host>:<port>/vhost`. The resolved host should follow a format like `amqp://guest:password@localhost:5672/vhost` or `http://guest:password@localhost:15672/vhost`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
+- `host` - Host of RabbitMQ with format `<protocol>://<host>:<port>/vhost`. If the protocol is HTTP than the host may follow this format `http://<host>:<port>/<path>/<vhost>`. In example the resolved host value could be `amqp://guest:password@localhost:5672/vhost` or `http://guest:password@localhost:15672/path/vhost`. If the host doesn't contain vhost than the trailing slash is required in this case like `http://guest:password@localhost:5672/`. When using a username/password consider using `hostFromEnv` or a TriggerAuthentication.
 - `queueName` - Name of the queue to read message from.
 - `mode` - QueueLength to trigger on number of messages in the queue. MessageRate to trigger on the published rate into the queue. (Values: `QueueLength`, `MessageRate`)
 - `value` - Message backlog or Publish/sec. rate to trigger on. (This value can be a float when `mode: MessageRate`)
@@ -65,7 +65,7 @@ Some parameters could be provided using environmental variables, instead of sett
 TriggerAuthentication CRD is used to connect and authenticate to RabbitMQ:
 
 - For AMQP, the URI should look similar to `amqp://guest:password@localhost:5672/vhost`.
-- For HTTP, the URI should look similar to `http://guest:password@localhost:15672/vhost`.
+- For HTTP, the URI should look similar to `http://guest:password@localhost:15672/path/vhost`.
 
 > See the [RabbitMQ Ports](https://www.rabbitmq.com/networking.html#ports) section for more details on how to configure the ports.
 
@@ -188,7 +188,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhost
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/path/vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -228,7 +228,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhost
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/path/vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -276,7 +276,7 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/vhost
+  host: <HTTP API endpoint> # base64 encoded value of format http://guest:password@localhost:15672/path/vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication


### PR DESCRIPTION
I didn't check enough [this PR](https://github.com/kedacore/keda-docs/pull/1146) and I missed that it was in the wrong file. This PR moves the changes from v2.11 to v2.12
