### PR TITLE
Add docs for additional metrics provided by metrics server

### DIFF
--- a/content/docs/2.11/operate/prometheus.md
+++ b/content/docs/2.11/operate/prometheus.md
@@ -35,6 +35,10 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
 
+The Metrics Adapter also exposes Promethues metrics provided by the kubernetes/apiserver library on port `6443` at `/metrics`. These metrics require you to define an allow rule for the `/metrics` endpoint as explained [here](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/) and must be accessed by providing a Bearer token
+
+- Metrics exposed (prepended w/ `apiserver_`) [here](https://kubernetes.io/docs/reference/instrumentation/metrics/)
+
 ## Premade Grafana dashboard
 
 A premade [Grafana dashboard](https://github.com/kedacore/keda/tree/main/config/grafana/keda-dashboard.json) is available to visualize metrics exposed by the KEDA Metrics Adapter.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Metrics server actually exposes an additional metric endpoint that many probably are not aware of; This is where SLO metrics can be retrieved from;  

exposes metrics like:
```
apiserver_request_total{group="external.metrics.k8s.io"}
apiserver_request_sli_duration_seconds_bucket{group="external.metrics.k8s.io"}
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes [#4460](https://github.com/kedacore/keda/issues/4460)
