### PR TITLE
Add TLS  authentication for redis scaler

### DIFF
--- a/content/docs/2.12/scalers/redis-cluster-lists.md
+++ b/content/docs/2.12/scalers/redis-cluster-lists.md
@@ -62,6 +62,16 @@ You can authenticate by using a password.
 - `username` - Redis username to authenticate with.
 - `password` - Redis password to authenticate with.
 
+**TLS:**
+
+Parameters used for configuring TLS authentication. Note this can not be used together with `enableTLS` and `unsafeSsl` on the `ScaledObject`, which is used to define using insecure TLS with skipping certificate check.
+
+- `tls` - To enable SSL auth for Redis, set this to `enable`. If not set, TLS for Redis is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `ca` - Certificate authority file for TLS authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
+
 ### Example
 
 Here is an example of how to deploy a scaled object with the `redis-cluster` scale trigger which uses `TriggerAuthentication`.

--- a/content/docs/2.12/scalers/redis-cluster-streams.md
+++ b/content/docs/2.12/scalers/redis-cluster-streams.md
@@ -113,6 +113,21 @@ spec:
 
 #### Using `TriggerAuthentication`
 
+**TLS:**
+
+Parameters used for configuring TLS authentication. Note this can not be used together with `enableTLS` and `unsafeSsl` on the `ScaledObject`, which is used to define using insecure TLS with skipping certificate check.
+
+- `tls` - To enable SSL auth for Redis, set this to `enable`. If not set, TLS for Redis is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `ca` - Certificate authority file for TLS authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
+
+**Authentication:**
+
+- `username` - Redis username to authenticate with.
+- `password` - Redis password to authenticate with.
+
 You can use `TriggerAuthentication` CRD to configure the authentication. For example:
 
 ```yaml
@@ -124,6 +139,10 @@ type: Opaque
 data:
   redis_username: <encoded redis username>
   redis_password: <encoded redis password>
+  tls: "enable"
+  ca: <your ca>
+  cert: <your cert>
+  key: <your key>
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -137,6 +156,18 @@ spec:
     - parameter: password
       name: redis-streams-auth # name of the Secret
       key: redis_password # name of the key in the Secret
+    - parameter: tls
+      name: redis-streams-auth
+      key: tls
+    - parameter: ca
+      name: redis-streams-auth
+      key: ca
+    - parameter: cert
+      name: redis-streams-auth
+      key: cert
+    - parameter: key
+      name: redis-streams-auth
+      key: key
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/content/docs/2.12/scalers/redis-lists.md
+++ b/content/docs/2.12/scalers/redis-lists.md
@@ -59,6 +59,16 @@ You can authenticate by using a username (optional) and password.
 - `host` - The hostname of the Redis server. If specified, the `port` should also be specified.
 - `port` - The port of the Redis server. If specified, the `host` should also be specified.
 
+**TLS:**
+
+Parameters used for configuring TLS authentication. Note this can not be used together with `enableTLS` and `unsafeSsl` on the `ScaledObject`, which is used to define using insecure TLS with skipping certificate check.
+
+- `tls` - To enable SSL auth for Redis, set this to `enable`. If not set, TLS for Redis is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `ca` - Certificate authority file for TLS authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
+
 **Authentication:**
 
 - `username` - Redis username to authenticate with.

--- a/content/docs/2.12/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.12/scalers/redis-sentinel-lists.md
@@ -75,6 +75,16 @@ You can authenticate by using a password.
 - `sentinelUsername` - Redis Sentinel username to authenticate with.
 - `sentinelPassword` - Redis Sentinel password to authenticate with.
 
+**TLS:**
+
+Parameters used for configuring TLS authentication. Note this can not be used together with `enableTLS` and `unsafeSsl` on the `ScaledObject`, which is used to define using insecure TLS with skipping certificate check.
+
+- `tls` - To enable SSL auth for Redis, set this to `enable`. If not set, TLS for Redis is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `ca` - Certificate authority file for TLS authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
+
 
 ### Example
 

--- a/content/docs/2.12/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.12/scalers/redis-sentinel-streams.md
@@ -119,6 +119,21 @@ spec:
 
 #### Using `TriggerAuthentication`
 
+**TLS:**
+
+Parameters used for configuring TLS authentication. Note this can not be used together with `enableTLS` and `unsafeSsl` on the `ScaledObject`, which is used to define using insecure TLS with skipping certificate check.
+
+- `tls` - To enable SSL auth for Redis, set this to `enable`. If not set, TLS for Redis is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `ca` - Certificate authority file for TLS authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
+
+**Authentication:**
+
+- `username` - Redis username to authenticate with.
+- `password` - Redis password to authenticate with.
+
 You can use `TriggerAuthentication` CRD to configure the authentication. For example:
 
 ```yaml
@@ -130,6 +145,10 @@ type: Opaque
 data:
   redis_username: <encoded redis username>
   redis_password: <encoded redis password>
+  tls: "enable"
+  ca: <your ca>
+  cert: <your cert>
+  key: <your key>
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -143,6 +162,18 @@ spec:
     - parameter: password
       name: redis-streams-auth # name of the Secret
       key: redis_password # name of the key in the Secret
+    - parameter: tls
+      name: redis-streams-auth
+      key: tls
+    - parameter: ca
+      name: redis-streams-auth
+      key: ca
+    - parameter: cert
+      name: redis-streams-auth
+      key: cert
+    - parameter: key
+      name: redis-streams-auth
+      key: key
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/content/docs/2.12/scalers/redis-streams.md
+++ b/content/docs/2.12/scalers/redis-streams.md
@@ -110,6 +110,21 @@ spec:
 
 #### Using `TriggerAuthentication`
 
+**TLS:**
+
+Parameters used for configuring TLS authentication. Note this can not be used together with `enableTLS` and `unsafeSsl` on the `ScaledObject`, which is used to define using insecure TLS with skipping certificate check.
+
+- `tls` - To enable SSL auth for Redis, set this to `enable`. If not set, TLS for Redis is not used. (Values: `enable`, `disable`, Default: `disable`, Optional)
+- `ca` - Certificate authority file for TLS authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the `keyPassword` is used to decrypt the provided `key`. (Optional)
+
+**Authentication:**
+
+- `username` - Redis username to authenticate with.
+- `password` - Redis password to authenticate with.
+
 You can use `TriggerAuthentication` CRD to configure the authentication. For example:
 
 ```yaml
@@ -121,6 +136,10 @@ type: Opaque
 data:
   redis_username: <encoded redis username>
   redis_password: <encoded redis password>
+  tls: "enable"
+  ca: <your ca>
+  cert: <your cert>
+  key: <your key>
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -134,6 +153,18 @@ spec:
     - parameter: password
       name: redis-streams-auth # name of the Secret
       key: redis_password # name of the key in the Secret
+    - parameter: tls
+      name: redis-streams-auth
+      key: tls
+    - parameter: ca
+      name: redis-streams-auth
+      key: ca
+    - parameter: cert
+      name: redis-streams-auth
+      key: cert
+    - parameter: key
+      name: redis-streams-auth
+      key: key
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add TLS  authentication for redis scalers and redis stream scalers.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
