### PR TITLE
chore: Add databaseIndex to documentation of redis-cluster scaler

### DIFF
--- a/content/docs/2.12/scalers/redis-cluster-lists.md
+++ b/content/docs/2.12/scalers/redis-cluster-lists.md
@@ -22,6 +22,7 @@ triggers:
     activationListLength: "5" # optional
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -40,6 +41,7 @@ triggers:
 - `activationListLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
 - `enableTLS` - Allow a connection to a redis queue using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.12/scalers/redis-cluster-streams.md
+++ b/content/docs/2.12/scalers/redis-cluster-streams.md
@@ -35,6 +35,7 @@ triggers:
     activationLagCount: "3" # required if lagCount is provided - lag count at which scaler triggers
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -68,6 +69,7 @@ triggers:
 - `activationLagCount` - Lag count threshold at which to start scaling. Any average lag count below this value will not trigger the scaler. (Default: `0`, Optional)
 - `enableTLS` - Allow a connection to Redis using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.12/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.12/scalers/redis-sentinel-lists.md
@@ -25,6 +25,7 @@ triggers:
     activationListLength: "5" # optional
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -46,6 +47,7 @@ triggers:
 - `activationListLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
 - `enableTLS` - Allow a connection to a redis queue using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.12/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.12/scalers/redis-sentinel-streams.md
@@ -35,6 +35,7 @@ triggers:
     activationLagCount: "3" # required if lagCount is provided - lag count at which scaler triggers
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -72,6 +73,7 @@ triggers:
 - `activationLagCount` - Lag count threshold at which to start scaling. Any average lag count below this value will not trigger the scaler. (Default: `0`, Optional)
 - `enableTLS` - Allow a connection to Redis using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.12/scalers/redis-streams.md
+++ b/content/docs/2.12/scalers/redis-streams.md
@@ -62,9 +62,9 @@ triggers:
 > Setting the `consumerGroup` causes the scaler to operate on `pendingEntriesCount`. Lack of `consumerGroup` will cause the scaler to be based on `streamLength`
 - `pendingEntriesCount` - Threshold for the number of `Pending Entries List`. This is the average target value to scale the workload. (Default: `5`, Optional)
 - `streamLength` - Threshold for stream length, alternative average target value to scale workload. (Default: `5`, Optional)
-- `databaseIndex` - The Redis database index. Defaults to `0` if not specified.
 - `enableTLS` - Allow a connection to Redis using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - The Redis database index. Defaults to `0` if not specified.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.13/scalers/redis-cluster-lists.md
+++ b/content/docs/2.13/scalers/redis-cluster-lists.md
@@ -22,6 +22,7 @@ triggers:
     activationListLength: "5" # optional
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -40,6 +41,7 @@ triggers:
 - `activationListLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
 - `enableTLS` - Allow a connection to a redis queue using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.13/scalers/redis-cluster-streams.md
+++ b/content/docs/2.13/scalers/redis-cluster-streams.md
@@ -35,6 +35,7 @@ triggers:
     activationLagCount: "3" # required if lagCount is provided - lag count at which scaler triggers
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -68,6 +69,7 @@ triggers:
 - `activationLagCount` - Lag count threshold at which to start scaling. Any average lag count below this value will not trigger the scaler. (Default: `0`, Optional)
 - `enableTLS` - Allow a connection to Redis using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.13/scalers/redis-sentinel-lists.md
+++ b/content/docs/2.13/scalers/redis-sentinel-lists.md
@@ -25,6 +25,7 @@ triggers:
     activationListLength: "5" # optional
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -46,6 +47,7 @@ triggers:
 - `activationListLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional)
 - `enableTLS` - Allow a connection to a redis queue using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.13/scalers/redis-sentinel-streams.md
+++ b/content/docs/2.13/scalers/redis-sentinel-streams.md
@@ -35,6 +35,7 @@ triggers:
     activationLagCount: "3" # required if lagCount is provided - lag count at which scaler triggers
     enableTLS: "false" # optional
     unsafeSsl: "false" # optional
+    databaseIndex: "0" # optional
     # Alternatively, you can use existing environment variables to read configuration from:
     # See details in "Parameter list" section
     addressesFromEnv: REDIS_ADDRESSES # Optional. You can use this instead of `addresses` parameter
@@ -72,6 +73,7 @@ triggers:
 - `activationLagCount` - Lag count threshold at which to start scaling. Any average lag count below this value will not trigger the scaler. (Default: `0`, Optional)
 - `enableTLS` - Allow a connection to Redis using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 

--- a/content/docs/2.13/scalers/redis-streams.md
+++ b/content/docs/2.13/scalers/redis-streams.md
@@ -62,9 +62,9 @@ triggers:
 > Setting the `consumerGroup` causes the scaler to operate on `pendingEntriesCount`. Lack of `consumerGroup` will cause the scaler to be based on `streamLength`
 - `pendingEntriesCount` - Threshold for the number of `Pending Entries List`. This is the average target value to scale the workload. (Default: `5`, Optional)
 - `streamLength` - Threshold for stream length, alternative average target value to scale workload. (Default: `5`, Optional)
-- `databaseIndex` - The Redis database index. Defaults to `0` if not specified.
 - `enableTLS` - Allow a connection to Redis using tls. (Values: `true`, `false`, Default: `false`, Optional)
 - `unsafeSsl` - Used for skipping certificate check e.g: using self-signed certs. (Values: `true`,`false`, Default: `false`, Optional, This requires `enableTLS: true`)
+- `databaseIndex` - Index of Redis database to use. If not specified, the default value is 0.
 
 Some parameters could be provided using environmental variables, instead of setting them directly in metadata. Here is a list of parameters you can use to retrieve values from environment variables:
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Add `databaseIndex` argument to documentation of `redis-cluster` scaler.
The text is identical to the `redis` scaler.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
