### PR TITLE
Fix scalingModifiers docs in concepts

### DIFF
--- a/content/docs/2.12/concepts/scaling-deployments.md
+++ b/content/docs/2.12/concepts/scaling-deployments.md
@@ -328,7 +328,7 @@ If the calculated value is <=2, the ScaledObject is not `Active` and it'll scale
 ```yaml
 advanced:
   scalingModifiers:
-    formula: "trig_one > 2 ? trig_one + trig_two : 1.0"
+    formula: "trig_one > 2 ? trig_one + trig_two : 1"
 ```
 
 If metric value of trigger `trig_one` is more than 2, then return `trig_one` + `trig_two` otherwise return 1.
@@ -338,7 +338,7 @@ If metric value of trigger `trig_one` is more than 2, then return `trig_one` + `
 ```yaml
 advanced:
   scalingModifiers:
-    formula: "count([trig_one,trig_two,trig_three],{#>1}) > 1 ? 5.0 : 0.0"
+    formula: "count([trig_one,trig_two,trig_three],{#>1}) > 1 ? 5 : 0"
 ```
 
 If atleast 2 metrics (from the list `trig_one`,`trig_two`,`trig_three`) have value of more than 1, then return 5, otherwise return 0
@@ -348,7 +348,7 @@ If atleast 2 metrics (from the list `trig_one`,`trig_two`,`trig_three`) have val
 ```yaml
 advanced:
   scalingModifiers:
-    formula: "trig_one < 2 ? trig_one+trig_two >= 2 ? 5.0 : 10.0 : 0.0"
+    formula: "float(trig_one < 2 ? trig_one+trig_two >= 2 ? 5 : 10 : 0)"
 ```
 
 Conditions can be used within another condition as well.

--- a/content/docs/2.13/concepts/scaling-deployments.md
+++ b/content/docs/2.13/concepts/scaling-deployments.md
@@ -328,17 +328,17 @@ If the calculated value is <=2, the ScaledObject is not `Active` and it'll scale
 ```yaml
 advanced:
   scalingModifiers:
-    formula: "trig_one > 2 ? trig_one + trig_two : 1.0"
+    formula: "float(trig_one > 2 ? trig_one + trig_two : 1)"
 ```
 
-If metric value of trigger `trig_one` is more than 2, then return `trig_one` + `trig_two` otherwise return 1.
+If metric value of trigger `trig_one` is more than 2, then return `trig_one` + `trig_two` otherwise return 1. Result of a ternary operator is of type `any` therefore cast to `float` at the end.
 
 **Example: count function**
 
 ```yaml
 advanced:
   scalingModifiers:
-    formula: "count([trig_one,trig_two,trig_three],{#>1}) > 1 ? 5.0 : 0.0"
+    formula: "count([trig_one,trig_two,trig_three],{#>1}) > 1 ? 5 : 0"
 ```
 
 If atleast 2 metrics (from the list `trig_one`,`trig_two`,`trig_three`) have value of more than 1, then return 5, otherwise return 0
@@ -348,11 +348,11 @@ If atleast 2 metrics (from the list `trig_one`,`trig_two`,`trig_three`) have val
 ```yaml
 advanced:
   scalingModifiers:
-    formula: "trig_one < 2 ? trig_one+trig_two >= 2 ? 5.0 : 10.0 : 0.0"
+    formula: "float(trig_one < 2 ? trig_one+trig_two >= 2 ? 5 : 10 : 0)"
 ```
 
 Conditions can be used within another condition as well.
-If value of `trig_one` is less than 2 AND `trig_one`+`trig_two` is atleast 2 then return 5, if only the first is true return 10, if the first condition is false then return 0.
+If value of `trig_one` is less than 2 AND `trig_one`+`trig_two` is atleast 2 then return 5, if only the first is true return 10, if the first condition is false then return 0. Result of a ternary operator is `any` therefore cast to `float` before returing the result.
 
 Complete language definition of `expr` package can be found [here](https://expr.medv.io/docs/Language-Definition). Formula must return a single value (not boolean)
 ### Activating and Scaling thresholds


### PR DESCRIPTION
Fix docs for scalingModifiers structure. Expr package returns type `any` on ternary operator therefore manually cast float at the result before returning