### PR TITLE
use correct apiVersion for redis lists example

### DIFF
--- a/content/docs/1.4/scalers/redis-lists.md
+++ b/content/docs/1.4/scalers/redis-lists.md
@@ -58,7 +58,7 @@ type: Opaque
 data:
   redis_password: YWRtaW4=
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: keda-trigger-auth-redis-secret
@@ -69,7 +69,7 @@ spec:
     name: votes-db-secret
     key: redis_password
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: redis-scaledobject


### PR DESCRIPTION
Fix the documentation for Redis lists trigger to use the correct apiVersion. The version in the example does not work.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

