### PR TITLE
Fix the documentation on github-runner.md to use correct variable name for githubApiURL

### DIFF
--- a/content/docs/2.12/scalers/github-runner.md
+++ b/content/docs/2.12/scalers/github-runner.md
@@ -15,7 +15,7 @@ triggers:
   - type: github-runner
     metadata:
       # Optional: The URL of the GitHub API, defaults to https://api.github.com
-      githubAPIURL: "https://api.github.com"
+      githubApiURL: "https://api.github.com"
       # Required: The owner of the GitHub repository, or the organization that owns the repository
       owner: "{owner}"
       # Required: The scope of the runner, can be either "org" (organisation), "ent" (enterprise) or "repo" (repository)
@@ -36,7 +36,7 @@ triggers:
 
 **Parameter list:**
 
-- `githubAPIURL` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
+- `githubApiURL` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
 - `owner` - The owner of the GitHub repository, or the organization that owns the repository. (Required)
 - `runnerScope` - The scope of the runner, can be either "org", "ent" or "repo". (Required)
 - `repos` - The list of repositories to scale, separated by comma. (Optional)
@@ -50,7 +50,7 @@ triggers:
 You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
-- `githubAPIURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
+- `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
 - `ownerFromEnv` - The owner of the GitHub repository, or the organization that owns the repository. (Required)
 - `runnerScopeFromEnv` - The scope of the runner, can be either "org", "ent" or "repo". (Required)
 - `reposFromEnv` - The list of repositories to scale, separated by comma. (Optional)
@@ -159,7 +159,7 @@ spec:
   triggers:
   - type: github-runner
     metadata:
-      githubAPIURL: "https://api.github.com"
+      githubApiURL: "https://api.github.com"
       owner: "kedacore"
       runnerScope: "repo"
       repos: "keda,keda-docs"


### PR DESCRIPTION
The variable name should be `githubApiURL`, not the `githubAPIURL` as per the line below:

https://github.com/kedacore/keda/blob/main/pkg/scalers/github_runner_scaler.go#L412

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
