### PR TITLE
fix: Update prometheus documentation to reflect current metrics

### DIFF
--- a/content/docs/2.11/operate/prometheus.md
+++ b/content/docs/2.11/operate/prometheus.md
@@ -34,7 +34,7 @@ The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` 
 The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
-- Metrics exposed (prepended with `apiserver_`) by [Kubernetes API Server](https://kubernetes.io/docs/reference/instrumentation/metrics/)
+
 
 ## Premade Grafana dashboard
 

--- a/content/docs/2.12/operate/prometheus.md
+++ b/content/docs/2.12/operate/prometheus.md
@@ -34,6 +34,7 @@ The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` 
 The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
+- Metrics exposed (prepended with `apiserver_`) by [Kubernetes API Server](https://kubernetes.io/docs/reference/instrumentation/metrics/)
 
 ## Premade Grafana dashboard
 

--- a/content/docs/2.13/operate/prometheus.md
+++ b/content/docs/2.13/operate/prometheus.md
@@ -34,6 +34,7 @@ The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` 
 The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:
 
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
+- Metrics exposed (prepended with `apiserver_`) by [Kubernetes API Server](https://kubernetes.io/docs/reference/instrumentation/metrics/)
 
 ## Premade Grafana dashboard
 


### PR DESCRIPTION
It looks that the change was applied to the wrong page as it was introduced as part of v2.12
https://github.com/kedacore/keda/pull/4982

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
