### PR TITLE
Clarify that autoscaling.keda.sh/paused annotation value is not important. Only prescence is checked

### DIFF
--- a/content/docs/2.11/concepts/scaling-jobs.md
+++ b/content/docs/2.11/concepts/scaling-jobs.md
@@ -28,7 +28,7 @@ kind: ScaledJob
 metadata:
   name: {scaled-job-name}
   annotations:
-    autoscaling.keda.sh/paused: true          # Optional. Use to pause autoscaling of Jobs
+    autoscaling.keda.sh/paused: any-value          # Optional. Use to pause autoscaling of Jobs.
 spec:
   jobTargetRef:
     parallelism: 1                            # [max number of desired pods](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)
@@ -251,10 +251,10 @@ You can enable this by adding the below annotation to your `ScaledJob` definitio
 ```yaml
 metadata:
   annotations:
-    autoscaling.keda.sh/paused: true
+    autoscaling.keda.sh/paused: any-value
 ```
 
-The above annotation will pause autoscaling. To enable autoscaling again, simply remove the annotation from the `ScaledJob` definition.
+The above annotation will pause autoscaling. To enable autoscaling again, simply remove the annotation from the `ScaledJob` definition. Note, the annotation value is not important, only the presence of the annotation is used to determine if autoscaling is paused or not.
 
 # Sample
 

--- a/content/docs/2.11/concepts/scaling-jobs.md
+++ b/content/docs/2.11/concepts/scaling-jobs.md
@@ -28,7 +28,7 @@ kind: ScaledJob
 metadata:
   name: {scaled-job-name}
   annotations:
-    autoscaling.keda.sh/paused: any-value          # Optional. Use to pause autoscaling of Jobs.
+    autoscaling.keda.sh/paused: any-value          # Optional. Use to pause autoscaling of Jobs
 spec:
   jobTargetRef:
     parallelism: 1                            # [max number of desired pods](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)

--- a/content/docs/2.12/concepts/scaling-jobs.md
+++ b/content/docs/2.12/concepts/scaling-jobs.md
@@ -28,7 +28,7 @@ kind: ScaledJob
 metadata:
   name: {scaled-job-name}
   annotations:
-    autoscaling.keda.sh/paused: true          # Optional. Use to pause autoscaling of Jobs
+    autoscaling.keda.sh/paused: any-value          # Optional. Use to pause autoscaling of Jobs
 spec:
   jobTargetRef:
     parallelism: 1                            # [max number of desired pods](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)
@@ -251,10 +251,10 @@ You can enable this by adding the below annotation to your `ScaledJob` definitio
 ```yaml
 metadata:
   annotations:
-    autoscaling.keda.sh/paused: true
+    autoscaling.keda.sh/paused: any-value
 ```
 
-The above annotation will pause autoscaling. To enable autoscaling again, simply remove the annotation from the `ScaledJob` definition.
+The above annotation will pause autoscaling. To enable autoscaling again, simply remove the annotation from the `ScaledJob` definition. Note, the annotation value is not important, only the presence of the annotation is used to determine if autoscaling is paused or not.
 
 # Sample
 

--- a/content/docs/2.13/concepts/scaling-deployments.md
+++ b/content/docs/2.13/concepts/scaling-deployments.md
@@ -41,7 +41,7 @@ metadata:
   annotations:
     scaledobject.keda.sh/transfer-hpa-ownership: "true"      # Optional. Use to transfer an existing HPA ownership to this ScaledObject
     autoscaling.keda.sh/paused-replicas: "0"                # Optional. Use to pause autoscaling of objects
-    autoscaling.keda.sh/paused: "true"                      # Optional. Use to pause autoscaling of objects explicitly
+    autoscaling.keda.sh/paused: "any-value"                      # Optional. Use to pause autoscaling of objects explicitly
 spec:
   scaleTargetRef:
     apiVersion:    {api-version-of-target-resource}         # Optional. Default: apps/v1
@@ -275,7 +275,7 @@ It can be useful to instruct KEDA to pause autoscaling of objects, if you want t
 metadata:
   annotations:
     autoscaling.keda.sh/paused-replicas: "0"
-    autoscaling.keda.sh/paused: "true"
+    autoscaling.keda.sh/paused: "any-value"
 ```
 
 The presence of these annotations will pause autoscaling no matter what number of replicas is provided.

--- a/content/docs/2.13/concepts/scaling-jobs.md
+++ b/content/docs/2.13/concepts/scaling-jobs.md
@@ -30,7 +30,7 @@ metadata:
   labels:
     my-label: {my-label-value}                # Optional. ScaledJob labels are applied to child Jobs
   annotations:
-    autoscaling.keda.sh/paused: true          # Optional. Use to pause autoscaling of Jobs
+    autoscaling.keda.sh/paused: any-value          # Optional. Use to pause autoscaling of Jobs
     my-annotation: {my-annotation-value}      # Optional. ScaledJob annotations are applied to child Jobs
 spec:
   jobTargetRef:
@@ -254,7 +254,7 @@ You can enable this by adding the below annotation to your `ScaledJob` definitio
 ```yaml
 metadata:
   annotations:
-    autoscaling.keda.sh/paused: true
+    autoscaling.keda.sh/paused: any-value
 ```
 
 The above annotation will pause autoscaling. To enable autoscaling again, simply remove the annotation from the `ScaledJob` definition.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Essentially, as a new Keda user I spent a long time trying to figure out why `autoscaling.keda.sh/paused: false` wasn't working as expected.

I opened this https://github.com/kedacore/keda/issues/5215 in `keda-core`. Until a resolution is decided there, I think this documentation update would be beneficial to avoid end-user communication.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
Potentially fixes - https://github.com/kedacore/keda/issues/5215
