### PR TITLE
Omitted 'TIMESERIES' from the examples, as TIMESERIES breaks the valu…

### DIFF
--- a/content/docs/2.10/scalers/new-relic.md
+++ b/content/docs/2.10/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: "50.50"
       # Optional: activationThreshold - Target value for activating the scaler.
@@ -96,7 +96,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.11/scalers/new-relic.md
+++ b/content/docs/2.11/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: "50.50"
       # Optional: activationThreshold - Target value for activating the scaler.
@@ -96,7 +96,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.12/scalers/new-relic.md
+++ b/content/docs/2.12/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: "50.50"
       # Optional: activationThreshold - Target value for activating the scaler.
@@ -96,7 +96,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.13/scalers/new-relic.md
+++ b/content/docs/2.13/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: "50.50"
       # Optional: activationThreshold - Target value for activating the scaler.
@@ -96,7 +96,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.6/scalers/new-relic.md
+++ b/content/docs/2.6/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: '100'
 ```
@@ -83,7 +83,7 @@ spec:
       metadata:
         account: '1234567'
         region: "US"
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.7/scalers/new-relic.md
+++ b/content/docs/2.7/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: '100'
 ```
@@ -93,7 +93,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.8/scalers/new-relic.md
+++ b/content/docs/2.8/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: "50.50"
       # Optional: activationThreshold - Target value for activating the scaler.
@@ -96,7 +96,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:

--- a/content/docs/2.9/scalers/new-relic.md
+++ b/content/docs/2.9/scalers/new-relic.md
@@ -23,7 +23,7 @@ triggers:
       # Optional: noDataError - If the query returns no data should this be treated as an error. Default value is false.
       noDataError: "true"
       # Required: nrql
-      nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+      nrql: "SELECT average(duration) from Transaction where appName='SITE'"
       # Required: threshold
       threshold: "50.50"
       # Optional: activationThreshold - Target value for activating the scaler.
@@ -96,7 +96,7 @@ spec:
   triggers:
     - type: new-relic
       metadata:
-        nrql: "SELECT average(duration) from Transaction where appName='SITE' TIMESERIES"
+        nrql: "SELECT average(duration) from Transaction where appName='SITE'"
         noDataError: "true"
         threshold: '1000'
       authenticationRef:


### PR DESCRIPTION
…e returned by the query

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
