### PR TITLE
Add documentation for `spec.hashiCorpVault.credential.seviceAccount` default value

### DIFF
--- a/content/docs/2.13/concepts/authentication.md
+++ b/content/docs/2.13/concepts/authentication.md
@@ -209,7 +209,7 @@ secretTargetRef:                          # Optional.
 ### Hashicorp Vault secret(s)
 
 You can pull one or more Hashicorp Vault secrets into the trigger by defining the authentication metadata such as Vault `address` and the `authentication` method (token | kubernetes). If you choose kubernetes auth method you should provide `role` and `mount` as well.
-`credential` defines the Hashicorp Vault credentials depending on the authentication method, for kubernetes you should provide path to service account token (the default value is /var/run/secrets/kubernetes.io/serviceaccount/token) and for token auth method provide the token.
+`credential` defines the Hashicorp Vault credentials depending on the authentication method, for kubernetes you should provide path to service account token (the default value is `/var/run/secrets/kubernetes.io/serviceaccount/token`) and for token auth method provide the token.
 `secrets` list defines the mapping between the path and the key of the secret in Vault to the parameter.
 `namespace` may be used to target a given Vault Enterprise namespace.
 

--- a/content/docs/2.13/concepts/authentication.md
+++ b/content/docs/2.13/concepts/authentication.md
@@ -209,7 +209,7 @@ secretTargetRef:                          # Optional.
 ### Hashicorp Vault secret(s)
 
 You can pull one or more Hashicorp Vault secrets into the trigger by defining the authentication metadata such as Vault `address` and the `authentication` method (token | kubernetes). If you choose kubernetes auth method you should provide `role` and `mount` as well.
-`credential` defines the Hashicorp Vault credentials depending on the authentication method, for kubernetes you should provide path to service account token (/var/run/secrets/kubernetes.io/serviceaccount/token) and for token auth method provide the token.
+`credential` defines the Hashicorp Vault credentials depending on the authentication method, for kubernetes you should provide path to service account token (the default value is /var/run/secrets/kubernetes.io/serviceaccount/token) and for token auth method provide the token.
 `secrets` list defines the mapping between the path and the key of the secret in Vault to the parameter.
 `namespace` may be used to target a given Vault Enterprise namespace.
 
@@ -222,7 +222,7 @@ hashiCorpVault:                                     # Optional.
   mount: {hashicorp-vault-mount}                    # Optional.
   credential:                                       # Optional.
     token: {hashicorp-vault-token}                  # Optional.
-    serviceAccount: {path-to-service-account-file}  # Optional.
+    serviceAccount: {path-to-service-account-file}  # Optional. Default is /var/run/secrets/kubernetes.io/serviceaccount/token
   secrets:                                          # Required.
   - parameter: {scaledObject-parameter-name}        # Required.
     key: {hasicorp-vault-secret-key-name}           # Required.


### PR DESCRIPTION
Hi team,

This PR incorporates changes from the PR https://github.com/kedacore/keda/pull/5180.

Let me know if we need to retrospectively change documentation for previous release ( < 2.13 ) as well



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
