### PR TITLE
docs(prometheus): remove deprecated metricName from examples

### DIFF
--- a/content/docs/2.12/scalers/prometheus.md
+++ b/content/docs/2.12/scalers/prometheus.md
@@ -360,7 +360,6 @@ spec:
     - type: prometheus
       metadata:
         serverAddress: http://<prometheus-host>:9090
-        metricName: http_requests_total
         threshold: '100'
         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
         authModes: "custom"
@@ -393,7 +392,6 @@ spec:
   - type: prometheus
     metadata:
       serverAddress: https://test-azure-monitor-workspace-name-9ksc.eastus.prometheus.monitor.azure.com
-      metricName: http_requests_total
       query: sum(rate(http_requests_total{deployment="my-deployment"}[2m])) # Note: query must return a vector/scalar single element response
       threshold: '100.50'
       activationThreshold: '5.5'


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

`metricName` was removed in the [2.12 release](https://github.com/kedacore/keda/releases/tag/v2.12.0) but was still present in the examples.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
