### PR TITLE
allow to authenticate to Azure Storage using SAS tokens

### DIFF
--- a/content/docs/2.13/scalers/azure-storage-blob.md
+++ b/content/docs/2.13/scalers/azure-storage-blob.md
@@ -53,6 +53,11 @@ You can authenticate by using pod identity or connection string authentication.
 
 - `connection` - Connection string for Azure Storage Account.
 
+  The following formats are supported.
+
+  - **Shared Key authentication** - `DefaultEndpointsProtocol=https;AccountName=<accountName>;AccountKey=<accountKey>;EndpointSuffix=<endpointSuffix>`
+  - **Shared access signature** (SAS) - `BlobEndpoint=<blobEndpoint>;SharedAccessSignature=<sasToken>`
+
 **Pod Identity Authentication**
 
 [Azure AD Pod Identity](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) or [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/) providers can be used.

--- a/content/docs/2.13/scalers/azure-storage-queue.md
+++ b/content/docs/2.13/scalers/azure-storage-queue.md
@@ -41,6 +41,11 @@ You can authenticate by using pod identity or connection string authentication.
 
 - `connection` - Connection string for Azure Storage Account.
 
+  The following formats are supported.
+
+  - **Shared Key authentication** - `DefaultEndpointsProtocol=https;AccountName=<accountName>;AccountKey=<accountKey>;EndpointSuffix=<endpointSuffix>`
+  - **Shared access signature** (SAS) - `QueueEndpoint=<queueEndpoint>;SharedAccessSignature=<sasToken>`
+
 **Pod identity based authentication:**
 
 [Azure AD Pod Identity](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) or [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/) providers can be used.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Related to https://github.com/kedacore/keda/pull/5382. Add support to use Shared Access Signature (SAS) authentication in Azure Storage Queue scaler.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
