### PR TITLE
update docs on metric value needing to be greater than activation value

### DIFF
--- a/content/docs/2.10/concepts/scaling-deployments.md
+++ b/content/docs/2.10/concepts/scaling-deployments.md
@@ -269,6 +269,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.

--- a/content/docs/2.11/concepts/scaling-deployments.md
+++ b/content/docs/2.11/concepts/scaling-deployments.md
@@ -270,6 +270,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.

--- a/content/docs/2.12/concepts/scaling-deployments.md
+++ b/content/docs/2.12/concepts/scaling-deployments.md
@@ -380,6 +380,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.

--- a/content/docs/2.13/concepts/scaling-deployments.md
+++ b/content/docs/2.13/concepts/scaling-deployments.md
@@ -380,6 +380,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.

--- a/content/docs/2.14/concepts/scaling-deployments.md
+++ b/content/docs/2.14/concepts/scaling-deployments.md
@@ -380,6 +380,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.

--- a/content/docs/2.8/concepts/scaling-deployments.md
+++ b/content/docs/2.8/concepts/scaling-deployments.md
@@ -253,6 +253,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.

--- a/content/docs/2.9/concepts/scaling-deployments.md
+++ b/content/docs/2.9/concepts/scaling-deployments.md
@@ -269,6 +269,8 @@ Each scaler defines parameters for their use-cases, but the activation will alwa
 There are some important topics to take into account:
 
 - Opposite to scaling value, the activation value is always optional and the default value is 0.
+- Activation only occurs when this value is greater than the set value; not greater than or equal to.
+  - ie, in the default case: `activationThreshold: 0` will only activate when the metric value is 1 or more
 - The activation value has more priority than the scaling value in case of different decisions for each. ie: `threshold: 10` and `activationThreshold: 50`, in case of 40 messages the scaler is not active and it'll be scaled to zero even the HPA requires 4 instances.
 
 > ⚠️ **NOTE:** If a scaler doesn't define "activation" parameter (a property that starts with `activation` prefix), then this specific scaler doesn't support configurable activation value and the activation value is always 0.


### PR DESCRIPTION
Related to https://github.com/kedacore/keda/issues/5383. Updating the activation docs to make it more clear on the value needing to be greater than this value, not equal to

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda/issues/5383
