### PR TITLE
Added ScaledObject parameter StartReplicaCount to scale from 0 to N

### DIFF
--- a/content/docs/2.13/concepts/scaling-deployments.md
+++ b/content/docs/2.13/concepts/scaling-deployments.md
@@ -48,11 +48,12 @@ spec:
     kind:          {kind-of-target-resource}                # Optional. Default: Deployment
     name:          {name-of-target-resource}                # Mandatory. Must be in the same namespace as the ScaledObject
     envSourceContainerName: {container-name}                # Optional. Default: .spec.template.spec.containers[0]
-  pollingInterval:  30                                      # Optional. Default: 30 seconds
-  cooldownPeriod:   300                                     # Optional. Default: 300 seconds
-  idleReplicaCount: 0                                       # Optional. Default: ignored, must be less than minReplicaCount
-  minReplicaCount:  1                                       # Optional. Default: 0
-  maxReplicaCount:  100                                     # Optional. Default: 100
+  pollingInterval:   30                                     # Optional. Default: 30 seconds
+  cooldownPeriod:    300                                    # Optional. Default: 300 seconds
+  idleReplicaCount:  0                                      # Optional. Default: ignored, must be less than minReplicaCount
+  minReplicaCount:   1                                      # Optional. Default: 0
+  maxReplicaCount:   100                                    # Optional. Default: 100
+  startReplicaCount: 5                                      # Optional. Default: 0
   fallback:                                                 # Optional. Section to specify fallback options
     failureThreshold: 3                                     # Mandatory if fallback section is included
     replicas: 6                                             # Mandatory if fallback section is included


### PR DESCRIPTION
This pull request introduces a new parameter, startReplicaCount, to the ScaledObject in order to change the scaling behavior from 0. The goal is to facilitate scaling from 0 to N replicas, instead of the default 0 to 1.
This change can be useful in scenarios where applications need fast responsiveness when is activated.

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)