### PR TITLE
fix: correct grammatical mistake in scaling-deployments.md

### DIFF
--- a/content/docs/2.13/concepts/scaling-deployments.md
+++ b/content/docs/2.13/concepts/scaling-deployments.md
@@ -265,7 +265,7 @@ Trigger fields:
 
 ### Caching Metrics
 
-This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then is this request routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metrics Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval.
+This feature enables caching of metric values during polling interval (as specified in `.spec.pollingInterval`). Kubernetes (HPA controller) asks for a metric every few seconds (as defined by `--horizontal-pod-autoscaler-sync-period`, usually 15s), then this request is routed to KEDA Metrics Server, that by default queries the scaler and reads the metric values. Enabling this feature changes this behavior, KEDA Metrics Server tries to read metric from the cache first. This cache is being updated periodically during the polling interval.
 
 Enabling this feature can significantly reduce the load on the scaler service.
 


### PR DESCRIPTION
Fixes a small grammatical mistake in the *Caching Metrics* section of scaling deployments doc.
