### PR TITLE
fix: Scalers not shown on landing page #1314

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -395,22 +395,3 @@
     });
   });
 </script>
-
-{{/* This logic expands collapsed section when URL is loaded in browser*/}}
-<script>
-  window.addEventListener(
-    "DOMContentLoaded",
-    () => {
-      "use strict";
-      const hash = (window.location.hash).slice(1);
-      const cardContents = document.querySelectorAll(".card-content");
-      cardContents.forEach((item) => {
-        const id = item.getAttribute("id");
-        if (hash === id) {
-          item.style.display = "";
-        } else {
-          item.style.display = "none";
-        }
-      });
-    });
-</script>


### PR DESCRIPTION
Remove bugged feature that causes scaler cards to load incorrectly.


Fixes #1314 
