### PR TITLE
Document prometheus metric deprecations

### DIFF
--- a/content/docs/2.14/operate/prometheus.md
+++ b/content/docs/2.14/operate/prometheus.md
@@ -34,13 +34,13 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 The following metrics are exposed as well, but are deprecated and will be removed in KEDA v2.16.
 
-- `keda_scaler_metrics_latency` - Replaced by `keda_scaler_metrics_latency_seconds`. The latency of retrieving current metric from each scaler.
-- `keda_scaler_errors` - Replaced by `keda_scaler_detail_errors_total`. The number of errors that have occurred for each scaler.
-- `keda_scaler_errors_total` - Replaced by `keda_scaler_detail_errors_total`. The total number of errors encountered for all scalers.
-- `keda_scaled_object_errors` - Replaced by `keda_scaled_object_errors_total`. The number of errors that have occurred for each ScaledObject.
-- `keda_resource_totals` - Replaced by `keda_resource_handled_total`. Total number of KEDA custom resources per namespace for each custom resource type (CRD).
-- `keda_trigger_totals` - Replaced by `keda_trigger_handled_total`. Total number of triggers per trigger type.
-- `keda_internal_scale_loop_latency` - Replaced by `keda_internal_scale_loop_latency_seconds`. Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
+- `keda_scaler_metrics_latency` - The latency of retrieving current metric from each scaler. Replaced by `keda_scaler_metrics_latency_seconds`.
+- `keda_scaler_errors` - The number of errors that have occurred for each scaler. Replaced by `keda_scaler_detail_errors_total`.
+- `keda_scaler_errors_total` - The total number of errors encountered for all scalers. Replaced by `keda_scaler_detail_errors_total`.
+- `keda_scaled_object_errors` - The number of errors that have occurred for each ScaledObject. Replaced by `keda_scaled_object_errors_total`.
+- `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD). Replaced by `keda_resource_handled_total`.
+- `keda_trigger_totals` - Total number of triggers per trigger type. Replaced by `keda_trigger_handled_total`.
+- `keda_internal_scale_loop_latency` - Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. Replaced by `keda_internal_scale_loop_latency_seconds`.
 
 ### Admission Webhooks
 

--- a/content/docs/2.14/operate/prometheus.md
+++ b/content/docs/2.14/operate/prometheus.md
@@ -32,7 +32,7 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 #### Deprecated metrics
 
-The following metrics are exposed as well, but are deprecated and will be removed in a future release.
+The following metrics are exposed as well, but are deprecated and will be removed in KEDA v2.16.
 
 - `keda_scaler_metrics_latency` - Replaced by `keda_scaler_metrics_latency_seconds`. The latency of retrieving current metric from each scaler.
 - `keda_scaler_errors` - Replaced by `keda_scaler_detail_errors_total`. The number of errors that have occurred for each scaler.

--- a/content/docs/2.14/operate/prometheus.md
+++ b/content/docs/2.14/operate/prometheus.md
@@ -14,14 +14,13 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_scaler_active` - This metric marks whether the particular scaler is active (value == 1) or in-active (value == 0).
 - `keda_scaled_object_paused` - This metric indicates whether a ScaledObject is paused (value == 1) or un-paused (value == 0).
 - `keda_scaler_metrics_value` - The current value for each scaler's metric that would be used by the HPA in computing the target average.
-- `keda_scaler_metrics_latency` - The latency of retrieving current metric from each scaler.
-- `keda_scaler_errors` - The number of errors that have occurred for each scaler.
-- `keda_scaler_errors_total` - The total number of errors encountered for all scalers.
-- `keda_scaled_object_errors` - The number of errors that have occurred for each ScaledObject.
+- `keda_scaler_metrics_latency_seconds` - The latency of retrieving current metric from each scaler.
+- `keda_scaler_detail_errors_total` - The number of errors encountered for each scaler.
+- `keda_scaled_object_errors_total` - The number of errors that have occurred for each ScaledObject.
 - `keda_scaled_job_errors` - The number of errors that have occurred for each ScaledJob.
-- `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD).
-- `keda_trigger_totals` - Total number of triggers per trigger type.
-- `keda_internal_scale_loop_latency` - Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
+- `keda_resource_handled_total` - Total number of KEDA custom resources per namespace for each custom resource type (CRD) handled by the operator.
+- `keda_trigger_handled_total` - Total number of triggers per trigger type handled by the operator.
+- `keda_internal_scale_loop_latency_seconds` - Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
 - `keda_cloudeventsource_events_emitted_total` - Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state.
 - `keda_cloudeventsource_events_queued` - The number of events that are in the emitting queue.
 - `keda_internal_metricsservice_grpc_server_started_total` - Total number of RPCs started on the server.
@@ -30,6 +29,18 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_internal_metricsservice_grpc_server_msg_sent_total` - Total number of gRPC stream messages sent by the server.
 - `keda_internal_metricsservice_grpc_server_handling_seconds` - Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
+
+#### Deprecated metrics
+
+The following metrics are exposed as well, but are deprecated and will be removed in a future release.
+
+- `keda_scaler_metrics_latency` - Replaced by `keda_scaler_metrics_latency_seconds`. The latency of retrieving current metric from each scaler.
+- `keda_scaler_errors` - Replaced by `keda_scaler_detail_errors_total`. The number of errors that have occurred for each scaler.
+- `keda_scaler_errors_total` - Replaced by `keda_scaler_detail_errors_total`. The total number of errors encountered for all scalers.
+- `keda_scaled_object_errors` - Replaced by `keda_scaled_object_errors_total`. The number of errors that have occurred for each ScaledObject.
+- `keda_resource_totals` - Replaced by `keda_resource_handled_total`. Total number of KEDA custom resources per namespace for each custom resource type (CRD).
+- `keda_trigger_totals` - Replaced by `keda_trigger_handled_total`. Total number of triggers per trigger type.
+- `keda_internal_scale_loop_latency` - Replaced by `keda_internal_scale_loop_latency_seconds`. Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
 
 ### Admission Webhooks
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Original work in https://github.com/kedacore/keda-docs/pull/1258, reasons for duplicate PR https://github.com/kedacore/keda/pull/5687#issuecomment-2058419250

> Updates the docs with the changes in kedacore/keda#5174.

I merely cherry-picked the documentation changes and applied review suggestions
* moved the docs to target 2.14
* fixed minor typos
* also kept original text next to the deprecated metrics right after the deprecation notice and recommendation to use new metric
 
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

closes: https://github.com/kedacore/keda-docs/pull/1258