### PR TITLE
add note for null and coalesce for mysql

### DIFF
--- a/content/docs/1.4/scalers/mysql.md
+++ b/content/docs/1.4/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 - `connectionString` - MySQL connection string that should point to environment variable with valid value.
 

--- a/content/docs/1.5/scalers/mysql.md
+++ b/content/docs/1.5/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 - `connectionString` - MySQL connection string that should point to environment variable with valid value.
 

--- a/content/docs/2.0/scalers/mysql.md
+++ b/content/docs/2.0/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` MySQL connection string that should point to environment variable with valid value

--- a/content/docs/2.1/scalers/mysql.md
+++ b/content/docs/2.1/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` MySQL connection string that should point to environment variable with valid value

--- a/content/docs/2.10/scalers/mysql.md
+++ b/content/docs/2.10/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.11/scalers/mysql.md
+++ b/content/docs/2.11/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.12/scalers/mysql.md
+++ b/content/docs/2.12/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.13/scalers/mysql.md
+++ b/content/docs/2.13/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.14/scalers/mysql.md
+++ b/content/docs/2.14/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.15/scalers/mysql.md
+++ b/content/docs/2.15/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.2/scalers/mysql.md
+++ b/content/docs/2.2/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` MySQL connection string that should point to environment variable with valid value

--- a/content/docs/2.3/scalers/mysql.md
+++ b/content/docs/2.3/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` MySQL connection string that should point to environment variable with valid value

--- a/content/docs/2.4/scalers/mysql.md
+++ b/content/docs/2.4/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` MySQL connection string that should point to environment variable with valid value

--- a/content/docs/2.5/scalers/mysql.md
+++ b/content/docs/2.5/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.6/scalers/mysql.md
+++ b/content/docs/2.6/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetAverageValue` in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.7/scalers/mysql.md
+++ b/content/docs/2.7/scalers/mysql.md
@@ -15,6 +15,8 @@ The trigger always requires the following information:
 - `query` - A MySQL query that should return single numeric value.
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA.
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.8/scalers/mysql.md
+++ b/content/docs/2.8/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.

--- a/content/docs/2.9/scalers/mysql.md
+++ b/content/docs/2.9/scalers/mysql.md
@@ -16,6 +16,8 @@ The trigger always requires the following information:
 - `queryValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in HPA. (This value can be a float)
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#function_coalesce) for more information on the `COALESCE` function.
+
 To provide information about how to connect to MySQL you can provide:
 
 - `connectionStringFromEnv` - MySQL connection string that should point to environment variable with valid value.


### PR DESCRIPTION
Adds a note about the use of coalesce for null values for MySQL. Follows on from: https://github.com/kedacore/keda-docs/pull/1393
