### PR TITLE
add note for null and coalesce for mssql

### DIFF
--- a/content/docs/2.10/scalers/mssql.md
+++ b/content/docs/2.10/scalers/mssql.md
@@ -45,6 +45,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.11/scalers/mssql.md
+++ b/content/docs/2.11/scalers/mssql.md
@@ -45,6 +45,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.12/scalers/mssql.md
+++ b/content/docs/2.12/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.13/scalers/mssql.md
+++ b/content/docs/2.13/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.14/scalers/mssql.md
+++ b/content/docs/2.14/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.15/scalers/mssql.md
+++ b/content/docs/2.15/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.2/scalers/mssql.md
+++ b/content/docs/2.2/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
 - `targetValue` - A threshold that is used as `targetAverageValue` in the Horizontal Pod Autoscaler (HPA).
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.3/scalers/mssql.md
+++ b/content/docs/2.3/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
 - `targetValue` - A threshold that is used as `targetAverageValue` in the Horizontal Pod Autoscaler (HPA).
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.4/scalers/mssql.md
+++ b/content/docs/2.4/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
 - `targetValue` - A threshold that is used as `targetAverageValue` in the Horizontal Pod Autoscaler (HPA).
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.5/scalers/mssql.md
+++ b/content/docs/2.5/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
 - `targetValue` - A threshold that is used as `targetAverageValue` in the Horizontal Pod Autoscaler (HPA).
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.6/scalers/mssql.md
+++ b/content/docs/2.6/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
 - `targetValue` - A threshold that is used as `targetAverageValue` in the Horizontal Pod Autoscaler (HPA).
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.7/scalers/mssql.md
+++ b/content/docs/2.7/scalers/mssql.md
@@ -43,6 +43,8 @@ The `mssql` trigger always requires the following information:
 - `query` - A [T-SQL](https://docs.microsoft.com/sql/t-sql/language-reference) query that returns a single numeric value. This can be a regular query or the name of a stored procedure.
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA).
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.8/scalers/mssql.md
+++ b/content/docs/2.8/scalers/mssql.md
@@ -45,6 +45,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.

--- a/content/docs/2.9/scalers/mssql.md
+++ b/content/docs/2.9/scalers/mssql.md
@@ -45,6 +45,8 @@ The `mssql` trigger always requires the following information:
 - `targetValue` - A threshold that is used as `targetValue` or `targetAverageValue` (depending on the trigger metric type) in the Horizontal Pod Autoscaler (HPA). (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
+> Note that the query must return a single integer value. If the query has a possibility of returning `null`, a default value can be set using the `COALESCE` function. For example, `SELECT COALESCE(column_name, 0) FROM table_name;`. See [MSSQL documentation](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql) for more information on the `COALESCE` function.
+
 To connect to the MSSQL instance, you can provide either:
 
 - `connectionStringFromEnv` - The name of an environment variable containing a valid MSSQL connection string.


### PR DESCRIPTION
Adds a note about the use of coalesce for null values for MSSQL. Follows on from: https://github.com/kedacore/keda-docs/pull/1393
