### PR TITLE
Add queueLengthStrategy option to azure-storage-queue scaler.

### DIFF
--- a/content/docs/2.15/scalers/azure-storage-queue.md
+++ b/content/docs/2.15/scalers/azure-storage-queue.md
@@ -17,6 +17,7 @@ triggers:
   metadata:
     queueName: orders
     queueLength: '5'
+    queueLengthStrategy: all|visibleonly
     activationQueueLength: '50'
     connectionFromEnv: STORAGE_CONNECTIONSTRING_ENV_NAME
     accountName: storage-account-name
@@ -27,6 +28,7 @@ triggers:
 
 - `queueName` - Name of the queue.
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (Default: `5`, Optional)
+- `queueLengthStrategy` - `all` considers both visible and invisible messages, while `visibleonly` uses Peek to count only visible messages. In `visibleonly`, if the count of messages is 32 or higher, it falls back to the default `all` strategy, counting both visible and invisible messages. (Default: `all`, Optional)
 - `activationQueueLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
 - `accountName` - Name of the storage account that the queue belongs to.
@@ -78,6 +80,8 @@ spec:
       #
       # Optional
       queueLength: "5" # default 5
+      # Optional
+      queueLengthStrategy: "all" # or visibleonly. Default: all
       cloud: Private
       endpointSuffix: queue.local.azurestack.external # Required when cloud=Private
     authenticationRef:


### PR DESCRIPTION
This adds documentation about the new `queueLengthStrategy` configuration option for the Azure Storage Queue scaler.

Related to https://github.com/kedacore/keda/issues/4478