### PR TITLE
feat: add GCP Pub/Sub new optional valueIfNull trigger configuration

### DIFF
--- a/content/docs/2.15/scalers/gcp-pub-sub.md
+++ b/content/docs/2.15/scalers/gcp-pub-sub.md
@@ -19,6 +19,7 @@ triggers:
     mode: "SubscriptionSize" # Optional - Default is SubscriptionSize - SubscriptionSize or OldestUnackedMessageAge
     aggregation: "sum" # Optional - Only meaningful for distribution-valued metrics
     value: "5.5" # Optional - Default is 10
+    valueIfNull: '0.0' # Optional - Default is ""
     activationValue: "10.5" # Optional - Default is 0
     timeHorizon: "1m" # Optional - Default is 2m and with aggregation 5m
     # Exactly one of the subscription or topic name options is required
@@ -41,6 +42,8 @@ The Google Cloud Platform (GCP) Pub/Sub trigger allows you to scale based on any
 - `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
 - `timeHorizon` - Time range for which you want to retrieve the matrics. (Default: `2m` and Default with aggregation field: `5m`)
+
+- `valueIfNull` - Value returned if request returns no timeseries.(Default: `""`, Optional, This value can be a float) 
 
 - `subscriptionName` defines the subscription that should be monitored. You can use different formulas:
   - Just the subscription name, in which case you will reference a subscription from the current project or the one specified in the credentials file used.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Update Google Cloud Platform Pub/Sub scaler documentation to include the new optional valueIfNull configuration.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to #
https://github.com/kedacore/keda/pull/5897
