### PR TITLE
Adding a note about Prometheus metrics exposed on metrics endpoint 

### DIFF
--- a/content/docs/2.15/operate/prometheus.md
+++ b/content/docs/2.15/operate/prometheus.md
@@ -17,7 +17,7 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_scaler_metrics_latency_seconds` - The latency of retrieving current metric from each scaler.
 - `keda_scaler_detail_errors_total` - The number of errors encountered for each scaler.
 - `keda_scaled_object_errors_total` - The number of errors that have occurred for each ScaledObject.
-- `keda_scaled_job_errors` - The number of errors that have occurred for each ScaledJob.
+- `keda_scaled_job_errors_total` - The number of errors that have occurred for each ScaledJob.
 - `keda_resource_registered_total` - Total number of KEDA custom resources per namespace for each custom resource type (CRD) handled by the operator.
 - `keda_trigger_registered_total` - Total number of triggers per trigger type handled by the operator.
 - `keda_internal_scale_loop_latency_seconds` - Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
@@ -30,6 +30,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_internal_metricsservice_grpc_server_handling_seconds` - Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
 
+> Note: When you deploy the KEDA Operator without any scalers deployed, the only metric you will see is `keda_build_info`. As you deploy scalers, you will start to see some of the metrics listed above but it is dependant on the types of scalers you have deployed.
+
 #### Deprecated metrics
 
 The following metrics are exposed as well, but are deprecated and will be removed in KEDA v2.16.
@@ -38,6 +40,7 @@ The following metrics are exposed as well, but are deprecated and will be remove
 - `keda_scaler_errors` - The number of errors that have occurred for each scaler. Replaced by `keda_scaler_detail_errors_total`.
 - `keda_scaler_errors_total` - The total number of errors encountered for all scalers. Replaced by `keda_scaler_detail_errors_total`.
 - `keda_scaled_object_errors` - The number of errors that have occurred for each ScaledObject. Replaced by `keda_scaled_object_errors_total`.
+- `keda_scaled_job_errors` - The number of errors that have occurred for each ScaledJob. Replace by `keda_scaled_job_errors_total`.
 - `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD). Replaced by `keda_resource_registered_total`.
 - `keda_trigger_totals` - Total number of triggers per trigger type. Replaced by `keda_trigger_registered_total`.
 - `keda_internal_scale_loop_latency` - Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. Replaced by `keda_internal_scale_loop_latency_seconds`.


### PR DESCRIPTION
Clarifying that Prometheus metrics emitted depends on scalers are deployed.

Resolves: https://github.com/kedacore/keda/issues/5609

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
