### PR TITLE
navbar + hero refactor

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -176,28 +176,40 @@ parent = "docs"
 weight = 3
 
 [[menu.docs]]
+url = "/docs/scalers"
+name = "Scalers"
+parent = "docs"
+weight = 4
+
+[[menu.docs]]
 url = "/docs/operate/"
 name = "Operate"
 parent = "docs"
-weight = 4
+weight = 5
+
+[[menu.docs]]
+url = "/docs/authentication-providers"
+name = "Auth providers"
+parent = "docs"
+weight = 6
 
 [[menu.docs]]
 url = "/docs/migration/"
 name = "Migration Guide"
 parent = "docs"
-weight = 5
+weight = 7
 
 [[menu.docs]]
 url = "/docs/reference/faq/"
 name = "FAQ"
 parent = "docs"
-weight = 6
+weight = 8
 
 [[menu.docs]]
 url = "/docs/troubleshooting/"
 name = "Troubleshooting"
 parent = "docs"
-weight = 7
+weight = 9
 
 [[menu.main]]
 url = "/blog"
@@ -327,6 +339,11 @@ url = "https://store.cncf.io/collections/keda"
 name = "Merch"
 parent = "project"
 weight = 12
+
+[[menu.main]]
+url = "/support/"
+name = "Support"
+weight = 5
 
 # "Features" section on the main page
 [[params.features]]

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -33,13 +33,13 @@
           </p>
         </div>
 
-        <div class="navbar-item is-size-5-desktop has-dropdown is-hoverable">
+        <!-- <div class="navbar-item is-size-5-desktop has-dropdown is-hoverable">
           <a class="navbar-link is-arrowless" href="/docs/{{ $latest }}/scalers">Scalers</a>
         </div>
 
         <div class="navbar-item is-size-5-desktop has-dropdown is-hoverable">
           <a class="navbar-link is-arrowless" href="/docs/{{ $latest }}/authentication-providers">Auth providers</a>
-        </div>
+        </div> -->
 
         {{ range $docs }}
         {{ $isExternal := hasPrefix .URL "http" }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The current Navbar and Hero duplicates a lot of links, I think we can simplify the navbar to provide more clarity. Also, adding support to the top level.

<img width="1461" alt="Screenshot 2024-07-16 at 13 16 00" src="https://github.com/user-attachments/assets/7bce6224-3bac-4929-bade-a6a7206e96c1">

->

<img width="1408" alt="Screenshot 2024-07-16 at 13 36 48" src="https://github.com/user-attachments/assets/255860c5-81e2-4685-8c78-10ab5ad31b35">

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

