### PR TITLE
feat: update IBM MQ scaler docs for TLS support

### DIFF
--- a/content/docs/2.15/scalers/ibm-mq.md
+++ b/content/docs/2.15/scalers/ibm-mq.md
@@ -23,6 +23,7 @@ triggers:
     activationQueueDepth: <activation-queue-depth> # OPTIONAL - Activation queue depth target. Default: 0 messages
     usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
     passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
+    unsafeSsl: <SSL enabled/disabled> # OPTIONAL - Set 'true' for unsafe SSL. Default: false
 ```
 
 **Parameter list:**
@@ -35,6 +36,7 @@ triggers:
 - `activationQueueDepth` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `usernameFromEnv` - Provide admin username from env instead of as a secret. (Optional)
 - `passwordFromEnv` - Provide admin password from env instead of as a secret. (Optional)
+- `unsafeSsl` - Whether to allow unsafe SSL (Values: `true`, `false`, Default: `false` )
 
 ### Authentication Parameters
 
@@ -44,10 +46,16 @@ TriggerAuthentication CRD is used to connect and authenticate to IBM MQ:
 
 - `ADMIN_USER` - REQUIRED - The admin REST endpoint username for your MQ Queue Manager`.
 - `ADMIN_PASSWORD` - REQUIRED - The admin REST endpoint API key for your MQ Queue Manager.
+- `ca` - Certificate authority file for TLS client authentication. (Optional)
+- `cert` - Certificate for client authentication. (Optional)
+- `key` - Key for client authentication. (Optional)
+- `keyPassword` - If set the keyPassword is used to decrypt the provided key. (Optional)
 - `usernameFromEnv` - Provide admin username from env instead of as a secret. (Optional)
 - `passwordFromEnv` - Provide admin password from env instead of as a secret. (Optional)
 
 ### Example
+
+Example with Basic Auth
 
 ```yaml
 apiVersion: v1
@@ -98,3 +106,64 @@ spec:
       name: keda-ibmmq-secret
       key: ADMIN_PASSWORD
 ```
+
+### Example
+
+Example with Basic Auth and TLS
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-ibmmq-secret
+data:
+  ADMIN_USER: <encoded-username> # REQUIRED - Admin Username
+  ADMIN_PASSWORD: <encoded-password> # REQUIRED - Admin Password
+  cert: <your tls.crt>
+  key: <your tls.key>
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ibmmq-scaledobject
+  namespace: default
+  labels:
+    deploymentName: ibmmq-deployment
+spec:
+  scaleTargetRef:
+    name: ibmmq-deployment
+  pollingInterval: 5 # OPTIONAL - Default: 30 seconds
+  cooldownPeriod: 30 # OPTIONAL - Default: 300 seconds
+  maxReplicaCount: 18 # OPTIONAL - Default: 100
+  triggers:
+    - type: ibmmq
+      metadata:
+        host: <ibm-host> # REQUIRED - IBM MQ Queue Manager Admin REST Endpoint
+        queueManager: <queue-manager> # REQUIRED - Your queue manager
+        queueName: <queue-name> # REQUIRED - Your queue name
+        tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
+        queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
+      authenticationRef:
+        name: keda-ibmmq-trigger-auth
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-ibmmq-trigger-auth
+  namespace: default
+spec:
+  secretTargetRef:
+    - parameter: username
+      name: keda-ibmmq-secret
+      key: ADMIN_USER
+    - parameter: password
+      name: keda-ibmmq-secret
+      key: ADMIN_PASSWORD
+    - parameter: cert
+      name: keda-ibmmq-secret
+      key: cert
+    - parameter: key
+      name: keda-ibmmq-secret
+      key: key
+```
+


### PR DESCRIPTION
Adding support to enable authentication with TLS certs within the existing IBM MQ scaler by extending it, with additional optional parameters.

Currently, MQ appliance is expecting the Basic Auth credentials as well along with certificates. The change is therefore made in such a way that Basic Auth remains necessary if you also provide a TLS certificate.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes: [5974](https://github.com/kedacore/keda/issues/5974)
