### PR TITLE
remove metrics server leader election env vars

### DIFF
--- a/content/docs/2.15/operate/cluster.md
+++ b/content/docs/2.15/operate/cluster.md
@@ -158,7 +158,7 @@ To modify this properties you can set environment variables on both KEDA Operato
 
 ## Configure Leader Election
 
-Like reconciliation, KEDA also uses the [controller-runtime project](https://github.com/kubernetes-sigs/controller-runtime) for electing the leader replica. The following properties can be configured for either the Operator and Metrics Server Deployment:
+Like reconciliation, KEDA Operator also uses the [controller-runtime project](https://github.com/kubernetes-sigs/controller-runtime) for electing the leader replica. The following properties can be configured for the Operator Deployment:
 
 - [`LeaseDuration`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Options.LeaseDuration)
 - [`RenewDeadline`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Options.RenewDeadline)
@@ -171,9 +171,6 @@ To specify values other than their defaults, you can set the following environme
 | KEDA_OPERATOR_LEADER_ELECTION_LEASE_DURATION | Operator       | 15s           | LeaseDuration    |
 | KEDA_OPERATOR_LEADER_ELECTION_RENEW_DEADLINE | Operator       | 10s           | RenewDeadline    |
 | KEDA_OPERATOR_LEADER_ELECTION_RETRY_PERIOD   | Operator       | 2s            | RetryPeriod      |
-| KEDA_METRICS_LEADER_ELECTION_LEASE_DURATION  | Metrics Server | 15s           | LeaseDuration    |
-| KEDA_METRICS_LEADER_ELECTION_RENEW_DEADLINE  | Metrics Server | 10s           | RenewDeadline    |
-| KEDA_METRICS_LEADER_ELECTION_RETRY_PERIOD    | Metrics Server | 2s            | RetryPeriod      |
 
 ## Restrict the Namespaces KEDA is Watching
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The documentation originally mentions the possibility to set leader election parameters through environment variables for the keda-metrics-server. However, it was confirmed in https://github.com/kedacore/keda/issues/5959 that the keda-metrics-server does not use leader election, and these parameters should not be there. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
