### PR TITLE
Remove and deprecate unused variables and correct queueDepth default in IBM MQ scaler

### DIFF
--- a/content/docs/2.16/scalers/ibm-mq.md
+++ b/content/docs/2.16/scalers/ibm-mq.md
@@ -17,7 +17,7 @@ triggers:
   metadata:
     host: <ibm-host> # REQUIRED - IBM MQ Queue Manager Admin REST Endpoint
     queueName: <queue-name> # REQUIRED - Your queue name
-    tlsDisabled: <TLS enabled/disabled> # DEPRECATED: This parameter is deprecated as of KEDA v2.16 in favor of unsafeSsl and will be removed in version v2.17
+    tlsDisabled: <TLS enabled/disabled> # DEPRECATED: This parameter is deprecated as of KEDA v2.16 in favor of unsafeSsl and will be removed in version v2.18
     queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 20 messages
     activationQueueDepth: <activation-queue-depth> # OPTIONAL - Activation queue depth target. Default: 0 messages
     usernameFromEnv: <admin-user> # OPTIONAL - Provide admin username from env instead of as a secret

--- a/content/docs/2.16/scalers/ibm-mq.md
+++ b/content/docs/2.16/scalers/ibm-mq.md
@@ -16,27 +16,25 @@ triggers:
 - type: ibmmq
   metadata:
     host: <ibm-host> # REQUIRED - IBM MQ Queue Manager Admin REST Endpoint
-    queueManager: <queue-manager> # REQUIRED - Your queue manager
     queueName: <queue-name> # REQUIRED - Your queue name
-    tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
-    queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
+    tlsDisabled: <TLS enabled/disabled> # DEPRECATED: This parameter is deprecated as of KEDA v2.16 in favor of unsafeSsl and will be removed in version v2.17
+    queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 20 messages
     activationQueueDepth: <activation-queue-depth> # OPTIONAL - Activation queue depth target. Default: 0 messages
-    usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-    passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
-    unsafeSsl: <SSL enabled/disabled> # OPTIONAL - Set 'true' for unsafe SSL. Default: false
+    usernameFromEnv: <admin-user> # OPTIONAL - Provide admin username from env instead of as a secret
+    passwordFromEnv: <admin-password> # OPTIONAL - Provide admin password from env instead of as a secret
+    unsafeSsl: "false" # OPTIONAL - Used for skipping certificate check when having self-signed certs 'true'. Default: false
 ```
 
 **Parameter list:**
 
 - `host` - IBM MQ Queue Manager Admin REST Endpoint. Example URI endpoint structure on IBM cloud `https://example.mq.appdomain.cloud/ibmmq/rest/v2/admin/action/qmgr/QM/mqsc`.
-- `queueManager` - Name of the queue manager from which messages will be consumed.
-- `queueName` - Name of the Queue within the Queue Manager defined from which messages will be consumed.
-- `tlsDisabled` - Can be set to 'true' to disable TLS. (Values: `true`, `false` , Default: `false`, Optional)
-- `queueDepth` - Queue depth Target for HPA. (Default: `5`, Optional)
+- `queueName` - Name of the Queue defined from which messages will be consumed.
+- `tlsDisabled` - Can be set to 'true' to disable TLS. (DEPRECATED: This parameter is deprecated as of KEDA v2.16 in favor of unsafeSsl and will be removed in version v2.17, Values: `true`, `false` , Default: `false`, Optional)
+- `queueDepth` - Queue depth Target for HPA. (Default: `20`, Optional)
 - `activationQueueDepth` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `usernameFromEnv` - Provide admin username from env instead of as a secret. (Optional)
 - `passwordFromEnv` - Provide admin password from env instead of as a secret. (Optional)
-- `unsafeSsl` - Whether to allow unsafe SSL (Values: `true`, `false`, Default: `false` )
+- `unsafeSsl` - Whether to allow unsafe SSL (Values: `true`, `false`, Default: `false`, Optional)
 
 ### Authentication Parameters
 
@@ -83,12 +81,10 @@ spec:
     - type: ibmmq
       metadata:
         host: <ibm-host> # REQUIRED - IBM MQ Queue Manager Admin REST Endpoint
-        queueManager: <queue-manager> # REQUIRED - Your queue manager
         queueName: <queue-name> # REQUIRED - Your queue name
-        tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
-        queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
-        usernameFromEnv: <admin-user> # Optional: Provide admin username from env instead of as a secret
-        passwordFromEnv: <admin-password> # Optional: Provide admin password from env instead of as a secret
+        queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 20 messages
+        usernameFromEnv: <admin-user> # OPTIONAL - Provide admin username from env instead of as a secret
+        passwordFromEnv: <admin-password> # OPTIONAL - Provide admin password from env instead of as a secret
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---
@@ -106,8 +102,6 @@ spec:
       name: keda-ibmmq-secret
       key: ADMIN_PASSWORD
 ```
-
-### Example
 
 Example with Basic Auth and TLS
 
@@ -139,10 +133,8 @@ spec:
     - type: ibmmq
       metadata:
         host: <ibm-host> # REQUIRED - IBM MQ Queue Manager Admin REST Endpoint
-        queueManager: <queue-manager> # REQUIRED - Your queue manager
         queueName: <queue-name> # REQUIRED - Your queue name
-        tlsDisabled: <TLS enabled/disabled> # OPTIONAL - Set 'true' to disable TLS. Default: false
-        queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 5 messages
+        queueDepth: <queue-depth> # OPTIONAL - Queue depth target for HPA. Default: 20 messages
       authenticationRef:
         name: keda-ibmmq-trigger-auth
 ---
@@ -166,4 +158,3 @@ spec:
       name: keda-ibmmq-secret
       key: key
 ```
-

--- a/content/docs/2.16/scalers/ibm-mq.md
+++ b/content/docs/2.16/scalers/ibm-mq.md
@@ -29,7 +29,7 @@ triggers:
 
 - `host` - IBM MQ Queue Manager Admin REST Endpoint. Example URI endpoint structure on IBM cloud `https://example.mq.appdomain.cloud/ibmmq/rest/v2/admin/action/qmgr/QM/mqsc`.
 - `queueName` - Name of the Queue defined from which messages will be consumed.
-- `tlsDisabled` - Can be set to 'true' to disable TLS. (DEPRECATED: This parameter is deprecated as of KEDA v2.16 in favor of unsafeSsl and will be removed in version v2.17, Values: `true`, `false` , Default: `false`, Optional)
+- `tlsDisabled` - Can be set to 'true' to disable TLS. (DEPRECATED: This parameter is deprecated as of KEDA v2.16 in favor of unsafeSsl and will be removed in version v2.18, Values: `true`, `false` , Default: `false`, Optional)
 - `queueDepth` - Queue depth Target for HPA. (Default: `20`, Optional)
 - `activationQueueDepth` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `usernameFromEnv` - Provide admin username from env instead of as a secret. (Optional)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

- The current documentation states that the default `queueDepth` is `5`, while the code default is `20`. The documentation will be updated to reflect the correct default value of `20`, aligning it with the code.
- The `queueManager` parameter is currently checked to see if it's filled, but it's not used elsewhere in the code. This unused code is removed. The documentation is updated accordingly.
- The parameter `tlsDisabled` is set to **DEPRECATED**. All other scalers use the parameter `unsafeSsl`. To maintain consistency across the other scalers, the code related to `tlsDisabled` is set to deprecated, as `unsafeSsl` already handles this functionality.
- Finally, some minor adjustments to the documentation to keep the formatting the same.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Related: [6034](https://github.com/kedacore/keda/pull/6034)