### PR TITLE
fix: Datadog example uses all the required values

### DIFF
--- a/content/docs/2.15/scalers/datadog.md
+++ b/content/docs/2.15/scalers/datadog.md
@@ -148,6 +148,9 @@ spec:
     - parameter: authMode
       name: datadog-config
       key: authMode
+    - parameter: datadogMetricsService
+      name: datadog-config
+      key: datadogMetricsService
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/content/docs/2.16/scalers/datadog.md
+++ b/content/docs/2.16/scalers/datadog.md
@@ -148,6 +148,9 @@ spec:
     - parameter: authMode
       name: datadog-config
       key: authMode
+    - parameter: datadogMetricsService
+      name: datadog-config
+      key: datadogMetricsService
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
The example has a missing field which is required

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

