### PR TITLE
fix: Correct Elasticsearch index field

### DIFF
--- a/content/docs/2.10/scalers/elasticsearch.md
+++ b/content/docs/2.10/scalers/elasticsearch.md
@@ -32,11 +32,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.11/scalers/elasticsearch.md
+++ b/content/docs/2.11/scalers/elasticsearch.md
@@ -32,11 +32,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.12/scalers/elasticsearch.md
+++ b/content/docs/2.12/scalers/elasticsearch.md
@@ -32,11 +32,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.13/scalers/elasticsearch.md
+++ b/content/docs/2.13/scalers/elasticsearch.md
@@ -32,11 +32,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.14/scalers/elasticsearch.md
+++ b/content/docs/2.14/scalers/elasticsearch.md
@@ -33,11 +33,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.15/scalers/elasticsearch.md
+++ b/content/docs/2.15/scalers/elasticsearch.md
@@ -33,11 +33,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.16/scalers/elasticsearch.md
+++ b/content/docs/2.16/scalers/elasticsearch.md
@@ -33,11 +33,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.5/scalers/elasticsearch.md
+++ b/content/docs/2.5/scalers/elasticsearch.md
@@ -31,10 +31,10 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0.
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiples param separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.6/scalers/elasticsearch.md
+++ b/content/docs/2.6/scalers/elasticsearch.md
@@ -31,10 +31,10 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0.
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.7/scalers/elasticsearch.md
+++ b/content/docs/2.7/scalers/elasticsearch.md
@@ -31,10 +31,10 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0.
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.8/scalers/elasticsearch.md
+++ b/content/docs/2.8/scalers/elasticsearch.md
@@ -32,11 +32,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 

--- a/content/docs/2.9/scalers/elasticsearch.md
+++ b/content/docs/2.9/scalers/elasticsearch.md
@@ -32,11 +32,11 @@ triggers:
 - `addresses` - Comma separated list of hosts and ports of the Elasticsearch cluster client nodes.
 - `username` - Username to authenticate with to Elasticsearch cluster.
 - `passwordFromEnv` - Environment variable to read the authentication password from to authenticate with the Elasticsearch cluster.
-- `index` - Comma separated list of indexes to run the search template query on.
+- `index` - Index to run the search template query on. It supports multiple indexes separated by a semicolon character ( `;` ).
 - `searchTemplateName` - The search template name to run.
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `parameters` - Parameters that will be used by the search template. It supports multiples params separated by a semicolon character ( `;` ).
+- `parameters` - Parameters that will be used by the search template. It supports multiple params separated by a semicolon character ( `;` ).
 - `valueLocation` - [GJSON path notation](https://github.com/tidwall/gjson#path-syntax) to refer to the field in the payload containing the metric value.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 


### PR DESCRIPTION
The documentation states that the field index is comma separated. In the code it is semicolon. This PR is to improve the documentation.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Related: [6101](https://github.com/kedacore/keda/pull/6101)
