### PR TITLE
Added datadogMetricsService and fix datadogNamespace key in triggerAu…

### DIFF
--- a/content/docs/2.15/scalers/datadog.md
+++ b/content/docs/2.15/scalers/datadog.md
@@ -142,9 +142,6 @@ spec:
     - parameter: datadogNamespace
       name: datadog-config
       key: datadogNamespace
-    - parameter: datadogMetricsService
-      name: datadog-config
-      key: datadogMetricsService
     - parameter: unsafeSsl
       name: datadog-config
       key: unsafeSsl

--- a/content/docs/2.15/scalers/datadog.md
+++ b/content/docs/2.15/scalers/datadog.md
@@ -141,7 +141,10 @@ spec:
       key: token
     - parameter: datadogNamespace
       name: datadog-config
-      key: namespace
+      key: datadogNamespace
+    - parameter: datadogMetricsService
+      name: datadog-config
+      key: datadogMetricsService
     - parameter: unsafeSsl
       name: datadog-config
       key: unsafeSsl

--- a/content/docs/2.16/scalers/datadog.md
+++ b/content/docs/2.16/scalers/datadog.md
@@ -142,9 +142,6 @@ spec:
     - parameter: datadogNamespace
       name: datadog-config
       key: datadogNamespace
-    - parameter: datadogMetricsService
-      name: datadog-config
-      key: datadogMetricsService
     - parameter: unsafeSsl
       name: datadog-config
       key: unsafeSsl

--- a/content/docs/2.16/scalers/datadog.md
+++ b/content/docs/2.16/scalers/datadog.md
@@ -141,7 +141,10 @@ spec:
       key: token
     - parameter: datadogNamespace
       name: datadog-config
-      key: namespace
+      key: datadogNamespace
+    - parameter: datadogMetricsService
+      name: datadog-config
+      key: datadogMetricsService
     - parameter: unsafeSsl
       name: datadog-config
       key: unsafeSsl


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Included `datadogMetricsService` and fixed `datadogNamespace` key in triggerAuthenticatio specs. When I have been Tried this configurations I got errors. After I fix this keys, provide in this PR, works well. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
