### PR TITLE
kafka: doc ability to disable krb FAST

### DIFF
--- a/content/docs/2.16/scalers/apache-kafka.md
+++ b/content/docs/2.16/scalers/apache-kafka.md
@@ -100,6 +100,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `realm` - Kerberos realm.  (Optional unless sasl mode is `gssapi`)
 - `kerberosConfig` - Kerberos configuration file. (Optional unless sasl mode is `gssapi`)
 - `kerberosServiceName` - Kerberos service name. (Optional takes default value of `kafka` if not provided)
+- `kerberosDisableFAST` - To disable FAST negotation, set this to `true` (Values: `true`, `false`, Default: `false`, Optional)
 - `oauthTokenEndpointUri` - The OAuth Access Token URI used for oauthbearer token requests. (Optional unless sasl mode set to oauthbearer)
 - `scopes` - A comma separated lists of OAuth scopes used in the oauthbearer token requests. (Optional)
 - `oauthExtensions` - A comma separated lists of key value pairs in the format key=value OAuth extensions used in the oauthbearer token. (Optional)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Documents the `kerberosDisableFAST` auth parameter added as part of https://github.com/kedacore/keda/pull/6189 which fixes https://github.com/kedacore/keda/issues/6188

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

