### PR TITLE
docs: fix spacing in ScaledJob's overview section

### DIFF
--- a/content/docs/2.15/reference/scaledjob-spec.md
+++ b/content/docs/2.15/reference/scaledjob-spec.md
@@ -5,9 +5,7 @@ weight = 4000
 
 ## Overview
 
-This specification describes the `ScaledJob` custom resource definition that defines the triggers and scaling behaviors use by KEDA 
-
-to scale jobs. The `.spec.ScaleTargetRef` section holds the reference to the job, defined in [_scaledjob_types.go_](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledjob_types.go).
+This specification describes the `ScaledJob` custom resource definition that defines the triggers and scaling behaviors use by KEDA to scale `Job` resources. The `.spec.ScaleTargetRef` section holds the reference to the job, defined in [_scaledjob_types.go_](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledjob_types.go).
 
 ```yaml
 apiVersion: keda.sh/v1alpha1

--- a/content/docs/2.16/reference/scaledjob-spec.md
+++ b/content/docs/2.16/reference/scaledjob-spec.md
@@ -5,9 +5,7 @@ weight = 4000
 
 ## Overview
 
-This specification describes the `ScaledJob` custom resource definition that defines the triggers and scaling behaviors use by KEDA 
-
-to scale jobs. The `.spec.ScaleTargetRef` section holds the reference to the job, defined in [_scaledjob_types.go_](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledjob_types.go).
+This specification describes the `ScaledJob` custom resource definition that defines the triggers and scaling behaviors use by KEDA to scale jobs. The `.spec.ScaleTargetRef` section holds the reference to the job, defined in [_scaledjob_types.go_](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledjob_types.go).
 
 ```yaml
 apiVersion: keda.sh/v1alpha1


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Remove spacing between words which makes it easier to read

### Before

<img width="974" alt="image" src="https://github.com/user-attachments/assets/1c875cbd-0f2f-43e3-8cab-978cab86dadf">

### After

<img width="980" alt="image" src="https://github.com/user-attachments/assets/1ad1a84d-304b-4e62-bc96-3a81f6207acb">


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

