### PR TITLE
Announce removal of deprecated variable in CPU Memory Scaler

### DIFF
--- a/content/docs/2.16/scalers/cpu.md
+++ b/content/docs/2.16/scalers/cpu.md
@@ -40,7 +40,7 @@ triggers:
 - type: cpu
   metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
+    type: Utilization # DEPRECATED: This parameter is deprecated in favor of trigger.metricType and will be removed in version v2.18; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
     containerName: "" # Optional. You can use this to target a specific container in a pod
 ```

--- a/content/docs/2.16/scalers/memory.md
+++ b/content/docs/2.16/scalers/memory.md
@@ -40,7 +40,7 @@ triggers:
 - type: memory
   metricType: Utilization # Allowed types are 'Utilization' or 'AverageValue'
   metadata:
-    type: Utilization # Deprecated in favor of trigger.metricType; allowed types are 'Utilization' or 'AverageValue'
+    type: Utilization # DEPRECATED: This parameter is deprecated in favor of trigger.metricType and will be removed in version v2.18; allowed types are 'Utilization' or 'AverageValue'
     value: "60"
     containerName: "" # Optional. You can use this to target a specific container in a pod
 ```


### PR DESCRIPTION
The parameter `type` is already from release 2.7 deprecated. I think it's time to announce  and remove the deprecated code in version 2.18.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Related https://github.com/kedacore/keda/pull/6229
