### PR TITLE
fix firewall link in Reference

### DIFF
--- a/content/docs/2.15/reference/_index.md
+++ b/content/docs/2.15/reference/_index.md
@@ -8,6 +8,6 @@ Reference information for the KEDA autoscaler.
 - [ScaledObject specification](./scaledobject-spec)
 - [ScaledJob specification](./scaledjob-spec)
 - [Kubernetes Events](./events)
-- [Firewall requirements]
+- [Firewall requirements](../operate/cluster#firewall)
 - [FAQ](./faq.md)
 - [Glossary](./glossary.md)

--- a/content/docs/2.16/reference/_index.md
+++ b/content/docs/2.16/reference/_index.md
@@ -8,6 +8,6 @@ Reference information for the KEDA autoscaler.
 - [ScaledObject specification](./scaledobject-spec)
 - [ScaledJob specification](./scaledjob-spec)
 - [Kubernetes Events](./events)
-- [Firewall requirements]
+- [Firewall requirements](../operate/cluster#firewall)
 - [FAQ](./faq.md)
 - [Glossary](./glossary.md)


### PR DESCRIPTION
In version 2.15 the link to the firewall requirements disappeared in the Reference section. This PR restore this.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
