### PR TITLE
rfac: Replace links for direct links at Operate page

### DIFF
--- a/content/docs/2.0/operate/_index.md
+++ b/content/docs/2.0/operate/_index.md
@@ -6,4 +6,4 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
+- [Cluster](./cluster)

--- a/content/docs/2.1/operate/_index.md
+++ b/content/docs/2.1/operate/_index.md
@@ -6,4 +6,4 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
+- [Cluster](./cluster)

--- a/content/docs/2.10/operate/_index.md
+++ b/content/docs/2.10/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.11/operate/_index.md
+++ b/content/docs/2.11/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.12/operate/_index.md
+++ b/content/docs/2.12/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.13/operate/_index.md
+++ b/content/docs/2.13/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.14/operate/_index.md
+++ b/content/docs/2.14/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.15/operate/_index.md
+++ b/content/docs/2.15/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance and requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](../reference/events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](../reference/events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.16/operate/_index.md
+++ b/content/docs/2.16/operate/_index.md
@@ -6,8 +6,8 @@ weight = 1
 
 We provide guidance and requirements around various areas to operate KEDA:
 
-- Admission Webhooks ([link](./admission-webhooks))
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](../reference/events))
-- KEDA Metrics Server ([link](./metrics-server))
-- Security ([link](./security))
+- [Admission Webhooks](./admission-webhooks)
+- [Cluster](./cluster)
+- [Kubernetes Events](../reference/events)
+- [KEDA Metrics Server](./metrics-server)
+- [Security](./security)

--- a/content/docs/2.2/operate/_index.md
+++ b/content/docs/2.2/operate/_index.md
@@ -6,5 +6,5 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)

--- a/content/docs/2.3/operate/_index.md
+++ b/content/docs/2.3/operate/_index.md
@@ -6,5 +6,5 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)

--- a/content/docs/2.4/operate/_index.md
+++ b/content/docs/2.4/operate/_index.md
@@ -6,6 +6,6 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)

--- a/content/docs/2.5/operate/_index.md
+++ b/content/docs/2.5/operate/_index.md
@@ -6,6 +6,6 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)

--- a/content/docs/2.6/operate/_index.md
+++ b/content/docs/2.6/operate/_index.md
@@ -6,6 +6,6 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)

--- a/content/docs/2.7/operate/_index.md
+++ b/content/docs/2.7/operate/_index.md
@@ -6,6 +6,6 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)

--- a/content/docs/2.8/operate/_index.md
+++ b/content/docs/2.8/operate/_index.md
@@ -6,6 +6,6 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)

--- a/content/docs/2.9/operate/_index.md
+++ b/content/docs/2.9/operate/_index.md
@@ -6,6 +6,6 @@ weight = 1
 
 We provide guidance & requirements around various areas to operate KEDA:
 
-- Cluster ([link](./cluster))
-- Kubernetes Events ([link](./events))
-- KEDA Metrics Server ([link](./metrics-server))
+- [Cluster](./cluster)
+- [Kubernetes Events](./events)
+- [KEDA Metrics Server](./metrics-server)


### PR DESCRIPTION
Pages like the [Reference page](https://keda.sh/docs/2.15/reference/) use direct links. The [Operate page](https://keda.sh/docs/2.15/operate/) however uses separate 'link' links. This PR is used to keep it consistent.
If there is a reason to present the links for this page in this way, the PR may be closed.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)