### PR TITLE
feat: allow configuring min tls for grpc

### DIFF
--- a/content/docs/2.17/operate/cluster.md
+++ b/content/docs/2.17/operate/cluster.md
@@ -130,6 +130,16 @@ The gRPC Metrics Service is part of the KEDA Operator deployment and serves scal
 | metrics-service-address        | keda-operator.keda.svc.cluster.local:9666 | The address of the gRPC Metrics Service Server                                                                                                                                                                                                                                                            |
 | metrics-service-grpc-authority | ""                                        | Host Authority override for the Metrics Service if the Host Authority is not the same as the address used for the gRPC Metrics Service Server. This is required for mutual TLS when the identity of the adapter server as presented in its TLS certificate is not the same as the metrics-service-address |
 
+By default, KEDA uses TLS1.3 as a minimum TLS version for GRPC client/server. However, if you need to support another version you can configure it by using the environment variable `KEDA_GRPC_MIN_TLS_VERSION`.
+
+For example:
+
+```yaml
+- env:
+    KEDA_GRPC_MIN_TLS_VERSION: TLS12
+```
+
+
 ## Configure `MaxConcurrentReconciles` for Controllers
 
 To implement internal controllers KEDA uses the [controller-runtime project](https://github.com/kubernetes-sigs/controller-runtime), that enables configuration of [MaxConcurrentReconciles property](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options), ie. the maximum number of concurrent reconciles which can be run for a controller.

--- a/content/docs/2.17/operate/cluster.md
+++ b/content/docs/2.17/operate/cluster.md
@@ -130,6 +130,8 @@ The gRPC Metrics Service is part of the KEDA Operator deployment and serves scal
 | metrics-service-address        | keda-operator.keda.svc.cluster.local:9666 | The address of the gRPC Metrics Service Server                                                                                                                                                                                                                                                            |
 | metrics-service-grpc-authority | ""                                        | Host Authority override for the Metrics Service if the Host Authority is not the same as the address used for the gRPC Metrics Service Server. This is required for mutual TLS when the identity of the adapter server as presented in its TLS certificate is not the same as the metrics-service-address |
 
+# gRPC TLS min version
+
 By default, KEDA uses TLS1.3 as a minimum TLS version for GRPC client/server. However, if you need to support another version you can configure it by using the environment variable `KEDA_GRPC_MIN_TLS_VERSION`.
 
 For example:


### PR DESCRIPTION
Supporting https://github.com/kedacore/keda/pull/6320 (pending merge)

Documenting the option to configure GRPC min TLS version.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

