### PR TITLE
Remove Prometheus metric deprecations

### DIFF
--- a/content/docs/2.17/integrations/prometheus.md
+++ b/content/docs/2.17/integrations/prometheus.md
@@ -33,19 +33,6 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 
 > Note: When you deploy the KEDA Operator without any scalers deployed, the only metric you will see is `keda_build_info`. As you deploy scalers, you will start to see some of the metrics listed above but it is dependant on the types of scalers you have deployed.
 
-#### Deprecated metrics
-
-The following metrics are exposed as well, but are deprecated and will be removed in KEDA v2.16.
-
-- `keda_scaler_metrics_latency` - The latency of retrieving current metric from each scaler. Replaced by `keda_scaler_metrics_latency_seconds`.
-- `keda_scaler_errors` - The number of errors that have occurred for each scaler. Replaced by `keda_scaler_detail_errors_total`.
-- `keda_scaler_errors_total` - The total number of errors encountered for all scalers. Replaced by `keda_scaler_detail_errors_total`.
-- `keda_scaled_object_errors` - The number of errors that have occurred for each ScaledObject. Replaced by `keda_scaled_object_errors_total`.
-- `keda_scaled_job_errors` - The number of errors that have occurred for each ScaledJob. Replace by `keda_scaled_job_errors_total`.
-- `keda_resource_totals` - Total number of KEDA custom resources per namespace for each custom resource type (CRD). Replaced by `keda_resource_registered_total`.
-- `keda_trigger_totals` - Total number of triggers per trigger type. Replaced by `keda_trigger_registered_total`.
-- `keda_internal_scale_loop_latency` - Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. Replaced by `keda_internal_scale_loop_latency_seconds`.
-
 ### Admission Webhooks
 
 The KEDA Webhooks expose Prometheus metrics which can be scraped on port `8080` at `/metrics`. The following metrics are being gathered:


### PR DESCRIPTION
Remove Prometheus metric deprecations

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Related: https://github.com/kedacore/keda/pull/6339
