### PR TITLE
Add `vhostName` to Auth Params RabbitMQ doc

### DIFF
--- a/content/docs/2.17/scalers/rabbitmq-queue.md
+++ b/content/docs/2.17/scalers/rabbitmq-queue.md
@@ -74,6 +74,7 @@ TriggerAuthentication CRD is used to connect and authenticate to RabbitMQ:
 
 > See the [RabbitMQ Ports](https://www.rabbitmq.com/networking.html#ports) section for more details on how to configure the ports.
 
+- `vhostName` - Vhost to use for the connection, overrides any vhost set in the connection string from `host`/`hostFromEnv`. (Optional / Required if Azure AD Workload Identity authorization is used)
 **Username and Password based authentication:**
 
 This allows sensitive credentials to be stored and managed separately from the connection string.
@@ -106,7 +107,8 @@ kind: Secret
 metadata:
   name: keda-rabbitmq-secret
 data:
-  host: <AMQP URI connection string> # base64 encoded value of format amqp://guest:password@localhost:5672/vhost
+  host: <AMQP URI connection string> # base64 encoded value of format amqp://guest:password@localhost:5672
+  vhostName: vhost
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -118,6 +120,9 @@ spec:
     - parameter: host
       name: keda-rabbitmq-secret
       key: host
+    - parameter: vhostName
+      name: keda-rabbitmq-secret
+      key: vhostName
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
Update the doc to show how `vhostName` can be added to auth Params referencing a secret 


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda/pull/6373
