### PR TITLE
Fixed typo in GCP PubSub documentation

### DIFF
--- a/content/docs/2.15/scalers/gcp-pub-sub.md
+++ b/content/docs/2.15/scalers/gcp-pub-sub.md
@@ -41,7 +41,7 @@ The Google Cloud Platform (GCP) Pub/Sub trigger allows you to scale based on any
 
 - `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
-- `timeHorizon` - Time range for which you want to retrieve the matrics. (Default: `2m` and Default with aggregation field: `5m`)
+- `timeHorizon` - Time range for which you want to retrieve the metrics. (Default: `2m` and Default with aggregation field: `5m`)
 
 - `valueIfNull` - Value returned if request returns no timeseries.(Default: `""`, Optional, This value can be a float) 
 

--- a/content/docs/2.16/scalers/gcp-pub-sub.md
+++ b/content/docs/2.16/scalers/gcp-pub-sub.md
@@ -41,7 +41,7 @@ The Google Cloud Platform (GCP) Pub/Sub trigger allows you to scale based on any
 
 - `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
-- `timeHorizon` - Time range for which you want to retrieve the matrics. (Default: `2m` and Default with aggregation field: `5m`)
+- `timeHorizon` - Time range for which you want to retrieve the metrics. (Default: `2m` and Default with aggregation field: `5m`)
 
 - `valueIfNull` - Value returned if request returns no timeseries.(Default: `""`, Optional, This value can be a float) 
 

--- a/content/docs/2.17/scalers/gcp-pub-sub.md
+++ b/content/docs/2.17/scalers/gcp-pub-sub.md
@@ -41,7 +41,7 @@ The Google Cloud Platform (GCP) Pub/Sub trigger allows you to scale based on any
 
 - `activationValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 
-- `timeHorizon` - Time range for which you want to retrieve the matrics. (Default: `2m` and Default with aggregation field: `5m`)
+- `timeHorizon` - Time range for which you want to retrieve the metrics. (Default: `2m` and Default with aggregation field: `5m`)
 
 - `valueIfNull` - Value returned if request returns no timeseries.(Default: `""`, Optional, This value can be a float) 
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Fixed typo in GCP PubSub documentation versions `2.15~2.17` where `matrics` was said instead of `metrics`. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
