### PR TITLE
Update azure-event-hub.md for Dapr versions >= 1.10

### DIFF
--- a/content/docs/2.10/scalers/azure-event-hub.md
+++ b/content/docs/2.10/scalers/azure-event-hub.md
@@ -51,9 +51,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.11/scalers/azure-event-hub.md
+++ b/content/docs/2.11/scalers/azure-event-hub.md
@@ -51,9 +51,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.12/scalers/azure-event-hub.md
+++ b/content/docs/2.12/scalers/azure-event-hub.md
@@ -51,9 +51,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.13/scalers/azure-event-hub.md
+++ b/content/docs/2.13/scalers/azure-event-hub.md
@@ -51,9 +51,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.14/scalers/azure-event-hub.md
+++ b/content/docs/2.14/scalers/azure-event-hub.md
@@ -52,9 +52,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.15/scalers/azure-event-hub.md
+++ b/content/docs/2.15/scalers/azure-event-hub.md
@@ -48,9 +48,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.16/scalers/azure-event-hub.md
+++ b/content/docs/2.16/scalers/azure-event-hub.md
@@ -48,9 +48,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.17/scalers/azure-event-hub.md
+++ b/content/docs/2.17/scalers/azure-event-hub.md
@@ -48,9 +48,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).

--- a/content/docs/2.9/scalers/azure-event-hub.md
+++ b/content/docs/2.9/scalers/azure-event-hub.md
@@ -51,9 +51,12 @@ triggers:
     - `azureFunction` - Suitable for Azure Functions & Azure WebJobs SDK. This is the default setting, when `blobcontainer` is not specified.
     - `blobMetadata` - For all implementations that store checkpoint information on blob metadata such as current C#, Python, Java and JavaScript Event Hub SDKs.
     - `goSdk` - For all implementations using the [Golang SDK](https://github.com/Azure/azure-event-hubs-go)'s checkpointing.
-    - `dapr` - Suitable for Dapr pubsub and bindings, depending on the used Dapr version:
-      - pubsub components: >= Dapr 1.6 (older versions need the GoSdk checkpointer)
-      - binding components: >= Dapr 1.9 (older versions need the GoSdk checkpointer)
+    - `dapr` - Suitable for older Dapr pubsub and bindings
+      - Compatible Dapr versions:
+        - pubsub components: 1.6, 1.7, 1.8, 1.9
+        - bindings: 1.9
+      - For newer Dapr versions, use the `blobMetadata` strategy.
+      - For older Dapr versions, use the `goSdk` strategy.
     - When no checkpoint strategy is specified, the Event Hub scaler will use backwards compatibility and able to scale older implementations of C#, Python or Java Event Hub SDKs. (see "Legacy checkpointing"). If this behaviour should be used, `blobContainer` is also required.
 - `cloud` - Name of the cloud environment that the Event Hub belongs to. (Values: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`, `AzureGermanCloud`, `Private`, Default: `AzurePublicCloud`, Optional)
 - `endpointSuffix` - Service Bus endpoint suffix of the cloud environment. (Required when `cloud` is set to `Private`, e.g. `servicebus.cloudapi.de` for `AzureGermanCloud`).


### PR DESCRIPTION
With Dapr 1.10, the Event Hub pubsub component and binding experienced a major refactoring. Since then, Dapr uses the Azure SDK for Go and therefore does not use its own checkpoint format anymore, but instead the `blobMetadata` strategy.

See [this PR](https://github.com/dapr/components-contrib/pull/2453) for the details of the change in Dapr. It is mentioned in the Dapr v1.10 [release notes](https://blog.dapr.io/posts/2023/02/16/dapr-v1.10-is-now-available/).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
