### PR TITLE
Correct sasl and lagTreshold in Apache Kafka scalers

### DIFF
--- a/content/docs/2.0/scalers/apache-kafka.md
+++ b/content/docs/2.0/scalers/apache-kafka.md
@@ -30,7 +30,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag.
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 
 ### Authentication Parameters

--- a/content/docs/2.1/scalers/apache-kafka.md
+++ b/content/docs/2.1/scalers/apache-kafka.md
@@ -30,7 +30,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag.
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 
 ### Authentication Parameters

--- a/content/docs/2.10/scalers/apache-kafka.md
+++ b/content/docs/2.10/scalers/apache-kafka.md
@@ -43,7 +43,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.11/scalers/apache-kafka.md
+++ b/content/docs/2.11/scalers/apache-kafka.md
@@ -43,7 +43,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.12/scalers/apache-kafka-go.md
+++ b/content/docs/2.12/scalers/apache-kafka-go.md
@@ -56,7 +56,7 @@ If 'false' (the default), the scaler will keep a single consumer for that partit
 partition will be scaled to zero. See the [discussion](https://github.com/kedacore/keda/issues/2612) about this parameter.
 - `excludePersistentLag` - When set to `true`, the scaler will exclude partition lag for partitions which current offset is the same as the current offset of the previous polling cycle. This parameter is useful to prevent scaling due to partitions which current offset message is unable to be consumed. If `false` (the default), scaler will include all consumer lag in all partitions as per normal. (Default: `false`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication
 
 > **Note:**
@@ -81,7 +81,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
 **SASL:**
 
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional)
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional)
 - `username` - Username used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 - `password` - Password used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 

--- a/content/docs/2.12/scalers/apache-kafka-go.md
+++ b/content/docs/2.12/scalers/apache-kafka-go.md
@@ -46,7 +46,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.12/scalers/apache-kafka.md
+++ b/content/docs/2.12/scalers/apache-kafka.md
@@ -44,7 +44,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.13/scalers/apache-kafka-go.md
+++ b/content/docs/2.13/scalers/apache-kafka-go.md
@@ -59,7 +59,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `excludePersistentLag` - When set to `true`, the scaler will exclude partition lag for partitions which current offset is the same as the current offset of the previous polling cycle. This parameter is useful to prevent scaling due to partitions which current offset message is unable to be consumed. If `false` (the default), scaler will include all consumer lag in all partitions as per normal. (Default: `false`, Optional)
 - `limitToPartitionsWithLag` - When set to `true`, the number of replicas will not exceed the number of partitions having non-zero lag. `topic` must be specified when this parameter is set to `true`. `allowIdleConsumers` cannot be `true` when this parameter is `true`. (Default: `false`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication
 
 > **Note:**
@@ -84,7 +84,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
 **SASL:**
 
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional)
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional)
 - `username` - Username used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 - `password` - Password used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 

--- a/content/docs/2.13/scalers/apache-kafka-go.md
+++ b/content/docs/2.13/scalers/apache-kafka-go.md
@@ -48,7 +48,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.13/scalers/apache-kafka.md
+++ b/content/docs/2.13/scalers/apache-kafka.md
@@ -45,7 +45,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.14/scalers/apache-kafka-go.md
+++ b/content/docs/2.14/scalers/apache-kafka-go.md
@@ -60,7 +60,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `excludePersistentLag` - When set to `true`, the scaler will exclude partition lag for partitions which current offset is the same as the current offset of the previous polling cycle. This parameter is useful to prevent scaling due to partitions which current offset message is unable to be consumed. If `false` (the default), scaler will include all consumer lag in all partitions as per normal. (Default: `false`, Optional)
 - `limitToPartitionsWithLag` - When set to `true`, the number of replicas will not exceed the number of partitions having non-zero lag. `topic` must be specified when this parameter is set to `true`. `allowIdleConsumers` cannot be `true` when this parameter is `true`. (Default: `false`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication
 
 > **Note:**
@@ -85,7 +85,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
 **SASL:**
 
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional)
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional)
 - `username` - Username used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 - `password` - Password used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 

--- a/content/docs/2.14/scalers/apache-kafka-go.md
+++ b/content/docs/2.14/scalers/apache-kafka-go.md
@@ -49,7 +49,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.14/scalers/apache-kafka.md
+++ b/content/docs/2.14/scalers/apache-kafka.md
@@ -46,7 +46,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.15/scalers/apache-kafka-go.md
+++ b/content/docs/2.15/scalers/apache-kafka-go.md
@@ -60,7 +60,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `excludePersistentLag` - When set to `true`, the scaler will exclude partition lag for partitions which current offset is the same as the current offset of the previous polling cycle. This parameter is useful to prevent scaling due to partitions which current offset message is unable to be consumed. If `false` (the default), scaler will include all consumer lag in all partitions as per normal. (Default: `false`, Optional)
 - `limitToPartitionsWithLag` - When set to `true`, the number of replicas will not exceed the number of partitions having non-zero lag. `topic` must be specified when this parameter is set to `true`. `allowIdleConsumers` cannot be `true` when this parameter is `true`. (Default: `false`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication
 
 > **Note:**
@@ -85,7 +85,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
 **SASL:**
 
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional)
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional)
 - `username` - Username used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 - `password` - Password used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 

--- a/content/docs/2.15/scalers/apache-kafka-go.md
+++ b/content/docs/2.15/scalers/apache-kafka-go.md
@@ -49,7 +49,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.15/scalers/apache-kafka.md
+++ b/content/docs/2.15/scalers/apache-kafka.md
@@ -46,7 +46,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.16/scalers/apache-kafka-go.md
+++ b/content/docs/2.16/scalers/apache-kafka-go.md
@@ -60,7 +60,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `excludePersistentLag` - When set to `true`, the scaler will exclude partition lag for partitions which current offset is the same as the current offset of the previous polling cycle. This parameter is useful to prevent scaling due to partitions which current offset message is unable to be consumed. If `false` (the default), scaler will include all consumer lag in all partitions as per normal. (Default: `false`, Optional)
 - `limitToPartitionsWithLag` - When set to `true`, the number of replicas will not exceed the number of partitions having non-zero lag. `topic` must be specified when this parameter is set to `true`. `allowIdleConsumers` cannot be `true` when this parameter is `true`. (Default: `false`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication
 
 > **Note:**
@@ -85,7 +85,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
 **SASL:**
 
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional)
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional)
 - `username` - Username used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 - `password` - Password used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 

--- a/content/docs/2.16/scalers/apache-kafka-go.md
+++ b/content/docs/2.16/scalers/apache-kafka-go.md
@@ -49,7 +49,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.16/scalers/apache-kafka.md
+++ b/content/docs/2.16/scalers/apache-kafka.md
@@ -46,7 +46,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.17/scalers/apache-kafka-go.md
+++ b/content/docs/2.17/scalers/apache-kafka-go.md
@@ -60,7 +60,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `excludePersistentLag` - When set to `true`, the scaler will exclude partition lag for partitions which current offset is the same as the current offset of the previous polling cycle. This parameter is useful to prevent scaling due to partitions which current offset message is unable to be consumed. If `false` (the default), scaler will include all consumer lag in all partitions as per normal. (Default: `false`, Optional)
 - `limitToPartitionsWithLag` - When set to `true`, the number of replicas will not exceed the number of partitions having non-zero lag. `topic` must be specified when this parameter is set to `true`. `allowIdleConsumers` cannot be `true` when this parameter is `true`. (Default: `false`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication
 
 > **Note:**
@@ -85,7 +85,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
 **SASL:**
 
-- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `aws_msk_iam` or `none`, Default: `none`, Optional)
+- `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `aws_msk_iam` or `none`, Default: `none`, Optional)
 - `username` - Username used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 - `password` - Password used for sasl authentication. (Required if `sasl` is not `none` or `aws_msk_iam`)
 

--- a/content/docs/2.17/scalers/apache-kafka-go.md
+++ b/content/docs/2.17/scalers/apache-kafka-go.md
@@ -49,7 +49,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.17/scalers/apache-kafka.md
+++ b/content/docs/2.17/scalers/apache-kafka.md
@@ -46,7 +46,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.2/scalers/apache-kafka.md
+++ b/content/docs/2.2/scalers/apache-kafka.md
@@ -30,7 +30,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag.
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 
 ### Authentication Parameters

--- a/content/docs/2.3/scalers/apache-kafka.md
+++ b/content/docs/2.3/scalers/apache-kafka.md
@@ -32,7 +32,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag.
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of
 partitions on a topic, allowing for idle consumers. (Default: `false`, Optional)

--- a/content/docs/2.4/scalers/apache-kafka.md
+++ b/content/docs/2.4/scalers/apache-kafka.md
@@ -33,7 +33,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag.
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of
 partitions on a topic, allowing for idle consumers. (Default: `false`, Optional)

--- a/content/docs/2.5/scalers/apache-kafka.md
+++ b/content/docs/2.5/scalers/apache-kafka.md
@@ -33,7 +33,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag.
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of
 partitions on a topic, allowing for idle consumers. (Default: `false`, Optional)

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -37,7 +37,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of
 partitions on a topic, allowing for idle consumers. (Default: `false`, Optional)

--- a/content/docs/2.7/scalers/apache-kafka.md
+++ b/content/docs/2.7/scalers/apache-kafka.md
@@ -38,7 +38,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of
 partitions on a topic, allowing for idle consumers. (Default: `false`, Optional)

--- a/content/docs/2.8/scalers/apache-kafka.md
+++ b/content/docs/2.8/scalers/apache-kafka.md
@@ -39,7 +39,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of

--- a/content/docs/2.9/scalers/apache-kafka.md
+++ b/content/docs/2.9/scalers/apache-kafka.md
@@ -41,7 +41,7 @@ triggers:
 - `bootstrapServers` - Comma separated list of Kafka brokers "hostname:port" to connect to for bootstrap.
 - `consumerGroup` - Name of the consumer group used for checking the offset on the topic and processing the related lag.
 - `topic` - Name of the topic on which processing the offset lag. (Optional, see note below)
-- `lagThreshold` - Average target value to trigger scaling actions. (Default: `5`, Optional)
+- `lagThreshold` - Average target value to trigger scaling actions. (Default: `10`, Optional)
 - `activationLagThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `offsetResetPolicy` - The offset reset policy for the consumer. (Values: `latest`, `earliest`, Default: `latest`, Optional)
 - `allowIdleConsumers` - When set to `true`, the number of replicas can exceed the number of


### PR DESCRIPTION
Correct default `lagTreshold` Apache Kafka scaler
Correct default `lagTreshold` Apache Kafka experimental scaler
Correct `sasl` Apache Kafka experimental scaler

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
