### PR TITLE
Update temporal.md

### DIFF
--- a/content/docs/2.17/scalers/temporal.md
+++ b/content/docs/2.17/scalers/temporal.md
@@ -3,7 +3,7 @@ title = "Temporal"
 availability = "v2.17+"
 maintainer = "Community"
 description = "Scale applications based on Temporal task queue."
-go_file = "temporal_scaler"
+go_file = "temporal"
 +++
 
 ### Trigger Specification


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The temporal scaler name is temporal.go, not temporal_scaler.go
This updates version 2.17 
I have another PR for version 2.18 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
