### PR TITLE
Fix ignoreNullValues example in trigger metadata

### DIFF
--- a/content/docs/2.10/scalers/loki.md
+++ b/content/docs/2.10/scalers/loki.md
@@ -21,7 +21,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.10/scalers/prometheus.md
+++ b/content/docs/2.10/scalers/prometheus.md
@@ -24,7 +24,7 @@ triggers:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # DEPRECATED: This parameter is deprecated as of KEDA v2.10 in favor of customHeaders and will be removed in version 2.12. Use custom headers instead to set X-Scope-OrgID header for Cortex. (see below)
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 
 ```

--- a/content/docs/2.11/scalers/loki.md
+++ b/content/docs/2.11/scalers/loki.md
@@ -21,7 +21,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.11/scalers/prometheus.md
+++ b/content/docs/2.11/scalers/prometheus.md
@@ -24,7 +24,7 @@ triggers:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # DEPRECATED: This parameter is deprecated as of KEDA v2.10 in favor of customHeaders and will be removed in version 2.12. Use custom headers instead to set X-Scope-OrgID header for Cortex. (see below)
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 
 ```

--- a/content/docs/2.12/scalers/loki.md
+++ b/content/docs/2.12/scalers/loki.md
@@ -21,7 +21,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.12/scalers/prometheus.md
+++ b/content/docs/2.12/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # DEPRECATED: This parameter is deprecated as of KEDA v2.10 in favor of customHeaders and will be removed in version 2.12. Use custom headers instead to set X-Scope-OrgID header for Cortex. (see below)
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 
 ```

--- a/content/docs/2.13/scalers/loki.md
+++ b/content/docs/2.13/scalers/loki.md
@@ -21,7 +21,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.13/scalers/prometheus.md
+++ b/content/docs/2.13/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # DEPRECATED: This parameter is deprecated as of KEDA v2.10 in favor of customHeaders and will be removed in version 2.12. Use custom headers instead to set X-Scope-OrgID header for Cortex. (see below)
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     queryParameters: key-1=value-1,key-2=value-2
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 

--- a/content/docs/2.14/scalers/loki.md
+++ b/content/docs/2.14/scalers/loki.md
@@ -21,7 +21,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.14/scalers/prometheus.md
+++ b/content/docs/2.14/scalers/prometheus.md
@@ -24,7 +24,7 @@ triggers:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # DEPRECATED: This parameter is deprecated as of KEDA v2.10 in favor of customHeaders and will be removed in version 2.12. Use custom headers instead to set X-Scope-OrgID header for Cortex. (see below)
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     queryParameters: key-1=value-1,key-2=value-2
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 

--- a/content/docs/2.15/scalers/loki.md
+++ b/content/docs/2.15/scalers/loki.md
@@ -22,7 +22,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.15/scalers/prometheus.md
+++ b/content/docs/2.15/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     queryParameters: key-1=value-1,key-2=value-2
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 

--- a/content/docs/2.16/scalers/aws-cloudwatch.md
+++ b/content/docs/2.16/scalers/aws-cloudwatch.md
@@ -28,7 +28,7 @@ triggers:
     targetMetricValue: "2.1"
     minMetricValue: "1.5"
     # Optional: ignoreNullValues
-    ignoreNullValues: false
+    ignoreNullValues: "false"
     # Required: region
     awsRegion: "eu-west-1"
     # Optional: AWS endpoint url

--- a/content/docs/2.16/scalers/loki.md
+++ b/content/docs/2.16/scalers/loki.md
@@ -22,7 +22,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.16/scalers/prometheus.md
+++ b/content/docs/2.16/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     queryParameters: key-1=value-1,key-2=value-2
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
 

--- a/content/docs/2.17/scalers/aws-cloudwatch.md
+++ b/content/docs/2.17/scalers/aws-cloudwatch.md
@@ -28,7 +28,7 @@ triggers:
     targetMetricValue: "2.1"
     minMetricValue: "1.5"
     # Optional: ignoreNullValues
-    ignoreNullValues: false
+    ignoreNullValues: "false"
     # Required: region
     awsRegion: "eu-west-1"
     # Optional: AWS endpoint url

--- a/content/docs/2.17/scalers/loki.md
+++ b/content/docs/2.17/scalers/loki.md
@@ -22,7 +22,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.17/scalers/prometheus.md
+++ b/content/docs/2.17/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     queryParameters: key-1=value-1,key-2=value-2
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
     timeout: 1000 # Optional. Custom timeout for the HTTP client used in this scaler

--- a/content/docs/2.18/scalers/aws-cloudwatch.md
+++ b/content/docs/2.18/scalers/aws-cloudwatch.md
@@ -28,7 +28,7 @@ triggers:
     targetMetricValue: "2.1"
     minMetricValue: "1.5"
     # Optional: ignoreNullValues
-    ignoreNullValues: false
+    ignoreNullValues: "false"
     # Required: region
     awsRegion: "eu-west-1"
     # Optional: AWS endpoint url

--- a/content/docs/2.18/scalers/loki.md
+++ b/content/docs/2.18/scalers/loki.md
@@ -22,7 +22,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.18/scalers/prometheus.md
+++ b/content/docs/2.18/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     customHeaders: X-Client-Id=cid,X-Tenant-Id=tid,X-Organization-Id=oid # Optional. Custom headers to include in query. In case of auth header, use the custom authentication or relevant authModes.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     queryParameters: key-1=value-1,key-2=value-2
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint    
     timeout: 1000 # Optional. Custom timeout for the HTTP client used in this scaler

--- a/content/docs/2.8/scalers/prometheus.md
+++ b/content/docs/2.8/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # Optional. X-Scope-OrgID header for Cortex.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
 ```
 
 **Parameter list:**

--- a/content/docs/2.9/scalers/loki.md
+++ b/content/docs/2.9/scalers/loki.md
@@ -21,7 +21,7 @@ triggers:
     # Optional fields:
     activationThreshold: '2.50'
     tenantName: Tenant1 # Optional. X-Scope-OrgID header for specifying the tenant name in a multi-tenant setup.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Loki. Set to `false` the scaler will return error when Loki target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Loki endpoint
 ```
 

--- a/content/docs/2.9/scalers/prometheus.md
+++ b/content/docs/2.9/scalers/prometheus.md
@@ -23,7 +23,7 @@ triggers:
     # Optional fields:
     namespace: example-namespace  # for namespaced queries, eg. Thanos
     cortexOrgID: my-org # Optional. X-Scope-OrgID header for Cortex.
-    ignoreNullValues: false # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
+    ignoreNullValues: "false" # Default is `true`, which means ignoring the empty value list from Prometheus. Set to `false` the scaler will return error when Prometheus target is lost
     unsafeSsl: "false" #  Default is `false`, Used for skipping certificate check when having self-signed certs for Prometheus endpoint
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The docs incorrectly show this trigger metadata field as a boolean type but the metadata is a map of strings. Fixing the example to correctly surface that `ignoreNullValues` should be set as a string.

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
