### PR TITLE
fix: replace typographic quotes in scaler descriptions

### DIFF
--- a/layouts/_default/list.lunr.json
+++ b/layouts/_default/list.lunr.json
@@ -1,6 +1,6 @@
 {{- $index := slice -}}
 {{- range $scalers := where site.RegularPages ".CurrentSection.Title" "Scalers" -}}
-    {{- $index = $index | append (dict "title" $scalers.Title "version" (index (first 3 (split (delimit (split $scalers.RelPermalink "/") "," "") ",")) 2) "href" $scalers.RelPermalink  "availability" $scalers.Params.availability "description" ($scalers.Description | markdownify) "maintainer" $scalers.Params.maintainer "category" $scalers.Params.category "type" "built-in" ) -}}
+    {{- $index = $index | append (dict "title" $scalers.Title "version" (index (first 3 (split (delimit (split $scalers.RelPermalink "/") "," "") ",")) 2) "href" $scalers.RelPermalink  "availability" $scalers.Params.availability "description" ($scalers.Params.description) "maintainer" $scalers.Params.maintainer "category" $scalers.Params.category "type" "built-in" ) -}}
 {{- end -}}
 
 {{- $index | jsonify -}}


### PR DESCRIPTION
Remove markdownify from the description field in the scaler tiles JSON (list.lunr.json).
The description is plain text from front matter and does not require markdownify.
Using markdownify caused visual issues in the UI, so this prevents single quotes (') from being converted to HTML entities like `&rsquo;` and `&lsquo;`.

Example:

<img width="341" height="345" alt="image" src="https://github.com/user-attachments/assets/8a9ec3f8-a2c9-4963-b302-4f71693851ff" />

<img width="320" height="455" alt="image" src="https://github.com/user-attachments/assets/4dab1527-b848-46e9-ba4c-9660784a81ce" />

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
