### PR TITLE
Extend stale-bot to PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -38,6 +38,3 @@ closeComment: >
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30
-
-# Limit to only `issues` or `pulls`
-only: issues


### PR DESCRIPTION
This PR removes the stale-bot limit to manage only issues and aligns configuration with other repos

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
