### PR TITLE
Add `ignoreUnavailable` and `defaultValue` options

### DIFF
--- a/content/docs/2.9/scalers/metrics-api.md
+++ b/content/docs/2.9/scalers/metrics-api.md
@@ -31,6 +31,8 @@ triggers:
 - `targetValue` - Target value to scale on. When the metric provided by the API is equal or higher to this value, KEDA will start scaling out. When the metric is 0 or less, KEDA will scale down to 0. (This value can be a float)
 - `activationTargetValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
+- `ignoreUnavaiable` - Do not error when the API is not available and instead use the default value. (Values: `true`, `false`, Default: `false`, Optional)
+- `defaultValue` - Default value when the metrics API is not available. (Default: `0`, Optional, This value can be a float)
 
 
 ### Authentication Parameters


### PR DESCRIPTION
The options `ignoreUnavailable` and `defaultValue` are added to the metrics API scaler. A potential use case for this is a deployment that uses multiple scalers and can also scale to zero. In this case, you might want to use the metrics API to prevent the deployment from being downscaled.

PR for Keda: https://github.com/kedacore/keda/pull/6962