### PR TITLE
Deprecate minMetricValue in Huawei Cloudeye scaler

### DIFF
--- a/content/docs/2.18/scalers/huawei-cloudeye.md
+++ b/content/docs/2.18/scalers/huawei-cloudeye.md
@@ -26,13 +26,13 @@ triggers:
 
 **Parameter list:**
 
-- `namespace` - Namespace of the metric.The format is service.item; service and item must be strings, must start with a letter, can only contain 0-9/a-z/A-Z/_, the total length of service.item is 3, the maximum is 32.
+- `namespace` - Namespace of the metric. The format is service.item; service and item must be strings, must start with a letter, can only contain 0-9/a-z/A-Z/_, the total length of service.item is 3, the maximum is 32.
 - `metricName` - Name of the metric.
 - `dimensionName` - Name of the metric dimension.
 - `dimensionValue` - Value of the metric dimension.
 - `targetMetricValue` - Target value for your metric. (This value can be a float)
 - `activationTargetMetricValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds).(Default: `0`, Optional, This value can be a float)
-- `minMetricValue` - **Deprecated if favor of `activationTargetMetricValue`** Minimum value for your metric. If the actual value of the metric you get from cloudeye is less than the minimum value, then the scaler is not active. (This value can be a float)
+- `minMetricValue` - Minimum value for your metric. If the actual value of the metric you get from cloudeye is less than the minimum value, then the scaler is not active. (This value can be a float) (**The 'minMetricValue' setting is DEPRECATED and will be removed in v2.20 - Use 'activationTargetMetricValue' instead**)
 - `metricCollectionTime` - Collection time of the metric in seconds. Equivalent to the earliest start time of the end time. (default: 300)
 - `metricFilter` - Aggregation method of the metric. (Values: `average`, `max`, `min`, `sum`, Default: `average`, Optional)
 - `metricPeriod` - Granularity of the metric in seconds. (Default: 300, Optional)


### PR DESCRIPTION
Related: https://github.com/kedacore/keda/pull/6978

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
