### PR TITLE
fix minor indent in temporal docs

### DIFF
--- a/content/docs/2.17/scalers/temporal.md
+++ b/content/docs/2.17/scalers/temporal.md
@@ -110,5 +110,5 @@ spec:
       activationTargetQueueSize: "0"
       endpoint: temporal-frontend.temporal.svc.cluster.local:7233
     authenticationRef:
-    name: keda-trigger-auth-temporal
+      name: keda-trigger-auth-temporal
 ```

--- a/content/docs/2.18/scalers/temporal.md
+++ b/content/docs/2.18/scalers/temporal.md
@@ -112,5 +112,5 @@ spec:
       activationTargetQueueSize: "0"
       endpoint: temporal-frontend.temporal.svc.cluster.local:7233
     authenticationRef:
-    name: keda-trigger-auth-temporal
+      name: keda-trigger-auth-temporal
 ```


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add an indent to the `authenticationRef.name` field in the temporal docs

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
