### PR TITLE
docs(temporal): Fix optional formatting

### DIFF
--- a/content/docs/2.17/scalers/temporal.md
+++ b/content/docs/2.17/scalers/temporal.md
@@ -22,7 +22,7 @@ triggers:
       queueTypes: workflow # optional
       buildId: 1.0.0 # optional
       selectAllActive: false # optional
-      selectUnversioned: false optional
+      selectUnversioned: false # optional
       minConnectTimeout: 5 # optional
       unsafeSsl: false # optional
 ```
@@ -35,7 +35,7 @@ triggers:
 - `activationTargetQueueSize` - This sets the target value for activating the scaler. More information about activation thresholds can be found  [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `targetQueueSize` - Target value for queue length passed to the scaler. The scaler will cause the replicas to increase if the queue message count is greater than the target value per active replica. (Default: `5`, Optional)
 - `taskQueue` - This parameter specifies the task queue name. (Required)
-- `queueTypes` - Task Queue type can be configured as `workflow`, `activity`, or both, separated by a comma (,) if multiple types are needed. The default type is `workflow`. This field is optional.
+- `queueTypes` - Task Queue type can be configured as `workflow`, `activity`, or both, separated by a comma (,) if multiple types are needed. (Default: `workflow`, Optional)
 - `buildId` - Build IDs identify Worker versions for Workflow versioning and task compatibility (Optional)
 - `selectAllActive` - Include all active versions (Default:`false`, Optional)
 - `selectUnversioned` - Include the unversioned queue (Default:`false`, Optional)

--- a/content/docs/2.17/scalers/temporal.md
+++ b/content/docs/2.17/scalers/temporal.md
@@ -21,10 +21,10 @@ triggers:
       endpoint: temporal-frontend.temporal.svc.cluster.local:7233
       queueTypes: workflow # optional
       buildId: 1.0.0 # optional
-      selectAllActive: false # optional
-      selectUnversioned: false # optional
-      minConnectTimeout: 5 # optional
-      unsafeSsl: false # optional
+      selectAllActive: "false" # optional
+      selectUnversioned: "false" # optional
+      minConnectTimeout: "5" # optional
+      unsafeSsl: "false" # optional
 ```
 
 **Parameter list:**

--- a/content/docs/2.18/scalers/temporal.md
+++ b/content/docs/2.18/scalers/temporal.md
@@ -22,7 +22,7 @@ triggers:
       queueTypes: workflow # optional
       buildId: 1.0.0 # optional
       selectAllActive: false # optional
-      selectUnversioned: false optional
+      selectUnversioned: false # optional
       minConnectTimeout: 5 # optional
       unsafeSsl: false # optional
       tlsServerName: "custom-tls-servername" # optional
@@ -36,7 +36,7 @@ triggers:
 - `activationTargetQueueSize` - This sets the target value for activating the scaler. More information about activation thresholds can be found  [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `targetQueueSize` - Target value for queue length passed to the scaler. The scaler will cause the replicas to increase if the queue message count is greater than the target value per active replica. (Default: `5`, Optional)
 - `taskQueue` - This parameter specifies the task queue name. (Required)
-- `queueTypes` - Task Queue type can be configured as `workflow`, `activity`, or both, separated by a comma (,) if multiple types are needed. The default type is `workflow`. This field is optional.
+- `queueTypes` - Task Queue type can be configured as `workflow`, `activity`, or both, separated by a comma (,) if multiple types are needed. (Default: `workflow`, Optional)
 - `buildId` - Build IDs identify Worker versions for Workflow versioning and task compatibility (Optional)
 - `selectAllActive` - Include all active versions (Default:`false`, Optional)
 - `selectUnversioned` - Include the unversioned queue (Default:`false`, Optional)

--- a/content/docs/2.18/scalers/temporal.md
+++ b/content/docs/2.18/scalers/temporal.md
@@ -21,10 +21,10 @@ triggers:
       endpoint: temporal-frontend.temporal.svc.cluster.local:7233
       queueTypes: workflow # optional
       buildId: 1.0.0 # optional
-      selectAllActive: false # optional
-      selectUnversioned: false # optional
-      minConnectTimeout: 5 # optional
-      unsafeSsl: false # optional
+      selectAllActive: "false" # optional
+      selectUnversioned: "false" # optional
+      minConnectTimeout: "5" # optional
+      unsafeSsl: "false" # optional
       tlsServerName: "custom-tls-servername" # optional
 ```
 


### PR DESCRIPTION
This PR adds a missing `#` to the specification, and makes the `queueTypes` parameter conform to the convention for documenting optional values. The change is applied to both versions for which the Temporal scaler is present.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


