### PR TITLE
Clarify queueLengthStrategy description in docs for Azure Queue Autoscaling

### DIFF
--- a/content/docs/2.17/scalers/azure-storage-queue.md
+++ b/content/docs/2.17/scalers/azure-storage-queue.md
@@ -28,7 +28,7 @@ triggers:
 
 - `queueName` - Name of the queue.
 - `queueLength` - Target value for queue length passed to the scaler. Example: if one pod can handle 10 messages, set the queue length target to 10. If the actual number of messages in the queue is 30, the scaler scales to 3 pods. (Default: `5`, Optional)
-- `queueLengthStrategy` - `all` considers both visible and invisible messages, while `visibleonly` uses Peek to count only visible messages. In `visibleonly`, if the count of messages is 32 or higher, it falls back to the default `all` strategy, counting both visible and invisible messages. (Default: `all`, Optional)
+- `queueLengthStrategy` - `all` considers both visible and invisible messages, while `visibleonly` uses Peek to count only visible messages. In `visibleonly`, if the count of visible messages is 32 or higher, it falls back to the default `all` strategy, counting both visible and invisible messages. (Default: `all`, Optional)
 - `activationQueueLength` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `connectionFromEnv` - Name of the environment variable your deployment uses to get the connection string.
 - `accountName` - Name of the storage account that the queue belongs to.


### PR DESCRIPTION
I noticed while reviewing the code for this path (https://github.com/kedacore/keda/blob/e89626a16563735b8cc6211fbcbdc43e51d37d15/pkg/scalers/azure_queue_scaler.go), that I had originally misinterpreted how the visibleonly queue length strategy works. This PR tries to clarify the mistaken behavior by making it explicit that the count that has to be 32 or higher before falling back to the regular behavior is that of the visible messages not the queue overall.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
