### PR TITLE
docs: Fixed type of boolean values

### DIFF
--- a/content/docs/2.10/scalers/apache-kafka.md
+++ b/content/docs/2.10/scalers/apache-kafka.md
@@ -29,9 +29,9 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     tls: enable

--- a/content/docs/2.11/scalers/apache-kafka.md
+++ b/content/docs/2.11/scalers/apache-kafka.md
@@ -29,9 +29,9 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     tls: enable

--- a/content/docs/2.12/scalers/apache-kafka.md
+++ b/content/docs/2.12/scalers/apache-kafka.md
@@ -29,9 +29,9 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.13/scalers/apache-kafka.md
+++ b/content/docs/2.13/scalers/apache-kafka.md
@@ -29,10 +29,10 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.14/scalers/apache-kafka.md
+++ b/content/docs/2.14/scalers/apache-kafka.md
@@ -30,10 +30,10 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.15/scalers/apache-kafka.md
+++ b/content/docs/2.15/scalers/apache-kafka.md
@@ -30,10 +30,10 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.16/scalers/apache-kafka.md
+++ b/content/docs/2.16/scalers/apache-kafka.md
@@ -30,10 +30,10 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.17/scalers/apache-kafka.md
+++ b/content/docs/2.17/scalers/apache-kafka.md
@@ -30,10 +30,10 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.18/scalers/apache-kafka.md
+++ b/content/docs/2.18/scalers/apache-kafka.md
@@ -30,11 +30,11 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
-    ensureEvenDistributionOfPartitions: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
+    ensureEvenDistributionOfPartitions: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.19/scalers/apache-kafka.md
+++ b/content/docs/2.19/scalers/apache-kafka.md
@@ -30,11 +30,11 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
-    limitToPartitionsWithLag: false
-    ensureEvenDistributionOfPartitions: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
+    limitToPartitionsWithLag: 'false'
+    ensureEvenDistributionOfPartitions: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
     sasl: plaintext

--- a/content/docs/2.3/scalers/apache-kafka.md
+++ b/content/docs/2.3/scalers/apache-kafka.md
@@ -24,7 +24,7 @@ triggers:
     topic: test-topic
     lagThreshold: '5'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
+    allowIdleConsumers: 'false'
 ```
 
 **Parameter list:**

--- a/content/docs/2.4/scalers/apache-kafka.md
+++ b/content/docs/2.4/scalers/apache-kafka.md
@@ -24,7 +24,7 @@ triggers:
     topic: test-topic
     lagThreshold: '5'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
+    allowIdleConsumers: 'false'
     version: 1.0.0
 ```
 

--- a/content/docs/2.5/scalers/apache-kafka.md
+++ b/content/docs/2.5/scalers/apache-kafka.md
@@ -24,7 +24,7 @@ triggers:
     topic: test-topic
     lagThreshold: '5'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
+    allowIdleConsumers: 'false'
     version: 1.0.0
 ```
 

--- a/content/docs/2.6/scalers/apache-kafka.md
+++ b/content/docs/2.6/scalers/apache-kafka.md
@@ -28,7 +28,7 @@ triggers:
     topic: test-topic
     lagThreshold: '5'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
+    allowIdleConsumers: 'false'
     version: 1.0.0
 ```
 

--- a/content/docs/2.7/scalers/apache-kafka.md
+++ b/content/docs/2.7/scalers/apache-kafka.md
@@ -28,8 +28,8 @@ triggers:
     topic: test-topic
     lagThreshold: '5'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
     version: 1.0.0
 ```
 

--- a/content/docs/2.8/scalers/apache-kafka.md
+++ b/content/docs/2.8/scalers/apache-kafka.md
@@ -29,8 +29,8 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
     version: 1.0.0
 ```
 

--- a/content/docs/2.9/scalers/apache-kafka.md
+++ b/content/docs/2.9/scalers/apache-kafka.md
@@ -29,9 +29,9 @@ triggers:
     lagThreshold: '5'
     activationLagThreshold: '3'
     offsetResetPolicy: latest
-    allowIdleConsumers: false
-    scaleToZeroOnInvalidOffset: false
-    excludePersistentLag: false
+    allowIdleConsumers: 'false'
+    scaleToZeroOnInvalidOffset: 'false'
+    excludePersistentLag: 'false'
     version: 1.0.0
     partitionLimitation: '1,2,10-20,31'
 ```


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR fixes the Kafka scaler document where some values are written as booleans whereas they should be strings. Please squash before merge.

Error message:
```text
  Error: unable to generate manifests: cannot patch "app" with kind ScaledObject: ScaledObject.keda.sh "app" is invalid:

[spec.triggers[1].metadata.allowIdleConsumers: Invalid value: "boolean": spec.triggers[1].metadata.allowIdleConsumers in body must be of type string: "boolean",

spec.triggers[1].metadata.ensureEvenDistributionOfPartitions: Invalid value: "boolean": spec.triggers[1].metadata.ensureEvenDistributionOfPartitions in body must be of type string: "boolean",

spec.triggers[1].metadata.excludePersistentLag: Invalid value: "boolean": spec.triggers[1].metadata.excludePersistentLag in body must be of type string: "boolean",

spec.triggers[1].metadata.limitToPartitionsWithLag: Invalid value: "boolean": spec.triggers[1].metadata.limitToPartitionsWithLag in body must be of type string: "boolean",

spec.triggers[1].metadata.scaleToZeroOnInvalidOffset: Invalid value: "boolean": spec.triggers[1].metadata.scaleToZeroOnInvalidOffset in body must be of type string: "boolean"]

  Error: plugin "diff" exited with error
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
- Quoted boolean fields in docs
