### PR TITLE
docs: Add `awsAccountId` parameter for CloudWatch cross-account observability

### DIFF
--- a/content/docs/2.19/scalers/aws-cloudwatch.md
+++ b/content/docs/2.19/scalers/aws-cloudwatch.md
@@ -31,6 +31,8 @@ triggers:
     ignoreNullValues: "false"
     # Required: region
     awsRegion: "eu-west-1"
+    # Optional: Specify metric source AWS Account ID when using CloudWatch cross-account observability
+    awsAccountId: ""
     # Optional: AWS endpoint url
     awsEndpoint: ""
     # Optional: AWS Access Key ID, can use TriggerAuthentication as well
@@ -54,6 +56,7 @@ triggers:
 **Parameter list:**
 
 - `awsRegion` - AWS Region for the AWS Cloudwatch.
+- `awsAccountId` - Specify metric source AWS Account ID when using CloudWatch cross-account observability
 - `awsEndpoint` - Endpoint URL to override the default AWS endpoint. (Default: `""`, Optional)
 - `namespace` - AWS Cloudwatch namespace where the metric is located (Optional, Required when `expression` is not specified)
 - `metricName` - AWS Cloudwatch metric name (Optional, Required when `expression` is not specified)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

This PR adds AWS Cloudwatch scaler documentation for the `awsAccountId` parameter which allows using CloudWatch cross-account observability.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda/issues/7189 and https://github.com/kedacore/keda/pull/7237
