### PR TITLE
documented tolerance of hpa behavior policy sections

### DIFF
--- a/content/docs/2.18/reference/scaledobject-spec.md
+++ b/content/docs/2.18/reference/scaledobject-spec.md
@@ -214,6 +214,7 @@ advanced:
         - type: Percent
           value: 100
           periodSeconds: 15
+          tolerance: 0.1                          # Kubernetes v1.34 is required to be specifiable
 ```
 
 #### horizontalPodAutoscalerConfig.name
@@ -226,7 +227,13 @@ Starting from Kubernetes v1.18 the autoscaling API allows scaling behavior to be
 
 **Assumptions:** KEDA must be running on Kubernetes cluster v1.18+, in order to be able to benefit from this setting.
 
+#### horizontalPodAutoscalerConfig.behavior tolerance
 
+As of Kubernetes v1.34 the `tolerance` field can be specified under the HPA behavior policy `scaleUp` and `scaleDown` sections. The field applies a tolerance thresholds for scaling decisions, allowing you to specify different behivour for scale-up and scale-down operations. This field was in alpha release under Kubernetes v1.33, which can be enabled through the Kubernetes `HPAConfigurableTolerance` feature gate. As of Kubernetes v1.34, this field has graduated to beta release and is specifiable by default.
+
+### scalingModifiers
+
+If defined, both `target` and `formula` are mandatory. Using this structure creates `composite-metric` for the HPA that will replace all requests for external metrics and handle them internally. With `scalingModifiers` each trigger used in the `formula` **must** have a name defined.
 
 ```yaml
 advanced:
@@ -236,10 +243,6 @@ advanced:
     metricType:  {metric-tipe-for-the-modifier}               # Optional. Metric type to be used if metrics are anyhow composed together
     formula: {formula-for-fetched-metrics}                    # Mandatory. Formula for calculation
 ```
-
-### scalingModifiers
-
-If defined, both `target` and `formula` are mandatory. Using this structure creates `composite-metric` for the HPA that will replace all requests for external metrics and handle them internally. With `scalingModifiers` each trigger used in the `formula` **must** have a name defined.
 
 #### scalingModifiers.target
 

--- a/content/docs/2.19/reference/scaledobject-spec.md
+++ b/content/docs/2.19/reference/scaledobject-spec.md
@@ -214,6 +214,7 @@ advanced:
         - type: Percent
           value: 100
           periodSeconds: 15
+          tolerance: 0.1                          # Kubernetes v1.34 is required to be specifiable
 ```
 
 #### horizontalPodAutoscalerConfig.name
@@ -226,7 +227,13 @@ Starting from Kubernetes v1.18 the autoscaling API allows scaling behavior to be
 
 **Assumptions:** KEDA must be running on Kubernetes cluster v1.18+, in order to be able to benefit from this setting.
 
+#### horizontalPodAutoscalerConfig.behavior tolerance
 
+As of Kubernetes v1.34 the `tolerance` field can be specified under the HPA behavior policy `scaleUp` and `scaleDown` sections. The field applies a tolerance thresholds for scaling decisions, allowing you to specify different behivour for scale-up and scale-down operations. This field was in alpha release under Kubernetes v1.33, which can be enabled through the Kubernetes `HPAConfigurableTolerance` feature gate. As of Kubernetes v1.34, this field has graduated to beta release and is specifiable by default.
+
+### scalingModifiers
+
+If defined, both `target` and `formula` are mandatory. Using this structure creates `composite-metric` for the HPA that will replace all requests for external metrics and handle them internally. With `scalingModifiers` each trigger used in the `formula` **must** have a name defined.
 
 ```yaml
 advanced:
@@ -236,10 +243,6 @@ advanced:
     metricType:  {metric-tipe-for-the-modifier}               # Optional. Metric type to be used if metrics are anyhow composed together
     formula: {formula-for-fetched-metrics}                    # Mandatory. Formula for calculation
 ```
-
-### scalingModifiers
-
-If defined, both `target` and `formula` are mandatory. Using this structure creates `composite-metric` for the HPA that will replace all requests for external metrics and handle them internally. With `scalingModifiers` each trigger used in the `formula` **must** have a name defined.
 
 #### scalingModifiers.target
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Task

HPA provides a tolerance threshold from Kubernetes 1.34. 

I have introduced documentation for versions of ScaledObject which support this native field, keda v2.18+ onwards. 

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/keda-docs/issues/1659, https://github.com/kedacore/keda/issues/5486