### PR TITLE
fix(doc): updated kubernetes-workload.md

### DIFF
--- a/content/docs/2.10/scalers/kubernetes-workload.md
+++ b/content/docs/2.10/scalers/kubernetes-workload.md
@@ -13,8 +13,8 @@ triggers:
 - type: kubernetes-workload
   metadata:
     podSelector: app=backend
-    value: 0.5
-    activationValue: 3.1
+    value: "0.5"
+    activationValue: "3.1"
 ```
 
 **Parameter list:**
@@ -44,6 +44,6 @@ spec:
   triggers:
   - type: kubernetes-workload
     metadata:
-      podSelector: app=backend,deploy notin (critical,monolith)
-      value: 3
+      podSelector: 'app=backend, deploy notin (critical, monolith)'
+      value: "3"
 ```


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #

- Numbers are usually provided as actual numbers, not strings. 
- YAML will accept both, but numeric values should be unquoted unless the scaler explicitly requires strings (this one doesn’t).
- Removing quotes avoids confusion about whether the value is being parsed as a string or number.
- Mixed quoting rules can confuse newcomers.