### PR TITLE
Add unreleased versions parameter for documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,8 @@ and uses the next version, instead of the current one. Ensure that Kubernetes cl
 
 Ensure that compatibility matrix on `content/docs/{next-version}/operate/cluster.md` is updated with the compatibilities for the incoming version.
 
+Update the new version in the `params.unreleased.docs` list in [config.toml](config.toml).
+
 ### Publishing a new version
 
 Once a version is ready to be published, we must add the version to the

--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,9 @@ favicon = "favicon.png"
 [params.versions]
 docs = ["2.18", "2.17", "2.16", "2.15", "2.14", "2.13", "2.12", "2.11", "2.10", "2.9", "2.8", "2.7", "2.6", "2.5", "2.4", "2.3", "2.2", "2.1", "2.0", "1.5", "1.4"]
 
+[params.unreleased]
+docs = ["2.19"]
+
 # Site fonts. For more options see https://fonts.google.com.
 [[params.fonts]]
 name = "Inria Sans"

--- a/layouts/partials/doc-version-selector.html
+++ b/layouts/partials/doc-version-selector.html
@@ -1,11 +1,14 @@
-{{ $allVersions   := index site.Params.versions .Section }}
-{{ $latest        := index $allVersions 0 }}
-{{ $version       := index (split .File.Path "/") 1 }}
-{{ $isLatest      := eq $latest $version }}
-{{ $versionsOfDoc := slice }}
-{{ $here          := (delimit (after 3 (split (delimit (split .RelPermalink "/") "," "") ",")) "/") }}
-{{ $path          := .File.Path }}
-{{ $section       := .Section }}
+{{ $releasedVersions   := index site.Params.versions .Section }}
+{{ $unreleasedVersions := default slice (index site.Params.unreleased .Section) }}
+{{ $allVersions        := $unreleasedVersions | append $releasedVersions }}
+{{ $latest             := index $releasedVersions 0 }}
+{{ $version            := index (split .File.Path "/") 1 }}
+{{ $isLatest           := eq $latest $version }}
+{{ $isUnreleased       := in $unreleasedVersions $version }}
+{{ $versionsOfDoc      := slice }}
+{{ $here               := (delimit (after 3 (split (delimit (split .RelPermalink "/") "," "") ",")) "/") }}
+{{ $path               := .File.Path }}
+{{ $section            := .Section }}
 {{ range $allVersions }}
 {{ $fileToCheck := replace $path $version . }}
 {{ if fileExists $fileToCheck }}
@@ -21,7 +24,12 @@
       <span class="has-text-weight-bold">
         {{ $version }}
       </span>
-      {{ if $isLatest }}
+      {{ if $isUnreleased }}
+      &nbsp;
+      <span>
+        (unreleased)
+      </span>
+      {{ else if $isLatest }}
       &nbsp;
       <span>
         (latest)
@@ -39,11 +47,17 @@
     <div class="dropdown-content">
       {{ range $versionsOfDoc }}
       {{ $isLatest := eq . $latest }}
+      {{ $isUnreleased := in $unreleasedVersions . }}
       <a class="dropdown-item" href="/{{ $section }}/{{ . }}/{{ $here }}">
         <span>
           {{ . }}
         </span>
-        {{ if $isLatest }}
+        {{ if $isUnreleased }}
+        &nbsp;
+        <span>
+          (unreleased)
+        </span>
+        {{ else if $isLatest }}
         &nbsp;
         <span>
           (latest)


### PR DESCRIPTION
Add unreleased versions parameter for documentation:

<img width="312" height="159" alt="image" src="https://github.com/user-attachments/assets/1772e203-6879-4635-8a8d-abea72bdffeb" />

I've called it `unreleased` now, although I prefer `upcoming`.

Which do you prefer, `unreleased` or `upcoming`?

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #https://github.com/kedacore/governance/issues/96
