### PR TITLE
Datadog scaler: clarify 422 no-data docs

### DIFF
--- a/content/docs/2.10/scalers/datadog.md
+++ b/content/docs/2.10/scalers/datadog.md
@@ -45,6 +45,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.11/scalers/datadog.md
+++ b/content/docs/2.11/scalers/datadog.md
@@ -45,6 +45,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.12/scalers/datadog.md
+++ b/content/docs/2.12/scalers/datadog.md
@@ -45,6 +45,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.13/scalers/datadog.md
+++ b/content/docs/2.13/scalers/datadog.md
@@ -45,6 +45,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.14/scalers/datadog.md
+++ b/content/docs/2.14/scalers/datadog.md
@@ -46,6 +46,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.15/scalers/datadog.md
+++ b/content/docs/2.15/scalers/datadog.md
@@ -212,6 +212,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.16/scalers/datadog.md
+++ b/content/docs/2.16/scalers/datadog.md
@@ -212,6 +212,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.17/scalers/datadog.md
+++ b/content/docs/2.17/scalers/datadog.md
@@ -211,6 +211,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.18/scalers/datadog.md
+++ b/content/docs/2.18/scalers/datadog.md
@@ -212,12 +212,12 @@ triggers:
 - `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional)
 - `timeWindowOffset`: The delayed time window offset (in seconds) to wait for the metric to be available. The values of some queries might be not available at now and need a small delay to become available, try to adjust `timeWindowOffset` if you encounter this issue. (Default: `0`, Optional)
 - `lastAvailablePointOffset`: The offset to retrieve the X to last data point. The value of last data point of some queries might be inaccurate [because of the implicit rollup function](https://docs.datadoghq.com/dashboards/functions/rollup/#rollup-interval-enforced-vs-custom), try to adjust to `1` if you encounter this issue. (Default: `0`, Optional)
-- `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, KEDA returns `0` for Datadog 422 "no data points found" responses; other failures are still surfaced to the HPA. (Optional, This value can be a float)
+- `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 - `timeout` - Timeout (in a Duration string format) **for this specific trigger**. This value will override the value defined in `KEDA_HTTP_DEFAULT_TIMEOUT`. (Optional)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
 >
-> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise `0`.
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.19/scalers/datadog.md
+++ b/content/docs/2.19/scalers/datadog.md
@@ -212,12 +212,12 @@ triggers:
 - `age`: The time window (in seconds) to retrieve metrics from Datadog. (Default: `90`, Optional)
 - `timeWindowOffset`: The delayed time window offset (in seconds) to wait for the metric to be available. The values of some queries might be not available at now and need a small delay to become available, try to adjust `timeWindowOffset` if you encounter this issue. (Default: `0`, Optional)
 - `lastAvailablePointOffset`: The offset to retrieve the X to last data point. The value of last data point of some queries might be inaccurate [because of the implicit rollup function](https://docs.datadoghq.com/dashboards/functions/rollup/#rollup-interval-enforced-vs-custom), try to adjust to `1` if you encounter this issue. (Default: `0`, Optional)
-- `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, KEDA returns `0` for Datadog 422 "no data points found" responses; other failures are still surfaced to the HPA. (Optional, This value can be a float)
+- `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 - `timeout` - Timeout (in a Duration string format) **for this specific trigger**. This value will override the value defined in `KEDA_HTTP_DEFAULT_TIMEOUT`. (Optional)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
 >
-> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise `0`.
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.7/scalers/datadog.md
+++ b/content/docs/2.7/scalers/datadog.md
@@ -37,6 +37,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.8/scalers/datadog.md
+++ b/content/docs/2.8/scalers/datadog.md
@@ -39,6 +39,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 

--- a/content/docs/2.9/scalers/datadog.md
+++ b/content/docs/2.9/scalers/datadog.md
@@ -45,6 +45,8 @@ triggers:
 - `metricUnavailableValue`: The value of the metric to return to the HPA if Datadog doesn't find a metric value for the specified time window. If not set, an error will be returned to the HPA, which will log a warning. (Optional, This value can be a float)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+>
+> 💡 **NOTE:** When using the Datadog REST API, Datadog can return HTTP 422 for empty time windows ("no data points found"). These are treated as "no data" and use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 


### PR DESCRIPTION
Clarify Datadog 422 "no data points found" behavior in the docs:
- Keep Cluster Agent section unchanged (still surfaces errors to HPA).
- Document REST API behavior that maps 422 no-data to metricUnavailableValue (or 0).
- Update both 2.18 and 2.19 versions.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes kedacore/keda#7246