### PR TITLE
mongodb: clarify `queryValue` documentation

### DIFF
--- a/content/docs/2.16/scalers/mongodb.md
+++ b/content/docs/2.16/scalers/mongodb.md
@@ -64,7 +64,7 @@ The `mongodb` trigger always requires the following information:
 - `dbName` - Name of the database.
 - `collection` - Name of the collection.
 - `query` - A MongoDB query that should return single numeric value.
-- `queryValue` - A threshold that will define when scaling should occur.
+- `queryValue` - The divisor to apply to the query result to obtain the final number of pods / jobs.
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 
 To connect to the MongoDB server, you can provide either:

--- a/content/docs/2.17/scalers/mongodb.md
+++ b/content/docs/2.17/scalers/mongodb.md
@@ -64,7 +64,7 @@ The `mongodb` trigger always requires the following information:
 - `dbName` - Name of the database.
 - `collection` - Name of the collection.
 - `query` - A MongoDB query that should return single numeric value.
-- `queryValue` - A threshold that will define when scaling should occur. This value can be a float.
+- `queryValue` - The divisor to apply to the query result to obtain the final number of pods / jobs. This value can be a float.
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional). This value can be a float.
 
 To connect to the MongoDB server, you can provide either:

--- a/content/docs/2.18/scalers/mongodb.md
+++ b/content/docs/2.18/scalers/mongodb.md
@@ -64,7 +64,7 @@ The `mongodb` trigger always requires the following information:
 - `dbName` - Name of the database.
 - `collection` - Name of the collection.
 - `query` - A MongoDB query that should return single numeric value.
-- `queryValue` - A threshold that will define when scaling should occur. This value can be a float.
+- `queryValue` - The divisor to apply to the query result to obtain the final number of pods / jobs. This value can be a float.
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional). This value can be a float.
 
 To connect to the MongoDB server, you can provide either:

--- a/content/docs/2.19/scalers/mongodb.md
+++ b/content/docs/2.19/scalers/mongodb.md
@@ -64,7 +64,7 @@ The `mongodb` trigger always requires the following information:
 - `dbName` - Name of the database.
 - `collection` - Name of the collection.
 - `query` - A MongoDB query that should return single numeric value.
-- `queryValue` - A threshold that will define when scaling should occur. This value can be a float.
+- `queryValue` - The divisor to apply to the query result to obtain the final number of pods / jobs. This value can be a float.
 - `activationQueryValue` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional). This value can be a float.
 
 To connect to the MongoDB server, you can provide either:


### PR DESCRIPTION
The current documentation for queryValue (for the mongoDB scaler) does not really hint that it should be used at the scaling divisor

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
