### PR TITLE
Fix ScaledJob spec documentation: change "job template" to "pod template"

### DIFF
--- a/content/docs/2.14/reference/scaledjob-spec.md
+++ b/content/docs/2.14/reference/scaledjob-spec.md
@@ -26,7 +26,7 @@ spec:
     activeDeadlineSeconds: 600                #  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
     backoffLimit: 6                           # Specifies the number of retries before marking this job failed. Defaults to 6
     template:
-      # describes the [job template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
+      # describes the job's [pod template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
   pollingInterval: 30                         # Optional. Default: 30 seconds
   successfulJobsHistoryLimit: 5               # Optional. Default: 100. How many completed jobs should be kept.
   failedJobsHistoryLimit: 5                   # Optional. Default: 100. How many failed jobs should be kept.

--- a/content/docs/2.15/reference/scaledjob-spec.md
+++ b/content/docs/2.15/reference/scaledjob-spec.md
@@ -24,7 +24,7 @@ spec:
     activeDeadlineSeconds: 600                #  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
     backoffLimit: 6                           # Specifies the number of retries before marking this job failed. Defaults to 6
     template:
-      # describes the [job template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
+      # describes the job's [pod template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
   pollingInterval: 30                         # Optional. Default: 30 seconds
   successfulJobsHistoryLimit: 5               # Optional. Default: 100. How many completed jobs should be kept.
   failedJobsHistoryLimit: 5                   # Optional. Default: 100. How many failed jobs should be kept.

--- a/content/docs/2.16/reference/scaledjob-spec.md
+++ b/content/docs/2.16/reference/scaledjob-spec.md
@@ -24,7 +24,7 @@ spec:
     activeDeadlineSeconds: 600                #  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
     backoffLimit: 6                           # Specifies the number of retries before marking this job failed. Defaults to 6
     template:
-      # describes the [job template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
+      # describes the job's [pod template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
   pollingInterval: 30                         # Optional. Default: 30 seconds
   successfulJobsHistoryLimit: 5               # Optional. Default: 100. How many completed jobs should be kept.
   failedJobsHistoryLimit: 5                   # Optional. Default: 100. How many failed jobs should be kept.

--- a/content/docs/2.17/reference/scaledjob-spec.md
+++ b/content/docs/2.17/reference/scaledjob-spec.md
@@ -24,7 +24,7 @@ spec:
     activeDeadlineSeconds: 600                #  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
     backoffLimit: 6                           # Specifies the number of retries before marking this job failed. Defaults to 6
     template:
-      # describes the [job template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
+      # describes the job's [pod template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
   pollingInterval: 30                         # Optional. Default: 30 seconds
   successfulJobsHistoryLimit: 5               # Optional. Default: 100. How many completed jobs should be kept.
   failedJobsHistoryLimit: 5                   # Optional. Default: 100. How many failed jobs should be kept.

--- a/content/docs/2.18/reference/scaledjob-spec.md
+++ b/content/docs/2.18/reference/scaledjob-spec.md
@@ -24,7 +24,7 @@ spec:
     activeDeadlineSeconds: 600                #  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
     backoffLimit: 6                           # Specifies the number of retries before marking this job failed. Defaults to 6
     template:
-      # describes the [job template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
+      # describes the job's [pod template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
   pollingInterval: 30                         # Optional. Default: 30 seconds
   successfulJobsHistoryLimit: 5               # Optional. Default: 100. How many completed jobs should be kept.
   failedJobsHistoryLimit: 5                   # Optional. Default: 100. How many failed jobs should be kept.

--- a/content/docs/2.19/reference/scaledjob-spec.md
+++ b/content/docs/2.19/reference/scaledjob-spec.md
@@ -24,7 +24,7 @@ spec:
     activeDeadlineSeconds: 600                #  Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer
     backoffLimit: 6                           # Specifies the number of retries before marking this job failed. Defaults to 6
     template:
-      # describes the [job template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
+      # describes the job's [pod template](https://kubernetes.io/docs/concepts/workloads/controllers/job)
   pollingInterval: 30                         # Optional. Default: 30 seconds
   successfulJobsHistoryLimit: 5               # Optional. Default: 100. How many completed jobs should be kept.
   failedJobsHistoryLimit: 5                   # Optional. Default: 100. How many failed jobs should be kept.


### PR DESCRIPTION
## Description
This PR fixes the documentation inaccuracy in the ScaledJob specification where `spec.jobTargetRef.template` was incorrectly referred to as a "job template" when it's actually a "pod template" (PodTemplateSpec in Kubernetes terminology).

## Changes
- Updated documentation across versions 2.14-2.19
- Changed comment from: `# describes the [job template](...)`
- To: `# describes the job's [pod template](...)`

## Related Issue
Fixes #7258

## Checklist
- [x] Documentation updated
- [x] Changes are backward compatible
- [x] Commit follows DCO requirements