### PR TITLE
use metricUnavailableValue for 422 errors in Datadog Scaler

### DIFF
--- a/content/docs/2.19/scalers/datadog.md
+++ b/content/docs/2.19/scalers/datadog.md
@@ -99,6 +99,7 @@ triggers:
 - `timeout` - Timeout (in a Duration string format) **for this specific trigger**. This value will override the value defined in `KEDA_HTTP_DEFAULT_TIMEOUT`. (Optional)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+> 💡 **NOTE:** Datadog may return HTTP 422 (Unprocessable Entity) or empty metric series. Both scenarios are treated as "no data" and will use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 
@@ -216,6 +217,7 @@ triggers:
 - `timeout` - Timeout (in a Duration string format) **for this specific trigger**. This value will override the value defined in `KEDA_HTTP_DEFAULT_TIMEOUT`. (Optional)
 
 > 💡 **NOTE:** The `type` parameter is deprecated in favor of the global `metricType` and will be removed in a future release. Users are advised to use `metricType` instead.
+> 💡 **NOTE:** Datadog may return HTTP 422 (Unprocessable Entity) or empty metric series. Both scenarios are treated as "no data" and will use `metricUnavailableValue` if set, otherwise an error is returned to the HPA.
 
 ### Authentication
 


### PR DESCRIPTION
Docs for PR https://github.com/kedacore/keda/pull/7384

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)