### PR TITLE
add keda_scaler_http_requests_total and keda_scaler_http_request_duration_seconds metrics

### DIFF
--- a/content/docs/2.20/integrations/opentelemetry.md
+++ b/content/docs/2.20/integrations/opentelemetry.md
@@ -47,6 +47,8 @@ The following metrics are being gathered:
 | `keda.internal.scale.loop.latency.seconds` | Total deviation between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. |
 | `keda.cloudeventsource.events.emitted.count` | Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state. |
 | `keda.cloudeventsource.events.queued` | The number of events that are in the emitting queue. |
+| `keda.scaler.http.requests.count` | Total number of outbound HTTP requests issued during scaler metric fetches. |
+| `keda.scaler.http.request.duration.seconds` | Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric fetches. |
 
 #### Deprecated metrics
 

--- a/content/docs/2.20/integrations/opentelemetry.md
+++ b/content/docs/2.20/integrations/opentelemetry.md
@@ -47,8 +47,8 @@ The following metrics are being gathered:
 | `keda.internal.scale.loop.latency.seconds` | Total deviation between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. |
 | `keda.cloudeventsource.events.emitted.count` | Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state. |
 | `keda.cloudeventsource.events.queued` | The number of events that are in the emitting queue. |
-| `keda.scaler.http.requests.count` | Total number of outbound HTTP requests issued during scaler metric fetches. |
-| `keda.scaler.http.request.duration.seconds` | Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric fetches. |
+| `keda.scaler.http.requests.count` | Total number of outbound HTTP requests issued during scaler metric collection. |
+| `keda.scaler.http.request.duration.seconds` | Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric collection. |
 
 #### Deprecated metrics
 

--- a/content/docs/2.20/integrations/prometheus.md
+++ b/content/docs/2.20/integrations/prometheus.md
@@ -24,6 +24,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_internal_scale_loop_latency_seconds` - Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
 - `keda_cloudeventsource_events_emitted_total` - Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state.
 - `keda_cloudeventsource_events_queued` - The number of events that are in the emitting queue.
+- `keda_scaler_http_requests_total` - Total number of outbound HTTP requests issued during scaler metric fetches.
+- `keda_scaler_http_request_duration_seconds` - Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric fetches.
 - `keda_internal_metricsservice_grpc_server_started_total` - Total number of RPCs started on the server.
 - `keda_internal_metricsservice_grpc_server_handled_total` - Total number of RPCs completed on the server, regardless of success or failure.
 - `keda_internal_metricsservice_grpc_server_msg_received_total` - Total number of RPC stream messages received on the server.

--- a/content/docs/2.20/integrations/prometheus.md
+++ b/content/docs/2.20/integrations/prometheus.md
@@ -24,8 +24,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_internal_scale_loop_latency_seconds` - Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric.
 - `keda_cloudeventsource_events_emitted_total` - Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state.
 - `keda_cloudeventsource_events_queued` - The number of events that are in the emitting queue.
-- `keda_scaler_http_requests_total` - Total number of outbound HTTP requests issued during scaler metric fetches.
-- `keda_scaler_http_request_duration_seconds` - Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric fetches.
+- `keda_scaler_http_requests_total` - Total number of outbound HTTP requests issued during scaler metric collection.
+- `keda_scaler_http_request_duration_seconds` - Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric collection.
 - `keda_internal_metricsservice_grpc_server_started_total` - Total number of RPCs started on the server.
 - `keda_internal_metricsservice_grpc_server_handled_total` - Total number of RPCs completed on the server, regardless of success or failure.
 - `keda_internal_metricsservice_grpc_server_msg_received_total` - Total number of RPC stream messages received on the server.


### PR DESCRIPTION
Add documentation entries for the two new scaler HTTP metrics introduced in kedacore/keda#7644:

- `keda_scaler_http_requests_total` / `keda.scaler.http.requests.count`
- `keda_scaler_http_request_duration_seconds` / `keda.scaler.http.request.duration.seconds`

### Checklist

- [x] Docs have been added/updated for new/changed functionality