### PR TITLE
feat: add HTTP Add-on docs

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -6,6 +6,9 @@ CheckExternal: false
 IgnoreAltMissing: true
 IgnoreEmptyHref: true
 IgnoreURLs:
+  # /latest/ URLs are redirect-only paths handled by Netlify; no static page exists for them
+  - /docs/latest/
+  - /http-add-on/latest/
   # Temporal ignores
   # Deprecated and removed resources
   # Renamed pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,12 @@ Thanks for helping make KEDA better 😍.
 
 There are many areas we can use contributions - documenting scalers, adding FAQ, troubleshooting, samples, and more.
 
-Our documentation is versioned so it's important to make the changes for the correct KEDA version. If you need to introduce a new version, we recommend reading our documentation about it [here](https://github.com/kedacore/keda-docs#working-with-documentation-versions).
-
-## Getting Help
-
-If you have a question about KEDA or how best to contribute, the [#KEDA](https://kubernetes.slack.com/archives/CKZJ36A5D) channel on the Kubernetes slack channel ([get an invite if you don't have one already](https://slack.k8s.io/)) is a good place to start. We also have regular [community stand-ups](https://github.com/kedacore/keda#community) to track ongoing work and discuss areas of contribution. For any issues with the product you can [create an issue](https://github.com/kedacore/keda/issues/new) in this repo.
-
-## Contributing New Documentation
-
-We provide easy ways to introduce new content:
+Our documentation is versioned so it's important to make the changes for the correct KEDA version.
+If you need to introduce a new version, we recommend reading our documentation about it [here](#working-with-documentation-versions).
 
 - [Contributing to KEDA](#contributing-to-keda)
   - [Getting Help](#getting-help)
+  - [Local development](#local-development)
   - [Contributing New Documentation](#contributing-new-documentation)
     - [Adding blog post](#adding-blog-post)
     - [Adding scaler documentation](#adding-scaler-documentation)
@@ -28,24 +22,51 @@ We provide easy ways to introduce new content:
     - [Publishing a new version](#publishing-a-new-version)
   - [Developer Certificate of Origin: Signing your work](#developer-certificate-of-origin-signing-your-work)
     - [Every commit needs to be signed](#every-commit-needs-to-be-signed)
-    - [I didn't sign my commit, now what?!](#i-didnt-sign-my-commit-now-what)
+    - [I didn't sign my commit, now what?](#i-didnt-sign-my-commit-now-what)
   - [Changing the website](#changing-the-website)
-    - [Creating and building a local environment](#creating-and-building-a-local-environment)
     - [Adding a new filter option](#adding-a-new-filter-option)
   - [Listing KEDA Users and Commercial Offerings](#listing-keda-users-and-commercial-offerings)
     - [Become a listed KEDA user](#become-a-listed-keda-user)
     - [Become a listed KEDA commercial offering](#become-a-listed-keda-commercial-offering)
 
+## Getting Help
 
-Learn more how to [create and build a local environment](#creating-and-building-a-local-environment).
+If you have a question about KEDA or how best to contribute, the [#KEDA](https://kubernetes.slack.com/archives/CKZJ36A5D) channel on the Kubernetes Slack ([get an invite if you don't have one already](https://slack.k8s.io/)) is a good place to start.
+We also have regular [community stand-ups](https://github.com/kedacore/keda#community) to track ongoing work and discuss areas of contribution.
+For any issues with the product you can [create an issue](https://github.com/kedacore/keda/issues/new) in this repo.
 
+## Local development
+
+1. Fork and clone this repository.
+2. Install [Node](https://nodejs.org/).
+   Hugo is bundled via the `hugo-extended` npm package — no separate Hugo install needed.
+3. Install dependencies:
+   ```console
+   npm install
+   ```
+4. Serve the site locally at [localhost:8888](http://localhost:8888):
+   ```console
+   npm run serve
+   ```
+5. To do a one-off build (output goes to `public/`):
+   ```console
+   npm run build
+   ```
+6. To check for broken links (runs a build first):
+   ```console
+   npm run check:links
+   ```
+
+## Contributing New Documentation
+
+We provide easy ways to introduce new content:
 
 ### Adding blog post
 
 To add a new post to the [KEDA blog](https://keda.sh/blog):
 
 ```console
-$ hugo new blog/my-new-post.md
+npx hugo new blog/my-new-post.md
 ```
 
 This creates a boilerplate Markdown file in `content/blog/my-new-post.md` whose
@@ -62,7 +83,7 @@ contents you can modify. The following fields are required:
 To add documentation for a new KEDA [scaler](https://keda.sh/docs/scalers):
 
 ```console
-$ hugo new --kind scaler docs/<VERSION>/scalers/my-new-scaler.md
+npx hugo new --kind scaler docs/<VERSION>/scalers/my-new-scaler.md
 ```
 
 This creates a boilerplate Markdown file in
@@ -96,7 +117,7 @@ Here are a few examples:
 To add documentation for a new [provider](https://keda.sh/docs/concepts/authentication):
 
 ```console
-$ hugo new --kind provider docs/<VERSION>/providers/my-new-provider.md
+npx hugo new --kind provider docs/<VERSION>/providers/my-new-provider.md
 ```
 
 This creates a boilerplate Markdown file in
@@ -122,7 +143,7 @@ a = "You're looking at it! 😀"
 To add a new section to the [troubleshooting page](https://keda.sh/docs/troubleshooting):
 
 ```console
-$ hugo new troubleshooting/<VERSION>/my-new-issue.md
+npx hugo new troubleshooting/<VERSION>/my-new-issue.md
 ```
 
 To adjust the order in which the troubleshooting tiles appear, use the `weight`
@@ -133,25 +154,18 @@ parameter in each page's metadata.
 The KEDA documentation is versioned. Each version has its own subdirectory under
 [content/docs](content/docs). To add a new version, follow these steps:
 
-1. Copy the directory for the most recent version. Here's an example:
-
-```console
-$ cp -rf content/docs/<CurrentVersion> content/docs/<NewVersion>
-```
-
-2. Copy the file for the most recent faq data in the `data` directory. Here's an example:
-
-```console
-$ cp -rf data/faq<CurrentVersion> data/faq<NewVersion>
-```
-
-3. Update the `versionData` option in `content/docs/<NewVersion>/reference/faq.md`:
-
-```
-{{< faq20 versionData="NEW_FAQ_FILE_NAME" >}}
-```
-
-Replace `NEW_FAQ_FILE_NAME` with the file name of the faq data for the new version.
+1. Copy the directory for the most recent version:
+   ```console
+   cp -rf content/docs/<CurrentVersion> content/docs/<NewVersion>
+   ```
+2. Copy the file for the most recent faq data in the `data` directory:
+   ```console
+   cp -rf data/faq<CurrentVersion> data/faq<NewVersion>
+   ```
+3. Update the `versionData` option in `content/docs/<NewVersion>/reference/faq.md`, replacing `NEW_FAQ_FILE_NAME` with the file name of the faq data for the new version:
+   ```text
+   {{< faq20 versionData="NEW_FAQ_FILE_NAME" >}}
+   ```
 
 By default, new documentation versions are not listed as available version so
 it's safe to make changes to them. After every release, the version will be
@@ -185,7 +199,7 @@ because the first element in that list is considered the latest version).
 
 The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:
 
-```
+```text
 By making a contribution to this project, I certify that:
 
     (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
@@ -199,7 +213,7 @@ By making a contribution to this project, I certify that:
 
 Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
 
-```
+```text
 This is my commit message
 
 Signed-off-by: Random J Developer <random@developer.example.org>
@@ -207,17 +221,17 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 
 Git even has a `-s` command line option to append this automatically to your commit message:
 
-```
-$ git commit -s -m 'This is my commit message'
+```console
+git commit -s -m 'This is my commit message'
 ```
 
 Each Pull Request is checked whether or not commits in a Pull Request do contain a valid Signed-off-by line.
 
-### I didn't sign my commit, now what?!
+### I didn't sign my commit, now what?
 
 No worries - You can easily replay your changes, sign them and force push them!
 
-```
+```console
 git checkout <branch-name>
 git reset $(git merge-base main <branch-name>)
 git add -A
@@ -227,104 +241,66 @@ git push --force
 
 ## Changing the website
 
-### Creating and building a local environment
-
-To build or serve the site locally, follow these steps:
-
-- Fork and clone this repository (for local development only).
-- Install the latest [LTS release](https://nodejs.org/en/about/releases/) of **Node**.
-- Get npm packages and other prerequisites:
-  ```console
-  $ npm install
-  ```
-- To build the site, run:
-  ```console
-  $ npm run build
-  ```
-  You'll find the generated site files under `public`.
-- Serve the site locally at [localhost:8888](http://localhost:8888) using:
-  ```console
-  $ npm run serve
-  ```
-
 ### Adding a new filter option
 
 To add a new filter option, simply follow these steps:
 
 1. Navigate to the doc file you want to annotate.
-2. In the frontmatter, add your new filter option.
-
-```
-+++
-FILTER_NAME = "filter_value"
-+++
-```
-
-Replace FILTER_NAME with any desired name of your choice. Same applies to the value.
-
-3. Navigate to the `list.lunr.json` file to edit: `cd layouts/_default/list.lunr.json`.
-4. Open the file and go down to line 3. You will notice the format of the data represented in a key/value pair. Just before the closing parenthesis, append your new option like this: `"FILTER_NAME" $scalers.Params.FILTER_NAME`.
-
-Replace FILTER_NAME with the same name represented in the frontmatter (see step 2 above for reference).
-
-5. Head over to `config.toml` file. In the `params.lunr` section, you will see two arrays named `vars` and `params`. Add your new filter option's name to each of the arrays:
-
-```toml
-vars = ["title", "maintainer", "description", "availability", "category", "type", "FILTER_NAME"]
-params = ["availability", "maintainer", "category", "type", "FILTER_NAME"]
-```
-
-6. In `assets/js/scaler-search.js`, find the `lunr()` callback where `this.field` is called. Append your field:
-
-```javascript
-this.field("FILTER_NAME", {
-  boost: 5,
-});
-```
-
-Replace FILTER_NAME with the same name represented in the frontmatter (see step 2 above for reference).
-
-In the same file, find where `parse[doc.title]` is built and add your field:
-
-```javascript
-parse[doc.title] = {
-  href: doc.href,
-  title: doc.title,
-  maintainer: doc.maintainer,
-  description: doc.description,
-  availability: doc.availability,
-  category: doc.category,
-  type: doc.type,
-  FILTER_NAME: doc.FILTER_NAME,
-};
-```
-
-7. Navigate to `layouts/partials/scaler-layout.html`. Locate the div with a class name of `filter-options`. Within the div, add this new block:
-
-```html
-<div class="has-extra-top-margin">
-  <h6>FILTER_NAME</h6>
-  {{ $FILTER_NAME := slice }} {{ range $scalers := where site.RegularPages
-  ".CurrentSection.Title" "Scalers" }} {{ with $scalers.Params.FILTER_NAME }} {{
-  $FILTER_NAME = $categories | append ($scalers.Params.FILTER_NAME) }} {{
-  $FILTER_NAME = uniq $FILTER_NAME }} {{ end }} {{ end }} {{ range $FILTER_NAME
-  }} {{ $item := . }}
-  <div>
-    <input
-      id="{{ . }}"
-      type="checkbox"
-      name="resource_filter"
-      value="FILTER_NAME:{{ . }}"
-    />
-    <label for="{{ . }}">{{ . }}</label>
-  </div>
-  {{ end }}
-</div>
-```
-
-Replace FILTER_NAME with the same name represented in the frontmatter (see step 2 above for reference).
-
-8. Save your changes and rebuild your frontend.
+2. In the frontmatter, add your new filter option:
+   ```toml
+   FILTER_NAME = "filter_value"
+   ```
+   Replace `FILTER_NAME` with any desired name of your choice. Same applies to the value.
+3. In `layouts/_default/list.lunr.json`, just before the closing parenthesis, append your new option:
+   ```text
+   "FILTER_NAME" $scalers.Params.FILTER_NAME
+   ```
+4. In `config.toml`, in the `params.lunr` section, add your new filter option's name to both arrays:
+   ```toml
+   vars = ["title", "maintainer", "description", "availability", "category", "type", "FILTER_NAME"]
+   params = ["availability", "maintainer", "category", "type", "FILTER_NAME"]
+   ```
+5. In `assets/js/scaler-search.js`, in the `lunr()` callback where `this.field` is called, append your field:
+   ```javascript
+   this.field("FILTER_NAME", {
+     boost: 5,
+   });
+   ```
+   And where `parse[doc.title]` is built, add your field:
+   ```javascript
+   parse[doc.title] = {
+     href: doc.href,
+     title: doc.title,
+     maintainer: doc.maintainer,
+     description: doc.description,
+     availability: doc.availability,
+     category: doc.category,
+     type: doc.type,
+     FILTER_NAME: doc.FILTER_NAME,
+   };
+   ```
+6. In `layouts/partials/scaler-layout.html`, locate the div with class `filter-options` and add this new block:
+   ```html
+   <div class="has-extra-top-margin">
+     <h6>FILTER_NAME</h6>
+     {{ $FILTER_NAME := slice }} {{ range $scalers := where site.RegularPages
+     ".CurrentSection.Title" "Scalers" }} {{ with $scalers.Params.FILTER_NAME }} {{
+     $FILTER_NAME = $categories | append ($scalers.Params.FILTER_NAME) }} {{
+     $FILTER_NAME = uniq $FILTER_NAME }} {{ end }} {{ end }} {{ range $FILTER_NAME
+     }} {{ $item := . }}
+     <div>
+       <input
+         id="{{ . }}"
+         type="checkbox"
+         name="resource_filter"
+         value="FILTER_NAME:{{ . }}"
+       />
+       <label for="{{ . }}">{{ . }}</label>
+     </div>
+     {{ end }}
+   </div>
+   ```
+7. Save your changes and rebuild your frontend.
 
 ## Listing KEDA Users and Commercial Offerings
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ HTMLTEST_ARGS?=--skip-external
 
 DOCS=public/docs
 LATEST_VERSION=$(shell grep -e '^docs' config.toml | grep -oe '[0-9][0-9]*.[0-9][0-9]' | head -1)
+HTTP_ADDON_LATEST_VERSION=$(shell grep -e '^http-add-on' config.toml | grep -oe '[0-9][0-9]*.[0-9][0-9]' | head -1)
 
 # Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
 ifeq (, $(shell which $(HTMLTEST)))
@@ -22,9 +23,14 @@ make-redirects-for-checking:
 		echo "Failed to extract LATEST_VERSION. Cannot setup symlinks for checking"; \
 		exit 1; \
 	fi
+	@if [ -z $(HTTP_ADDON_LATEST_VERSION) ]; then \
+		echo "Failed to extract HTTP_ADDON_LATEST_VERSION. Cannot setup symlinks for checking"; \
+		exit 1; \
+	fi
 	@echo "Creating symlinks of 'latest' to $(LATEST_VERSION) for the purpose of link checking"
 	(cd public && rm -f scalers && ln -s docs/$(LATEST_VERSION)/scalers scalers)
 	(cd public/docs && rm -f latest && ln -s $(LATEST_VERSION) latest)
+	(cd public/http-add-on && rm -f latest && ln -s $(HTTP_ADDON_LATEST_VERSION) latest)
 
 get-link-checker:
 	rm -Rf $(HTMLTEST_DIR)/bin

--- a/config.toml
+++ b/config.toml
@@ -57,9 +57,11 @@ docs = [
   "1.5",
   "1.4",
 ]
+http-add-on = ["0.14"]
 
 [params.unreleased]
 docs = ["2.20"]
+http-add-on = []
 
 # Site fonts served from @fontsource npm packages (see module mounts).
 # Browse available options at https://fonts.google.com.
@@ -183,10 +185,16 @@ pre = "fas fa-lock"
 weight = 5
 
 [[menu.buttons]]
+url = "/http-add-on/"
+name = "HTTP Add-on"
+pre = "fas fa-globe"
+weight = 6
+
+[[menu.buttons]]
 url = "/blog"
 name = "Blog"
 pre = "fas fa-rss"
-weight = 6
+weight = 7
 
 # Navbar and footer menu
 [[menu.docs]]
@@ -291,6 +299,14 @@ url = "/docs/troubleshooting/"
 name = "Troubleshooting Guide"
 parent = "docs"
 weight = 10
+
+[[menu.docs]]
+url = "/http-add-on/"
+name = "HTTP Add-on"
+parent = "docs"
+weight = 11
+[menu.docs.params]
+prependDivider = true
 
 [[menu.main]]
 url = "/blog"

--- a/content/docs/2.19/addons/_index.md
+++ b/content/docs/2.19/addons/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Add-ons"
+weight = 3
++++
+
+Add-ons extend KEDA with support for specific use cases beyond the built-in scalers.
+
+## HTTP Add-on
+
+The [HTTP Add-on](/http-add-on/latest/) enables autoscaling of HTTP-based workloads.
+It intercepts incoming HTTP requests and scales the target workload based on request volume.

--- a/content/docs/2.20/addons/_index.md
+++ b/content/docs/2.20/addons/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Add-ons"
+weight = 3
++++
+
+Add-ons extend KEDA with support for specific use cases beyond the built-in scalers.
+
+## HTTP Add-on
+
+The [HTTP Add-on](/http-add-on/latest/) enables autoscaling of HTTP-based workloads.
+It intercepts incoming HTTP requests and scales the target workload based on request volume.

--- a/content/http-add-on/0.14/_index.md
+++ b/content/http-add-on/0.14/_index.md
@@ -1,0 +1,47 @@
++++
+title = "KEDA HTTP Add-on"
+description = "HTTP-based autoscaling for Kubernetes workloads, including scale-to-zero"
+weight = 1
++++
+
+The KEDA HTTP Add-on enables automatic scaling of HTTP workloads on Kubernetes based on incoming traffic, including scaling to and from zero replicas.
+It extends [KEDA](https://keda.sh) with the infrastructure needed to intercept HTTP requests, count them, and report metrics that drive scaling decisions.
+
+## How It Works
+
+The HTTP Add-on deploys three components into your cluster:
+
+- An **interceptor** that sits in front of your application as a reverse proxy, routing requests and tracking concurrency.
+- A **scaler** that aggregates request metrics from the interceptor and reports them to KEDA.
+- An **operator** that manages the lifecycle of scaling resources.
+
+You create an `InterceptorRoute` to define how traffic reaches your service and a KEDA `ScaledObject` to control scaling behavior.
+The interceptor handles requests while KEDA scales your workload up and down based on demand.
+
+## Get Started
+
+If you are new to the HTTP Add-on, follow the [Getting Started guide](getting-started/) to deploy and scale your first HTTP application.
+
+## Upgrading from a Previous Version
+
+v0.14.0 introduces the `InterceptorRoute` (v1beta1) API, which replaces `HTTPScaledObject` (v1alpha1).
+If you have existing `HTTPScaledObject` resources, see [Migrate from HTTPScaledObject to InterceptorRoute](operations/migrate-httpscaledobject-to-interceptorroute/).
+
+## Documentation Sections
+
+- **[Getting Started](getting-started/)** — Tutorial: install the add-on and scale your first app end-to-end.
+- **[Concepts](concepts/)** — Understand the architecture, scaling mechanics, and routing model.
+- **[User Guide](user-guide/)** — Configure autoscaling, routing, and timeouts for your HTTP applications.
+- **[Operations](operations/)** — Install, configure, and manage the HTTP Add-on infrastructure.
+- **[Reference](reference/)** — API specifications, Helm chart values, environment variables, and metrics.
+
+## Getting Help
+
+- [Kubernetes Slack](https://kubernetes.slack.com/archives/CKZJ36A5D) — `#keda` channel ([join here](https://slack.k8s.io))
+- [GitHub Issues](https://github.com/kedacore/http-add-on/issues) — Bug reports and feature requests
+- [GitHub Discussions](https://github.com/kedacore/http-add-on/discussions) — Questions and general conversation
+
+## Contributing
+
+Contributions to the HTTP Add-on are welcome.
+See the [contributing guide](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md) in the source repository for development setup, commit conventions, and PR guidelines.

--- a/content/http-add-on/0.14/concepts/_index.md
+++ b/content/http-add-on/0.14/concepts/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Concepts"
+description = "Architecture, scaling mechanics, and routing model of the HTTP Add-on"
+weight = 200
++++
+
+Learn how the HTTP Add-on works before configuring it.
+
+- **[Architecture](architecture/)** — The three components, how they interact, and the request flow.
+- **[Routing](routing/)** — Host, path, and header matching with priority rules.
+- **[Scaling](scaling/)** — Scaling metrics, scale-to-zero, and cold-start behavior.

--- a/content/http-add-on/0.14/concepts/architecture.md
+++ b/content/http-add-on/0.14/concepts/architecture.md
@@ -1,0 +1,98 @@
++++
+title = "Architecture"
+description = "The three components of the HTTP Add-on, their responsibilities, and how they interact to scale HTTP workloads"
++++
+
+## The Problem: HTTP Has No Queue
+
+Event-driven scalers such as those for Kafka or RabbitMQ can read the number of pending messages directly from a broker.
+HTTP has no equivalent concept: a request arrives, gets processed, and is gone.
+There is nothing for an autoscaler to query.
+
+The HTTP Add-on solves this by placing dedicated infrastructure in the request path.
+An interceptor proxy sits in front of your application, counts requests as they flow through, and holds requests during cold starts while backends scale up.
+A scaler component aggregates those counts into metrics that [KEDA](https://keda.sh/docs/) can use to drive the Horizontal Pod Autoscaler (HPA).
+
+## KEDA Core Concepts
+
+Before diving into the HTTP Add-on components, a few KEDA primitives are relevant:
+
+- **ScaledObject** — A KEDA custom resource that binds a workload (Deployment, StatefulSet, etc.) to one or more scaling triggers. KEDA watches ScaledObjects and configures the Kubernetes HPA accordingly. See the [KEDA ScaledObject documentation](https://keda.sh/docs/latest/concepts/scaling-deployments/).
+- **External scaler** — A gRPC service that KEDA calls to fetch custom metrics. The HTTP Add-on's scaler component implements this interface. See the [KEDA external scalers documentation](https://keda.sh/docs/latest/concepts/external-scalers/).
+- **HPA** — The Kubernetes Horizontal Pod Autoscaler. KEDA creates and manages an HPA for each ScaledObject. The HPA adjusts replica counts based on the metrics KEDA feeds it.
+
+## Component Overview
+
+The HTTP Add-on consists of three components deployed into the cluster:
+
+### Interceptor
+
+The interceptor is a reverse proxy that sits in the request path between the ingress layer and the backend service.
+It performs three functions:
+
+1. **Routing** — Matches incoming requests to backend services based on hostname, path prefix, and headers. See [Routing](../routing/) for the matching model.
+2. **Counting** — Tracks the number of concurrent (in-flight) requests and total request counts per route. These counters are the raw data the scaler uses to compute scaling metrics.
+3. **Buffering** — During cold starts (when a backend has zero replicas), the interceptor holds the request open while waiting for the backend to become ready. Once at least one pod is available, the request is forwarded. If the backend does not become ready within the readiness timeout, the interceptor returns an error or routes to a fallback service if configured.
+
+The interceptor forwards requests to the backend's Kubernetes Service, relying on standard Kubernetes service load balancing for distribution across pods.
+
+The interceptor deployment is itself auto-scaled by KEDA via a ScaledObject created by the Helm chart.
+
+### Scaler
+
+The scaler is the bridge between the interceptor's in-memory counters and KEDA's scaling decisions.
+It implements the KEDA external scaler interface.
+
+The scaler periodically polls all interceptor pods to fetch per-route request counts.
+It aggregates concurrency across pods for each route and computes request rate from the total request counters.
+When KEDA queries the scaler, it returns these aggregated metrics so KEDA can adjust replica counts.
+
+See [Scaling](../scaling/) for details on how these metrics drive scaling decisions.
+
+### Operator
+
+The operator is a Kubernetes controller manager that reconciles HTTP Add-on custom resources:
+
+- **InterceptorRoute** (`http.keda.sh/v1beta1`) — Defines routing rules, scaling metrics, target service, and timeout/cold-start configuration in a single resource. Users pair it with a KEDA ScaledObject they create and manage.
+- **HTTPScaledObject** (`http.keda.sh/v1alpha1`, deprecated) — Combines routing, scaling, and ScaledObject management in one resource. The operator automatically creates the corresponding ScaledObject.
+
+See the [InterceptorRoute reference](../../reference/interceptorroute/) for the full API specification.
+
+## Request Flow
+
+```
++---------+     +-------------+     +---------+
+| Ingress +---->| Interceptor +---->| Backend |
++---------+     +------+------+     +---------+
+                       |
+                  poll metrics
+                       |
+                +------+------+
+                |   Scaler    |
+                +------+------+
+                       |
+                  report metrics
+                       |
+                +------+------+
+                |  KEDA Core  |
+                +------+------+
+                       |
+                  adjust replicas
+                       |
+                +------+------+
+                |     HPA     |
+                +-------------+
+```
+
+1. External traffic enters the cluster through an ingress controller (or Gateway API) and is routed to the interceptor service.
+2. The interceptor matches the request to a route, counts it, and forwards the request to the backend. If the backend has zero replicas, the interceptor holds the request until a pod becomes ready.
+3. When the backend responds, the interceptor returns the response to the client.
+4. The scaler polls the interceptor to aggregate request counts and compute rate metrics.
+5. KEDA queries the scaler for current metrics and determines the desired replica count.
+6. KEDA configures the HPA, which adjusts the backend's replica count.
+
+## What's Next
+
+- [Scaling](../scaling/) — How scaling decisions are made, including scale-to-zero and cold starts.
+- [Routing](../routing/) — How requests are matched to InterceptorRoutes.
+- [Install the HTTP Add-on](../../operations/installation/) — Install the HTTP Add-on via Helm.

--- a/content/http-add-on/0.14/concepts/routing.md
+++ b/content/http-add-on/0.14/concepts/routing.md
@@ -1,0 +1,101 @@
++++
+title = "Routing"
+description = "Interceptor request matching using hostname, path, and header rules"
++++
+
+The interceptor maintains an in-memory routing table that maps incoming HTTP requests to InterceptorRoute resources.
+Each InterceptorRoute defines one or more routing rules, and each rule can match on three dimensions: hostname, path prefix, and headers.
+
+## Routing Rules
+
+An InterceptorRoute contains a list of routing rules in `spec.rules`.
+Each rule specifies hosts, paths, and headers to match.
+A request that matches any rule in the InterceptorRoute is forwarded to that InterceptorRoute's target service.
+
+When a rule omits hosts, it matches any hostname (catch-all).
+When it omits paths, it matches the root path `/`.
+When it omits headers, no header matching is performed.
+
+## Matching Dimensions
+
+### Hostname Matching
+
+The interceptor matches the `Host` header of the request against the hostnames declared in routing rules.
+Three kinds of hostname values are supported:
+
+- **Exact hostnames** (`api.example.com`)
+  - Match the request hostname exactly.
+  - Exact matches take priority over all wildcard forms.
+- **Wildcard hostnames** (`*.example.com`)
+  - The `*` replaces the first DNS label.
+  - A wildcard matches any hostname that ends with the remaining labels: `*.example.com` matches `foo.example.com` and `foo.bar.example.com` (multi-level).
+  - More specific wildcards take priority: `*.bar.example.com` wins over `*.example.com` for a request to `api.bar.example.com`.
+- **Catch-all** (`*` or omitted)
+  - Matches any hostname.
+  - This is the lowest priority.
+
+The interceptor evaluates hostnames in priority order: exact match first, then wildcards from most specific to least specific, then catch-all.
+
+### Path Matching
+
+The interceptor uses longest-prefix matching on the request path.
+All paths are normalized by trimming leading and trailing slashes.
+
+When multiple routes match on hostname, the route with the longest matching path prefix wins.
+For example, a request to `/api/v1/users` matches a rule with path `/api/v1` over a rule with path `/api`.
+
+The routing table uses a radix tree internally, which makes longest-prefix lookups efficient regardless of the number of routes.
+
+### Header Matching
+
+Header matching adds a further dimension of specificity.
+A routing rule can declare one or more headers that the request must carry:
+
+- **Exact value match** — The rule specifies both a header name and a value (e.g., `name: X-Route, value: canary`). The request must contain the header with that exact value.
+- **Presence-only match** — The rule specifies a header name without a value (e.g., `name: X-Route`). The request must contain the header, but any value is accepted.
+
+All headers in a single rule must match for the rule to apply (AND semantics).
+If a rule declares no headers, it matches regardless of what headers the request carries.
+
+## Priority Order
+
+When multiple InterceptorRoutes match a request, the interceptor selects the most specific one using the following tiebreaking order:
+
+1. **Most specific hostname** — Exact hostname wins over wildcard, which wins over catch-all. Among wildcards, more specific patterns (more labels) take priority.
+2. **Longest path prefix** — A longer matching prefix wins.
+3. **Most specific headers** — Routes with more header matchers take priority. Among routes with the same number of headers, routes with more exact-value matches (as opposed to presence-only matches) take priority.
+4. **Oldest creation timestamp** — The InterceptorRoute created first wins.
+5. **Lexicographic namespace/name** — Final tiebreaker using the resource's namespace and name in descending lexicographic order.
+
+### Example
+
+Consider three InterceptorRoutes:
+
+| Route | Host              | Path      | Headers        |
+| ----- | ----------------- | --------- | -------------- |
+| A     | `api.example.com` | `/api`    | (none)         |
+| B     | `*.example.com`   | `/api/v1` | `X-Version: 2` |
+| C     | `api.example.com` | `/api/v1` | (none)         |
+
+A request to `api.example.com` with path `/api/v1/users` and header `X-Version: 2`:
+
+- Route A matches (exact host, path `/api` is a prefix).
+- Route B matches (wildcard host, path `/api/v1` is a prefix, header matches).
+- Route C matches (exact host, path `/api/v1` is a prefix).
+
+Applying the priority rules: Routes A and C have an exact hostname, which beats B's wildcard.
+Between A and C, C has the longer path prefix (`/api/v1` vs `/api`).
+**Route C wins.**
+
+## Multiple Rules per InterceptorRoute
+
+A single InterceptorRoute can contain multiple routing rules.
+Each rule independently specifies its own hosts, paths, and headers.
+A request that matches any one of these rules is routed to the InterceptorRoute's target service.
+
+This allows a single InterceptorRoute to serve traffic for multiple hostnames or path patterns without requiring separate resources for each.
+
+## What's Next
+
+- [Configure Routing Rules](../../user-guide/configure-routing/) — YAML examples for host, path, and header matching.
+- [InterceptorRoute Reference](../../reference/interceptorroute/) — Complete field definitions for routing rules.

--- a/content/http-add-on/0.14/concepts/scaling.md
+++ b/content/http-add-on/0.14/concepts/scaling.md
@@ -1,0 +1,77 @@
++++
+title = "Scaling"
+description = "HTTP Add-on scaling decisions, including metrics, scale-to-zero, and cold-start behavior"
++++
+
+The HTTP Add-on provides two scaling metrics: concurrency and request rate.
+KEDA uses these metrics to adjust the replica count of backend workloads through the Horizontal Pod Autoscaler (HPA).
+
+## Scaling Metrics
+
+### Concurrency
+
+Concurrency measures the number of in-flight requests at any instant for a given route.
+The interceptor increments a counter when a request arrives and decrements it when the response completes.
+
+### Request Rate
+
+Request rate measures the number of requests per second, averaged over a sliding time window.
+The windowed averaging smooths out short bursts and provides a stable signal for scaling.
+
+The default configuration is:
+
+- **Window**: 1 minute
+- **Granularity**: 1 second
+
+### Using Both Metrics
+
+When an InterceptorRoute specifies both concurrency and request rate targets, KEDA evaluates each metric independently and scales to whichever demands more replicas.
+This is standard KEDA/HPA behavior: the metric requiring the highest replica count wins.
+
+## The Scaling Formula
+
+The desired replica count for a single metric follows the standard HPA formula:
+
+```
+desiredReplicas = ceil(currentMetricValue / targetValue)
+```
+
+For example, with a concurrency target of 100 and a current concurrency of 250, the desired count is `ceil(250 / 100) = 3`.
+
+This calculation happens within the Kubernetes HPA based on the metrics and targets that KEDA provides.
+
+## How Metrics Flow
+
+1. A request arrives at the interceptor, which counts it.
+2. The scaler periodically polls all interceptor pods to collect per-route request counts.
+3. The scaler aggregates concurrency across pods and computes request rate for each route.
+4. KEDA queries the scaler for current metrics and determines the desired replica count.
+5. KEDA configures the HPA, which adjusts the backend's replica count.
+
+## Scale-to-Zero
+
+When all metrics for a route drop to zero and the ScaledObject's `cooldownPeriod` expires, KEDA scales the backend workload to zero replicas.
+
+The `cooldownPeriod` is a field on the KEDA ScaledObject (not the InterceptorRoute).
+It defines how long all metrics must remain at zero before KEDA scales the workload down to zero.
+
+## Cold Starts
+
+When a request arrives for a backend that has been scaled to zero, the interceptor holds the request while KEDA scales the backend up.
+The sequence is:
+
+1. The interceptor matches the request to a route and counts it.
+2. The scaler detects incoming traffic and reports the workload as active to KEDA.
+3. KEDA scales the backend workload from 0 to 1 or more replicas.
+4. Once at least one backend pod is ready, the interceptor forwards the held request.
+5. The response flows back through the interceptor to the client.
+
+If the backend does not become ready within the readiness timeout, the interceptor either routes to a fallback service (if configured) or returns an error.
+See [Configure Cold-Start Behavior](../../user-guide/configure-cold-start/) for fallback configuration and [Configure Timeouts](../../user-guide/configure-timeouts/) for timeout settings.
+
+## What's Next
+
+- [Configure Scaling Metrics](../../user-guide/configure-scaling/) — Choose between concurrency and request rate, and tune target values.
+- [Configure Timeouts](../../user-guide/configure-timeouts/) — Set readiness timeouts per route.
+- [Configure Cold-Start Behavior](../../user-guide/configure-cold-start/) — Fallback services and cold-start response headers.
+- [Architecture](../architecture/) — Overview of the three components and how they interact.

--- a/content/http-add-on/0.14/getting-started/_index.md
+++ b/content/http-add-on/0.14/getting-started/_index.md
@@ -1,0 +1,315 @@
++++
+title = "Getting Started"
+description = "Sample HTTP application deployment and autoscaling with the KEDA HTTP Add-on"
+weight = 100
++++
+
+In this tutorial, we will install the KEDA HTTP Add-on and use it to autoscale an HTTP application based on incoming traffic — including scaling to zero when idle.
+
+By the end, we will have:
+
+- A sample HTTP application running in our cluster
+- The HTTP Add-on intercepting and counting requests
+- KEDA scaling the application up under load and back to zero when traffic stops
+
+## Prerequisites
+
+Before we begin, we need:
+
+- A Kubernetes cluster (kind, minikube, or a cloud provider)
+- `kubectl` configured to access the cluster
+- [Helm 3](https://helm.sh/docs/intro/install/) installed
+- KEDA core installed:
+
+  ```shell
+  helm install keda kedacore/keda --namespace keda --create-namespace
+  ```
+
+  See the [KEDA deployment docs](https://keda.sh/docs/deploy/) for other installation methods.
+
+## Step 1: Add the KEDA Helm Repository
+
+If we have not already added the KEDA Helm repository, we add it now and update our local chart index:
+
+```shell
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+```
+
+## Step 2: Install the HTTP Add-on
+
+We install the HTTP Add-on into the same `keda` namespace where KEDA core is running:
+
+```shell
+helm install http-add-on kedacore/keda-add-ons-http --namespace keda
+```
+
+We verify that all components are running:
+
+```shell
+kubectl get pods -n keda
+```
+
+We will see pods for the operator, interceptor, and scaler — all with a `Running` status:
+
+```
+NAME                                                   READY   STATUS    RESTARTS   AGE
+keda-add-ons-http-interceptor-...                      1/1     Running   0          30s
+keda-add-ons-http-operator-...                         1/1     Running   0          30s
+keda-add-ons-http-scaler-...                           1/1     Running   0          30s
+keda-admission-webhooks-...                            1/1     Running   0          2m
+keda-operator-...                                      1/1     Running   0          2m
+keda-operator-metrics-apiserver-...                    1/1     Running   0          2m
+```
+
+## Step 3: Deploy a Sample Application
+
+We create a namespace and deploy a sample HTTP application using [traefik/whoami](https://github.com/traefik/whoami), a lightweight HTTP server that responds with request metadata.
+
+```shell
+kubectl create namespace demo
+```
+
+We deploy a Deployment and Service:
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-app
+  namespace: demo
+spec:
+  selector:
+    matchLabels:
+      app: sample-app
+  template:
+    metadata:
+      labels:
+        app: sample-app
+    spec:
+      containers:
+        - name: sample-app
+          image: traefik/whoami
+          args: ["--port=8080"]
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-app
+  namespace: demo
+spec:
+  selector:
+    app: sample-app
+  ports:
+    - port: 80
+      targetPort: 8080
+EOF
+```
+
+We verify the Deployment was created:
+
+```shell
+kubectl get deployment -n demo
+```
+
+We will see the Deployment with 1 replica running (the Kubernetes default):
+
+```
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+sample-app   1/1     1            1           10s
+```
+
+## Step 4: Create an InterceptorRoute
+
+The `InterceptorRoute` tells the interceptor how to route requests to our sample app and what scaling metric to use.
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: sample-app
+  namespace: demo
+spec:
+  target:
+    service: sample-app
+    port: 80
+  rules:
+    - hosts:
+        - sample-app.example.com
+  scalingMetric:
+    requestRate:
+      targetValue: 5
+      window: 1m
+      granularity: 1s
+EOF
+```
+
+The `requestRate` metric scales based on requests per second, averaged over the configured `window`.
+A `targetValue: 5` means the add-on targets 5 requests per second per replica.
+We use a low value here so that scaling is visible during testing.
+See [Scaling](../concepts/scaling/) for details on scaling metrics and how to tune them.
+
+We verify the InterceptorRoute is ready:
+
+```shell
+kubectl get interceptorroute -n demo
+```
+
+We will see:
+
+```
+NAME         TARGETSERVICE   READY   AGE
+sample-app   sample-app      True    10s
+```
+
+## Step 5: Create a ScaledObject
+
+The `ScaledObject` tells KEDA how to scale our `sample-app` deployment.
+It uses the `external-push` trigger type, which receives metrics from the HTTP Add-on's scaler component.
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: sample-app
+  namespace: demo
+spec:
+  scaleTargetRef:
+    name: sample-app
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  cooldownPeriod: 30
+  triggers:
+    - type: external-push
+      metadata:
+        scalerAddress: keda-add-ons-http-external-scaler.keda:9090
+        interceptorRoute: sample-app
+EOF
+```
+
+The `interceptorRoute` value must match the name of the `InterceptorRoute` we created in the previous step.
+See [Architecture](../concepts/architecture/) for details on how these components connect.
+
+We verify the ScaledObject was created:
+
+```shell
+kubectl get scaledobject -n demo
+```
+
+We will see:
+
+```
+NAME         SCALETARGETKIND      SCALETARGETNAME   MIN   MAX   TRIGGERS        ...
+sample-app   apps/v1.Deployment   sample-app        0     10    external-push   ...
+```
+
+## Step 6: Send Traffic and Observe Scaling
+
+Now we test that autoscaling works.
+Since there is no traffic, KEDA has scaled the deployment to 0 replicas.
+We verify this:
+
+```shell
+kubectl get deployment sample-app -n demo
+```
+
+```
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+sample-app   0/0     0            0           2m
+```
+
+For testing, we use `kubectl port-forward` to access the interceptor proxy.
+In production, your ingress or gateway must route traffic to the interceptor proxy service (`keda-add-ons-http-interceptor-proxy`) instead of directly to your application — see [Configure Ingress](../user-guide/configure-ingress/) for details.
+
+```shell
+kubectl port-forward -n keda svc/keda-add-ons-http-interceptor-proxy 8090:8080
+```
+
+In another terminal, we send a request with the matching `Host` header:
+
+```shell
+curl -H "Host: sample-app.example.com" localhost:8090
+```
+
+The first request may take a few seconds.
+This is the cold start: KEDA is scaling the deployment from 0 to 1 replica, and the interceptor holds the request until the pod is ready.
+We will see a response from the sample app once the pod starts.
+
+We check replicas again:
+
+```shell
+kubectl get deployment sample-app -n demo
+```
+
+We will see 1 replica running:
+
+```
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+sample-app   1/1     1            1           3m
+```
+
+## Step 7: Generate Load and Watch It Scale Up
+
+To see scaling beyond 1 replica, we generate a burst of traffic.
+The `wait=50ms` query parameter tells whoami to hold each response for 50 milliseconds, which produces a steady rate of about 20 requests per second — enough to trigger scaling with our `targetValue` of 5:
+
+```shell
+for i in $(seq 1 300); do curl -s -H "Host: sample-app.example.com" "localhost:8090/?wait=50ms" > /dev/null; done
+```
+
+After the burst finishes, we check the deployment:
+
+```shell
+kubectl get deployment sample-app -n demo
+```
+
+We will see the replica count has increased:
+
+```
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+sample-app   2/2     2            2           5m
+```
+
+## Step 8: Observe Scale to Zero
+
+After the burst ends and the cooldown period passes (30 seconds, as configured in our ScaledObject), KEDA scales the deployment back to 0.
+We can watch this happen:
+
+```shell
+kubectl get deployment sample-app -n demo -w
+```
+
+We will see replicas decrease to 0:
+
+```
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+sample-app   2/2     2            2           5m
+sample-app   1/1     1            1           6m
+sample-app   0/0     0            0           7m
+```
+
+## Step 9: Clean Up
+
+To remove the sample application and all its resources:
+
+```shell
+kubectl delete namespace demo
+```
+
+## What's Next
+
+- [Architecture](../concepts/architecture/) — Understand how the interceptor, scaler, and operator work together.
+- [Autoscale an App](../user-guide/autoscale-an-app/) — Apply this pattern to your own services.
+- [Configure Ingress](../user-guide/configure-ingress/) — Set up Gateway API or Ingress for production traffic.
+- [Configure Scaling Metrics](../user-guide/configure-scaling/) — Tune concurrency targets or switch to request-rate scaling.
+
+## Getting Help
+
+- [Kubernetes Slack](https://kubernetes.slack.com/archives/CKZJ36A5D) — `#keda` channel ([join here](https://slack.k8s.io))
+- [GitHub Issues](https://github.com/kedacore/http-add-on/issues) — Bug reports and feature requests
+- [GitHub Discussions](https://github.com/kedacore/http-add-on/discussions) — Questions and general conversation

--- a/content/http-add-on/0.14/operations/_index.md
+++ b/content/http-add-on/0.14/operations/_index.md
@@ -1,0 +1,14 @@
++++
+title = "Operations"
+description = "HTTP Add-on infrastructure installation, configuration, and management"
+weight = 400
++++
+
+Guides for platform administrators installing and managing the HTTP Add-on.
+
+- **[Configure the Interceptor](configure-interceptor/)** — Timeouts, connection tuning, and scaling.
+- **[Configure Observability](configure-observability/)** — Prometheus metrics, OpenTelemetry tracing, and request logging.
+- **[Configure TLS](configure-tls/)** — TLS termination, certificates, and cipher suites.
+- **[Install the HTTP Add-on](installation/)** — Install, upgrade, and uninstall via Helm.
+- **[Migrate from HTTPScaledObject to InterceptorRoute](migrate-httpscaledobject-to-interceptorroute/)** — Upgrade existing resources to the v1beta1 API.
+- **[Troubleshooting](troubleshooting/)** — Debug request routing, inspect queue state, and profile performance.

--- a/content/http-add-on/0.14/operations/configure-interceptor.md
+++ b/content/http-add-on/0.14/operations/configure-interceptor.md
@@ -1,0 +1,73 @@
++++
+title = "Configure the Interceptor"
+description = "Timeout, connection, and scaling configuration for the interceptor proxy"
++++
+
+The interceptor is the reverse proxy that sits in front of your application.
+This page covers infrastructure-level settings configured via Helm values and environment variables.
+
+## Timeouts
+
+Global timeouts apply to all routes and serve as cluster-wide defaults.
+Application developers can override these values per route on the `InterceptorRoute` — see [Configure Timeouts](../../user-guide/configure-timeouts/).
+
+Set global defaults via Helm values:
+
+```shell
+helm install http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.requestTimeout=30s \
+  --set interceptor.responseHeaderTimeout=15s \
+  --set interceptor.readinessTimeout=20s
+```
+
+| Timeout         | Helm value                          | Env var                             | Default                                                            |
+| --------------- | ----------------------------------- | ----------------------------------- | ------------------------------------------------------------------ |
+| Request         | `interceptor.requestTimeout`        | `KEDA_HTTP_REQUEST_TIMEOUT`         | `0s` (disabled — no total deadline)                                |
+| Response header | `interceptor.responseHeaderTimeout` | `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT` | `300s`                                                             |
+| Readiness       | `interceptor.readinessTimeout`      | `KEDA_HTTP_READINESS_TIMEOUT`       | `0s` (disabled — readiness wait is bounded by the request timeout) |
+| Connect         | `interceptor.tcpConnectTimeout`     | `KEDA_HTTP_CONNECT_TIMEOUT`         | `500ms`                                                            |
+
+## Cold-start response header
+
+The interceptor adds an `X-KEDA-HTTP-Cold-Start` response header to indicate whether a cold start occurred.
+This header is enabled by default.
+To disable it:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.extraEnvs.KEDA_HTTP_ENABLE_COLD_START_HEADER=false
+```
+
+## Connection tuning
+
+Configure the interceptor's connection pool for backend services:
+
+| Helm value                        | Env var                             | Default | Description                                                                                                       |
+| --------------------------------- | ----------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `interceptor.maxIdleConns`        | `KEDA_HTTP_MAX_IDLE_CONNS`          | `1000`  | Maximum idle connections across all backend services. Increase this if you proxy to many backends.                |
+| `interceptor.maxIdleConnsPerHost` | `KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST` | `200`   | Maximum idle connections per backend. Increase this if you observe frequent connection establishments under load. |
+
+## Interceptor scaling
+
+The interceptor itself is auto-scaled by KEDA via a `ScaledObject` created by the Helm chart.
+Configure the interceptor's scaling bounds:
+
+| Helm value                 | Default | Description                   |
+| -------------------------- | ------- | ----------------------------- |
+| `interceptor.replicas.min` | `3`     | Minimum interceptor replicas. |
+| `interceptor.replicas.max` | `50`    | Maximum interceptor replicas. |
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.replicas.min=<your-min> \
+  --set interceptor.replicas.max=<your-max>
+```
+
+## What's Next
+
+- [Configure TLS](../configure-tls/) — TLS termination, certificates, and cipher suites.
+- [Configure Observability](../configure-observability/) — Prometheus metrics, OpenTelemetry tracing, and request logging.
+- [Environment Variables Reference](../../reference/environment-variables/) — all environment variables for each component.

--- a/content/http-add-on/0.14/operations/configure-observability.md
+++ b/content/http-add-on/0.14/operations/configure-observability.md
@@ -1,0 +1,74 @@
++++
+title = "Configure Observability"
+description = "Prometheus metrics, OpenTelemetry tracing, and request logging configuration for the interceptor"
++++
+
+The interceptor exposes metrics and tracing data to help monitor HTTP traffic and scaling behavior.
+All observability settings are configured via environment variables, set through the `interceptor.extraEnvs` Helm value.
+
+## Prometheus metrics
+
+The interceptor exposes Prometheus metrics at `/metrics` on port `2223`.
+This is enabled by default.
+
+| Env var                      | Default | Description                               |
+| ---------------------------- | ------- | ----------------------------------------- |
+| `OTEL_PROM_EXPORTER_ENABLED` | `true`  | Enable the Prometheus metrics endpoint.   |
+| `OTEL_PROM_EXPORTER_PORT`    | `2223`  | Port for the Prometheus metrics endpoint. |
+
+See [Metrics Reference](../../reference/metrics/) for the full list of metrics and labels.
+
+## OpenTelemetry tracing
+
+Enable distributed tracing via OTLP:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_TRACES_ENABLED=true \
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc \
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317
+```
+
+The interceptor uses W3C TraceContext and Baggage propagation.
+
+| Env var                              | Default   | Description                                             |
+| ------------------------------------ | --------- | ------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_TRACES_ENABLED`  | `false`   | Enable OTLP trace export.                               |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | `console` | Exporter protocol (`grpc`, `http/protobuf`, `console`). |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`        | —         | Collector endpoint URL.                                 |
+| `OTEL_EXPORTER_OTLP_HEADERS`         | —         | Authentication headers (e.g., `api-key=<token>`).       |
+| `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`  | `10s`     | Timeout for trace export requests.                      |
+
+## OpenTelemetry metrics
+
+Enable OTLP metrics export alongside or instead of Prometheus:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_METRICS_ENABLED=true \
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317
+```
+
+| Env var                              | Default | Description                                         |
+| ------------------------------------ | ------- | --------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_METRICS_ENABLED` | `false` | Enable OTLP metrics export.                         |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`        | —       | Collector endpoint URL (shared with traces if set). |
+| `OTEL_EXPORTER_OTLP_HEADERS`         | —       | Authentication headers (shared with traces if set). |
+| `OTEL_METRIC_EXPORT_INTERVAL`        | `60s`   | Interval between periodic metric exports.           |
+
+## Request logging
+
+Enable Combined Log Format request logging:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.extraEnvs.KEDA_HTTP_LOG_REQUESTS=true
+```
+
+## What's Next
+
+- [Metrics Reference](../../reference/metrics/) — detailed Prometheus metric definitions.
+- [Environment Variables Reference](../../reference/environment-variables/) — all observability-related environment variables.

--- a/content/http-add-on/0.14/operations/configure-tls.md
+++ b/content/http-add-on/0.14/operations/configure-tls.md
@@ -1,0 +1,49 @@
++++
+title = "Configure TLS"
+description = "TLS termination, certificates, cipher suites, and SNI configuration for the interceptor proxy"
++++
+
+> **Note:** This page has not been fully verified against the current implementation.
+> Configuration values, environment variable names, or default values may be inaccurate or incomplete.
+> If you find an issue, please [open a GitHub issue](https://github.com/kedacore/keda-docs/issues/new) or submit a pull request.
+
+The interceptor can terminate TLS for incoming connections.
+All TLS settings are configured via Helm values and environment variables.
+
+## Enable TLS termination
+
+Enable TLS on the interceptor proxy:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.tls.enabled=true \
+  --set interceptor.tls.certSecret=<your-tls-secret>
+```
+
+The interceptor loads TLS certificates from a Kubernetes Secret mounted at `/certs`.
+The Secret must contain `tls.crt` and `tls.key` entries.
+
+## TLS settings
+
+| Helm value                         | Env var                                 | Default                        | Description                                                              |
+| ---------------------------------- | --------------------------------------- | ------------------------------ | ------------------------------------------------------------------------ |
+| `interceptor.tls.enabled`          | `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`                        | Enable TLS on the proxy.                                                 |
+| `interceptor.tls.port`             | `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`                         | Port the TLS proxy listens on.                                           |
+| `interceptor.tls.certSecret`       | —                                       | `keda-tls-certs`               | Name of the Kubernetes Secret containing the TLS certificate and key.    |
+| `interceptor.tls.certPath`         | `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt`               | Path to the certificate file.                                            |
+| `interceptor.tls.keyPath`          | `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key`               | Path to the private key file.                                            |
+| `interceptor.tls.minVersion`       | `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | Go default (TLS 1.2)           | Minimum TLS version (`"1.2"` or `"1.3"`).                                |
+| `interceptor.tls.maxVersion`       | `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | Go default (highest supported) | Maximum TLS version (`"1.2"` or `"1.3"`).                                |
+| `interceptor.tls.cipherSuites`     | `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | Go defaults                    | Comma-separated list of cipher suite names.                              |
+| `interceptor.tls.curvePreferences` | `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | Go defaults                    | Comma-separated list of elliptic curve names (e.g., `X25519,CurveP256`). |
+| `interceptor.tls.skipVerify`       | `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`                        | Skip TLS verification for upstream (backend) connections.                |
+
+## SNI-based certificate selection
+
+The interceptor supports SNI-based certificate selection when multiple certificate/key pairs are loaded via the `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` environment variable.
+Set this to a comma-separated list of paths containing additional certificate/key pairs.
+
+## What's Next
+
+- [Environment Variables Reference](../../reference/environment-variables/) — all TLS-related environment variables.

--- a/content/http-add-on/0.14/operations/installation.md
+++ b/content/http-add-on/0.14/operations/installation.md
@@ -1,0 +1,102 @@
++++
+title = "Install the HTTP Add-on"
+description = "HTTP Add-on installation, upgrade, and removal via Helm"
+weight = 1
++++
+
+## Prerequisites
+
+Before installing the HTTP Add-on, ensure you have:
+
+- A Kubernetes cluster (tested against the three most recent minor versions)
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- KEDA core installed ([deployment guide](https://keda.sh/docs/deploy/))
+
+If you have not installed KEDA yet, run:
+
+```shell
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+helm install keda kedacore/keda --namespace keda --create-namespace
+```
+
+## Install
+
+1. Add the KEDA Helm repository (if you have not already):
+
+   ```shell
+   helm repo add kedacore https://kedacore.github.io/charts
+   helm repo update
+   ```
+
+2. Install the HTTP Add-on into the same namespace as KEDA:
+
+   ```shell
+   helm install http-add-on kedacore/keda-add-ons-http --namespace keda
+   ```
+
+3. Verify the installation:
+
+   ```shell
+   kubectl get pods -n keda
+   ```
+
+   You should see pods for the operator, interceptor, and scaler components in a `Running` state.
+
+### Helm Values to Consider
+
+The following values are commonly configured at install time.
+Pass them with `--set` or in a values file (`-f values.yaml`).
+
+| Value                      | Description                                                                       | Default |
+| -------------------------- | --------------------------------------------------------------------------------- | ------- |
+| `interceptor.replicas.min` | Minimum number of interceptor replicas                                            | `3`     |
+| `interceptor.replicas.max` | Maximum number of interceptor replicas                                            | `50`    |
+| `operator.watchNamespace`  | Restrict the operator to a single namespace (empty string watches all namespaces) | `""`    |
+
+For the full list of configuration options, see the [http-add-on chart](https://github.com/kedacore/charts/tree/main/http-add-on#configuration).
+
+## Upgrade
+
+To upgrade to a newer version of the HTTP Add-on:
+
+```shell
+helm repo update
+helm upgrade http-add-on kedacore/keda-add-ons-http --namespace keda
+```
+
+The CRDs are included as Helm templates (not in the `crds/` directory), so they are updated automatically during `helm upgrade`.
+
+## Uninstall
+
+1. Remove the HTTP Add-on Helm release:
+
+   ```shell
+   helm uninstall http-add-on --namespace keda
+   ```
+
+2. CRDs are **not** automatically removed on uninstall. To remove them manually:
+
+   ```shell
+   kubectl delete crd httpscaledobjects.http.keda.sh interceptorroutes.http.keda.sh
+   ```
+
+   > **Warning:** Deleting the CRDs removes all `HTTPScaledObject` and `InterceptorRoute` resources in the cluster. Make sure you no longer need them before proceeding.
+
+## Namespace-Scoped Installation
+
+By default, the operator watches all namespaces for `HTTPScaledObject` and `InterceptorRoute` resources.
+To restrict the operator to a single namespace:
+
+```shell
+helm install http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set operator.watchNamespace=<your-namespace>
+```
+
+For the full list of configuration options, see the [http-add-on chart](https://github.com/kedacore/charts/tree/main/http-add-on#configuration).
+
+## What's Next
+
+- [Autoscale an App](../../user-guide/autoscale-an-app/) — Create a ScaledObject and InterceptorRoute for your service.
+- [Configure the Interceptor](../configure-interceptor/) — Timeouts, connection tuning, and scaling.

--- a/content/http-add-on/0.14/operations/migrate-httpscaledobject-to-interceptorroute.md
+++ b/content/http-add-on/0.14/operations/migrate-httpscaledobject-to-interceptorroute.md
@@ -1,0 +1,262 @@
++++
+title = "Migrate from HTTPScaledObject to InterceptorRoute"
+description = "How to migrate existing HTTPScaledObject resources to the InterceptorRoute API"
++++
+
+This guide shows you how to migrate existing `HTTPScaledObject` (v1alpha1) resources to the `InterceptorRoute` (v1beta1) API.
+
+## Prerequisites
+
+- KEDA HTTP Add-on v0.14.0 or later deployed on the cluster
+- `kubectl` access to the cluster
+- Existing `HTTPScaledObject` resources to migrate
+
+## What changed
+
+The `InterceptorRoute` API replaces `HTTPScaledObject` with a cleaner separation of concerns.
+
+- **Manual ScaledObject management:**
+  The `InterceptorRoute` controller no longer creates a KEDA `ScaledObject` for you.
+  You create and manage it yourself, with access to all supported KEDA ScaledObject fields.
+- **Multiple routing rules:**
+  A new `rules[]` structure lets you define multiple routing rules on a single resource, each with its own hosts, paths, and headers.
+- **Target reference for routing only:**
+  The target reference contains only `service` and `port`/`portName`.
+  Workload fields (`name`, `apiVersion`, `kind`) move to the `ScaledObject` where they belong.
+- **Flexible scaling metrics:**
+  Concurrency and request rate can be used independently or together.
+  When both are set, KEDA scales based on whichever metric demands more replicas.
+- **Granular timeouts:**
+  A new `request` timeout controls the full request lifecycle.
+  `conditionWait` is renamed to `readiness` for clarity.
+- **`targetValue` is required:**
+  On `HTTPScaledObject`, `targetValue` defaulted to `100` when omitted.
+  On `InterceptorRoute`, `targetValue` must be set explicitly.
+  If your `HTTPScaledObject` relied on the default, add `targetValue: 100` (or your preferred value) when migrating.
+- **Scaling fields move to ScaledObject:**
+  `replicas`, `targetPendingRequests`, `scaledownPeriod`, and `initialCooldownPeriod` are configured on the KEDA `ScaledObject` directly.
+
+## Convert an HTTPScaledObject to an InterceptorRoute
+
+The migration is a direct field-by-field conversion.
+The [Apply the migration without downtime](#apply-the-migration-without-downtime) section below shows how to perform the switchover without interrupting traffic.
+
+### Before: HTTPScaledObject
+
+```yaml
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  hosts:
+    - app.example.com
+  pathPrefixes:
+    - /api
+    - /health
+  headers:
+    - name: X-Custom-Header
+      value: "my-value"
+  scaleTargetRef:
+    name: my-app
+    kind: Deployment
+    apiVersion: apps/v1
+    service: my-app-svc
+    port: 8080
+  coldStartTimeoutFailoverRef:
+    service: fallback-svc
+    port: 8080
+    timeoutSeconds: 45
+  replicas:
+    min: 0
+    max: 10
+  scalingMetric:
+    concurrency:
+      targetValue: 50
+  timeouts:
+    conditionWait: 30s
+    responseHeader: 10s
+  scaledownPeriod: 120
+```
+
+### After: InterceptorRoute and ScaledObject
+
+The single `HTTPScaledObject` becomes two resources: an `InterceptorRoute` for routing and an independently managed `ScaledObject` for scaling.
+
+**InterceptorRoute:**
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  target:
+    service: my-app-svc
+    port: 8080
+  coldStart:
+    fallback:
+      service: fallback-svc
+      port: 8080
+  rules:
+    - hosts:
+        - app.example.com
+      paths:
+        - value: /api
+        - value: /health
+      headers:
+        - name: X-Custom-Header
+          value: "my-value"
+  scalingMetric:
+    concurrency:
+      targetValue: 50
+  timeouts:
+    readiness: 45s
+    responseHeader: 10s
+```
+
+**ScaledObject:**
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: my-app
+    kind: Deployment
+    apiVersion: apps/v1
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  cooldownPeriod: 120
+  triggers:
+    - type: external-push
+      metadata:
+        scalerAddress: "keda-add-ons-http-external-scaler.keda:9090"
+        interceptorRoute: "my-app"
+```
+
+Note the following conversions:
+
+1. `scaleTargetRef` becomes `target` with only `service` and `port`/`portName`.
+2. `hosts`, `pathPrefixes`, and `headers` move into a `rules[]` entry.
+3. `pathPrefixes` entries become `paths` entries, each with a `value` field.
+4. `coldStartTimeoutFailoverRef` splits: the service reference moves to `coldStart.fallback`, and `timeoutSeconds` moves to `timeouts.readiness` as a duration string (`"45s"`).
+5. `replicas`, `scaledownPeriod`, and `initialCooldownPeriod` move to the `ScaledObject`.
+6. The workload reference (`name`, `apiVersion`, `kind`) moves to the `ScaledObject`'s `scaleTargetRef`.
+
+## Apply the migration without downtime
+
+The `HTTPScaledObject` controller sets an owner reference on the KEDA `ScaledObject` it creates.
+Deleting the `HTTPScaledObject` triggers Kubernetes garbage collection, which cascade-deletes the owned `ScaledObject`.
+To prevent this, add the `httpscaledobject.keda.sh/orphan-scaledobject` annotation to the `HTTPScaledObject` before deleting it.
+The controller removes the owner reference from the `ScaledObject`, so it survives deletion.
+
+Set these environment variables before running the commands:
+
+```bash
+NAME=my-app
+NAMESPACE=default
+```
+
+1. Annotate the `HTTPScaledObject` to orphan its `ScaledObject`:
+
+   ```bash
+   kubectl annotate httpscaledobject $NAME -n $NAMESPACE \
+     httpscaledobject.keda.sh/orphan-scaledobject=true
+   ```
+
+   The controller removes the owner reference from the `ScaledObject`.
+   Verify that the owner reference was removed:
+
+   ```bash
+   kubectl get scaledobject $NAME -n $NAMESPACE \
+     -o jsonpath='{.metadata.ownerReferences}'
+   ```
+
+   The output is empty when the owner reference has been removed.
+
+2. Create the `InterceptorRoute`:
+
+   ```bash
+   kubectl apply -f interceptor-route.yaml
+   ```
+
+   When the `InterceptorRoute` shares the same namespace and name as the `HTTPScaledObject`, the routing table automatically gives the `InterceptorRoute` precedence and skips the `HTTPScaledObject`.
+
+3. Update the `ScaledObject` trigger metadata.
+   The auto-created `ScaledObject` references the `HTTPScaledObject` by name in its trigger metadata.
+   Replace `httpScaledObject` with `interceptorRoute` so the external scaler resolves metrics from the `InterceptorRoute`:
+
+   ```bash
+   kubectl patch scaledobject $NAME -n $NAMESPACE --type=json \
+     -p '[{"op": "remove", "path": "/spec/triggers/0/metadata/httpScaledObject"},
+          {"op": "add", "path": "/spec/triggers/0/metadata/interceptorRoute", "value": "'$NAME'"}]'
+   ```
+
+   Also compare the remaining fields with the ScaledObject YAML from the conversion example and adjust `minReplicaCount`, `maxReplicaCount`, or `cooldownPeriod` as needed.
+
+4. Verify the `ScaledObject` is still present and active:
+
+   ```bash
+   kubectl get scaledobject $NAME -n $NAMESPACE
+   ```
+
+5. Delete the old `HTTPScaledObject`:
+
+   ```bash
+   kubectl delete httpscaledobject $NAME -n $NAMESPACE
+   ```
+
+   The `ScaledObject` remains in the cluster because the owner reference was removed in step 1.
+
+> **GitOps:** In one commit, add the orphan annotation to the `HTTPScaledObject` manifest, add the `InterceptorRoute` manifest, and update the `ScaledObject` trigger metadata (`httpScaledObject` → `interceptorRoute`).
+> In the next commit, remove the `HTTPScaledObject` manifest.
+
+## Field mapping
+
+### HTTPScaledObject → InterceptorRoute
+
+| HTTPScaledObject field                            | InterceptorRoute field                                  |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| `spec.hosts`                                      | `spec.rules[].hosts`                                    |
+| `spec.pathPrefixes`                               | `spec.rules[].paths[].value`                            |
+| `spec.headers`                                    | `spec.rules[].headers`                                  |
+| `spec.scaleTargetRef.service`                     | `spec.target.service`                                   |
+| `spec.scaleTargetRef.port`                        | `spec.target.port`                                      |
+| `spec.scaleTargetRef.portName`                    | `spec.target.portName`                                  |
+| `spec.coldStartTimeoutFailoverRef.service`        | `spec.coldStart.fallback.service`                       |
+| `spec.coldStartTimeoutFailoverRef.port`           | `spec.coldStart.fallback.port`                          |
+| `spec.coldStartTimeoutFailoverRef.portName`       | `spec.coldStart.fallback.portName`                      |
+| `spec.coldStartTimeoutFailoverRef.timeoutSeconds` | `spec.timeouts.readiness` (as `Duration`, e.g. `"30s"`) |
+| `spec.scalingMetric.concurrency.targetValue`      | `spec.scalingMetric.concurrency.targetValue`            |
+| `spec.scalingMetric.requestRate.targetValue`      | `spec.scalingMetric.requestRate.targetValue`            |
+| `spec.scalingMetric.requestRate.window`           | `spec.scalingMetric.requestRate.window`                 |
+| `spec.scalingMetric.requestRate.granularity`      | `spec.scalingMetric.requestRate.granularity`            |
+| `spec.targetPendingRequests`                      | `spec.scalingMetric`                                    |
+| `spec.timeouts.conditionWait`                     | `spec.timeouts.readiness`                               |
+| `spec.timeouts.responseHeader`                    | `spec.timeouts.responseHeader`                          |
+| _(new)_                                           | `spec.timeouts.request`                                 |
+
+### HTTPScaledObject → ScaledObject
+
+| HTTPScaledObject field           | ScaledObject field               |
+| -------------------------------- | -------------------------------- |
+| `spec.scaleTargetRef.name`       | `spec.scaleTargetRef.name`       |
+| `spec.scaleTargetRef.apiVersion` | `spec.scaleTargetRef.apiVersion` |
+| `spec.scaleTargetRef.kind`       | `spec.scaleTargetRef.kind`       |
+| `spec.replicas.min`              | `spec.minReplicaCount`           |
+| `spec.replicas.max`              | `spec.maxReplicaCount`           |
+| `spec.scaledownPeriod`           | `spec.cooldownPeriod`            |
+| `spec.initialCooldownPeriod`     | `spec.initialCooldownPeriod`     |
+
+## What's Next
+
+- [Configure Routing Rules](../../user-guide/configure-routing/) — multiple rules, host, path, and header matching on an InterceptorRoute.
+- [Configure Scaling Metrics](../../user-guide/configure-scaling/) — concurrency, request rate, and combined metric configuration.
+- [InterceptorRoute Reference](../../reference/interceptorroute/) — full API specification.
+- [KEDA ScaledObject documentation](https://keda.sh/docs/latest/concepts/scaling-deployments/) — scaling configuration options.

--- a/content/http-add-on/0.14/operations/troubleshooting.md
+++ b/content/http-add-on/0.14/operations/troubleshooting.md
@@ -1,0 +1,67 @@
++++
+title = "Troubleshooting"
+description = "Request routing, queue state, and component performance troubleshooting"
++++
+
+## Queue inspection
+
+The interceptor exposes a `/queue` endpoint on its admin service (port `9090` by default) that returns the current pending request counts per route as JSON.
+
+```shell
+kubectl port-forward -n keda svc/keda-add-ons-http-interceptor-admin 9090
+```
+
+```shell
+curl -X GET localhost:9090/queue
+```
+
+The response is a JSON object keyed by `namespace/route-name`, with concurrency and request count for each route:
+
+```json
+{
+  "default/my-app": { "Concurrency": 3, "RequestCount": 42 },
+  "demo/sample-app": { "Concurrency": 0, "RequestCount": 0 }
+}
+```
+
+The endpoint shows raw counts from the interceptor.
+Request rate (RPS) is calculated by the scaler component based on these counts and the configured window — it is not part of this response.
+
+## Profiling
+
+Enable pprof profiling on the interceptor or scaler by setting the `PROFILING_BIND_ADDRESS` environment variable:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.extraEnvs.PROFILING_BIND_ADDRESS=0.0.0.0:6060
+```
+
+For the operator, use the `--profiling-bind-address` flag instead:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set operator.extraArgs.profiling-bind-address=:6060
+```
+
+Once enabled, collect profiles with `go tool pprof`:
+
+```shell
+kubectl port-forward -n keda deploy/keda-add-ons-http-interceptor 6060
+go tool pprof -http=:8080 http://localhost:6060/debug/pprof/heap
+```
+
+## Getting Help
+
+If you cannot resolve the issue, the following channels are available:
+
+- [Kubernetes Slack](https://kubernetes.slack.com/archives/CKZJ36A5D) — `#keda` channel ([join here](https://slack.k8s.io))
+- [GitHub Issues](https://github.com/kedacore/http-add-on/issues) — Bug reports and feature requests
+- [GitHub Discussions](https://github.com/kedacore/http-add-on/discussions) — Questions and general conversation
+
+## What's Next
+
+- [Configure the Interceptor](../configure-interceptor/) — Timeouts, connection tuning, and scaling.
+- [Environment Variables Reference](../../reference/environment-variables/) — all environment variables for each component.
+- [Metrics Reference](../../reference/metrics/) — Prometheus metric definitions for monitoring.

--- a/content/http-add-on/0.14/reference/_index.md
+++ b/content/http-add-on/0.14/reference/_index.md
@@ -1,0 +1,10 @@
++++
+title = "Reference"
+description = "API specifications, environment variables, and metrics"
+weight = 500
++++
+
+- **[Environment Variables](environment-variables/)** — Environment variables for each component.
+- **[HTTPScaledObject](httpscaledobject/)** — HTTPScaledObject CRD API reference (v1alpha1, deprecated).
+- **[InterceptorRoute](interceptorroute/)** — InterceptorRoute CRD API reference (v1beta1).
+- **[Metrics](metrics/)** — Prometheus metrics exposed by the interceptor.

--- a/content/http-add-on/0.14/reference/environment-variables.md
+++ b/content/http-add-on/0.14/reference/environment-variables.md
@@ -1,0 +1,104 @@
++++
+title = "Environment Variables"
+description = "Reference for all environment variables accepted by each component"
++++
+
+Environment variables configure runtime behavior for each HTTP Add-on component.
+These are set via the `extraEnvs` Helm value for each component or directly in the container spec.
+
+## Interceptor
+
+### Serving
+
+| Variable                                            | Default      | Description                                                                                   |
+| --------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------- |
+| `KEDA_HTTP_PROXY_PORT`                              | _(required)_ | Port for the public proxy server.                                                             |
+| `KEDA_HTTP_ADMIN_PORT`                              | _(required)_ | Port for the internal admin server (metrics RPC endpoint for the scaler).                     |
+| `KEDA_HTTP_WATCH_NAMESPACE`                         | `""`         | Namespace to watch for HTTPScaledObjects and InterceptorRoutes. Empty watches all namespaces. |
+| `KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD` | `60m`        | Resync interval for the controller-runtime cache.                                             |
+| `KEDA_HTTP_ENABLE_COLD_START_HEADER`                | `true`       | When enabled, the interceptor adds the `X-KEDA-HTTP-Cold-Start` response header.              |
+| `KEDA_HTTP_LOG_REQUESTS`                            | `false`      | Enable logging of incoming requests.                                                          |
+
+### Timeouts
+
+| Variable                            | Default | Description                                                                                                                                                                                                                                         |
+| ----------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KEDA_HTTP_REQUEST_TIMEOUT`         | `0s`    | Total request lifecycle deadline. `0s` disables the deadline.                                                                                                                                                                                       |
+| `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT` | `300s`  | Time to wait for response headers from the backend after the request is sent. `0s` disables the deadline.                                                                                                                                           |
+| `KEDA_HTTP_READINESS_TIMEOUT`       | `0s`    | Time to wait for the backing workload to reach 1 or more replicas. `0s` disables the dedicated readiness deadline, giving the full request budget to cold starts. When a fallback service is configured and this is `0s`, a 30s default is applied. |
+| `KEDA_HTTP_CONNECT_TIMEOUT`         | `500ms` | Per-attempt TCP dial timeout. Bounded by the request context deadline.                                                                                                                                                                              |
+| `KEDA_HTTP_MAX_IDLE_CONNS`          | `1000`  | Maximum idle connections in the connection pool across all backend services.                                                                                                                                                                        |
+| `KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST` | `200`   | Maximum idle connections per backend service.                                                                                                                                                                                                       |
+| `KEDA_HTTP_FORCE_HTTP2`             | `false` | Whether to force HTTP/2 for all proxied requests.                                                                                                                                                                                                   |
+
+#### Deprecated timeout variables
+
+These deprecated variables are still accepted.
+When set, they take precedence over their replacements.
+
+| Deprecated Variable            | Replacement                         | Description                                                       |
+| ------------------------------ | ----------------------------------- | ----------------------------------------------------------------- |
+| `KEDA_CONDITION_WAIT_TIMEOUT`  | `KEDA_HTTP_READINESS_TIMEOUT`       | Time to wait for the backing workload to have 1 or more replicas. |
+| `KEDA_RESPONSE_HEADER_TIMEOUT` | `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT` | Time to wait for response headers from the backend.               |
+
+### TLS
+
+| Variable                                | Default          | Description                                                                                     |
+| --------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
+| `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`          | Enable TLS on the proxy server.                                                                 |
+| `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt` | Path to the TLS certificate file.                                                               |
+| `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key` | Path to the TLS private key file.                                                               |
+| `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`             | Comma-separated list of paths to certificate/key pairs.                                         |
+| `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`          | Skip TLS verification for upstream connections.                                                 |
+| `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`           | Port for the TLS proxy server.                                                                  |
+| `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | `""`             | Minimum TLS version (`1.2` or `1.3`). Empty uses the Go default (TLS 1.2).                      |
+| `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | `""`             | Maximum TLS version (`1.2` or `1.3`). Empty uses the highest version supported by `crypto/tls`. |
+| `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | `""`             | Comma-separated list of TLS cipher suite names. Empty uses Go defaults.                         |
+| `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | `""`             | Comma-separated list of elliptic curve names. Empty uses Go defaults.                           |
+
+### Metrics
+
+| Variable                             | Default | Description                                          |
+| ------------------------------------ | ------- | ---------------------------------------------------- |
+| `OTEL_PROM_EXPORTER_ENABLED`         | `true`  | Enable the Prometheus metrics exporter.              |
+| `OTEL_PROM_EXPORTER_PORT`            | `2223`  | Port for the Prometheus-compatible metrics endpoint. |
+| `OTEL_EXPORTER_OTLP_METRICS_ENABLED` | `false` | Enable the OTLP metrics exporter.                    |
+
+### Tracing
+
+| Variable                             | Default   | Description                                                                  |
+| ------------------------------------ | --------- | ---------------------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_TRACES_ENABLED`  | `false`   | Enable OpenTelemetry trace export.                                           |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | `console` | Trace exporter protocol. Must be one of: `console`, `http/protobuf`, `grpc`. |
+
+### Profiling
+
+| Variable                 | Default | Description                                                             |
+| ------------------------ | ------- | ----------------------------------------------------------------------- |
+| `PROFILING_BIND_ADDRESS` | `""`    | Address (`host:port`) for the pprof endpoint. Empty disables profiling. |
+
+## Scaler
+
+| Variable                                            | Default      | Description                                                                         |
+| --------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `KEDA_HTTP_SCALER_PORT`                             | `8080`       | Port for the KEDA-compatible gRPC external scaler interface.                        |
+| `KEDA_HTTP_SCALER_TARGET_ADMIN_NAMESPACE`           | _(required)_ | Namespace where the scaler and interceptors are running.                            |
+| `KEDA_HTTP_SCALER_TARGET_ADMIN_SERVICE`             | _(required)_ | Name of the interceptor admin Service to issue metrics RPC requests to.             |
+| `KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT`          | _(required)_ | Name of the interceptor Deployment to issue metrics RPC requests to.                |
+| `KEDA_HTTP_SCALER_TARGET_ADMIN_PORT`                | _(required)_ | Port on the interceptor admin Service for metrics RPC requests.                     |
+| `KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD` | `60m`        | Resync interval for the controller-runtime cache.                                   |
+| `KEDA_HTTP_QUEUE_TICK_DURATION`                     | `500ms`      | Duration between queue polling ticks.                                               |
+| `KEDA_HTTP_SCALER_STREAM_INTERVAL_MS`               | `200`        | Interval in milliseconds between stream ticks for `IsActive` communication to KEDA. |
+| `PROFILING_BIND_ADDRESS`                            | `""`         | Address (`host:port`) for the pprof endpoint. Empty disables profiling.             |
+
+## Operator
+
+| Variable                                            | Default      | Description                                                                         |
+| --------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE`         | _(required)_ | Name of the Kubernetes Service for the external scaler.                             |
+| `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT`            | `8091`       | Port for the external scaler Service.                                               |
+| `KEDA_HTTP_OPERATOR_NAMESPACE`                      | `""`         | Namespace in which the operator is running.                                         |
+| `KEDA_HTTP_OPERATOR_WATCH_NAMESPACE`                | `""`         | Namespace to watch for resources. Empty watches all namespaces.                     |
+| `KEDA_HTTP_OPERATOR_LEADER_ELECTION_LEASE_DURATION` | _(unset)_    | Leader election lease duration. When unset, the controller-runtime default is used. |
+| `KEDA_HTTP_OPERATOR_LEADER_ELECTION_RENEW_DEADLINE` | _(unset)_    | Leader election renew deadline. When unset, the controller-runtime default is used. |
+| `KEDA_HTTP_OPERATOR_LEADER_ELECTION_RETRY_PERIOD`   | _(unset)_    | Leader election retry period. When unset, the controller-runtime default is used.   |

--- a/content/http-add-on/0.14/reference/httpscaledobject.md
+++ b/content/http-add-on/0.14/reference/httpscaledobject.md
@@ -1,0 +1,161 @@
++++
+title = "HTTPScaledObject (Deprecated)"
+description = "Field-by-field API reference for the HTTPScaledObject custom resource"
++++
+
+> **Deprecated:** HTTPScaledObject (v1alpha1) is deprecated.
+> [InterceptorRoute](../interceptorroute/) (v1beta1) is the current API.
+> See [Migrate from HTTPScaledObject to InterceptorRoute](../../operations/migrate-httpscaledobject-to-interceptorroute/) to upgrade.
+
+|                 |                         |
+| --------------- | ----------------------- |
+| **API version** | `http.keda.sh/v1alpha1` |
+| **Kind**        | `HTTPScaledObject`      |
+| **Short name**  | `httpso`                |
+| **Scope**       | Namespaced              |
+
+## Example
+
+```yaml
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  hosts:
+    - app.example.com
+  pathPrefixes:
+    - /api
+  scaleTargetRef:
+    name: my-app
+    service: my-app-svc
+    port: 8080
+  replicas:
+    min: 0
+    max: 10
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+```
+
+## Annotations
+
+| Annotation                                            | Value    | Description                                                                                                                                                          |
+| ----------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `httpscaledobject.keda.sh/skip-scaledobject-creation` | `"true"` | Skip automatic ScaledObject creation. Set this when you want to integrate the HTTP scaler with other KEDA scalers in a single ScaledObject that you manage yourself. |
+| `httpscaledobject.keda.sh/orphan-scaledobject`        | `"true"` | When the HTTPScaledObject is deleted, leave the generated ScaledObject in place instead of deleting it.                                                              |
+
+When `skip-scaledobject-creation` is set to `"true"`, the operator does not create or manage a ScaledObject.
+You can then create your own ScaledObject and add the HTTP external scaler as one of the triggers:
+
+```yaml
+triggers:
+  - type: external-push
+    metadata:
+      httpScaledObject: <your-httpso-name>
+      scalerAddress: keda-add-ons-http-external-scaler.keda:9090
+```
+
+> **Note:** The InterceptorRoute API does not use this annotation.
+> InterceptorRoute separates routing from scaling by design — you always create your own ScaledObject.
+
+## `spec`
+
+| Field                         | Type                                                             | Required | Default | Description                                                                                                                                                           |
+| ----------------------------- | ---------------------------------------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hosts`                       | `[]string`                                                       | No       |         | Hostnames to route. Requests whose `Host` header matches any entry (combined with `pathPrefixes`) are routed to the target.                                           |
+| `pathPrefixes`                | `[]string`                                                       | No       |         | URL path prefixes to match. Combined with `hosts` for routing.                                                                                                        |
+| `headers`                     | [`[]Header`](#header)                                            | No       |         | Custom headers for routing. After `hosts` and `pathPrefixes` match, requests must also match all listed headers. The interceptor uses the most specific header match. |
+| `scaleTargetRef`              | [`ScaleTargetRef`](#scaletargetref)                              | Yes      |         | The target workload and service to scale and route to.                                                                                                                |
+| `coldStartTimeoutFailoverRef` | [`*ColdStartTimeoutFailoverRef`](#coldstarttimeoutfailoverref)   | No       |         | Failover service to route to when the target is not available during cold start.                                                                                      |
+| `replicas`                    | [`*ReplicaStruct`](#replicastruct)                               | No       |         | Minimum and maximum replica counts.                                                                                                                                   |
+| `targetPendingRequests`       | `*int32`                                                         | No       | `100`   | **Deprecated.** Use `scalingMetric` instead. Target metric value for the HPA.                                                                                         |
+| `scaledownPeriod`             | `*int32`                                                         | No       | `300`   | Cooldown period in seconds before resources scale down.                                                                                                               |
+| `initialCooldownPeriod`       | `*int32`                                                         | No       | `0`     | Initial period in seconds before scaling begins.                                                                                                                      |
+| `scalingMetric`               | [`*ScalingMetricSpec`](#scalingmetricspec)                       | No       |         | Configuration for the scaling metric. When empty, concurrency-based scaling is used.                                                                                  |
+| `timeouts`                    | [`*HTTPScaledObjectTimeoutsSpec`](#httpscaledobjecttimeoutsspec) | No       |         | Per-object timeout overrides for the global interceptor timeouts.                                                                                                     |
+
+### `ScaleTargetRef`
+
+| Field        | Type     | Required | Default | Description                                                     |
+| ------------ | -------- | -------- | ------- | --------------------------------------------------------------- |
+| `name`       | `string` | No       |         | Name of the Deployment or StatefulSet to scale.                 |
+| `apiVersion` | `string` | No       |         | API version of the target workload.                             |
+| `kind`       | `string` | No       |         | Kind of the target workload.                                    |
+| `service`    | `string` | Yes      |         | Name of the Kubernetes Service to route to.                     |
+| `port`       | `int32`  | No       |         | Port number on the Service. Mutually exclusive with `portName`. |
+| `portName`   | `string` | No       |         | Named port on the Service. Mutually exclusive with `port`.      |
+
+**Validation:** Exactly one of `port` or `portName` must be set.
+
+### `Header`
+
+| Field   | Type      | Required | Default | Description                                                                                     |
+| ------- | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `name`  | `string`  | Yes      |         | Name of the HTTP header. Minimum length: 1.                                                     |
+| `value` | `*string` | No       |         | Value to match (exact match). If omitted, the header must be present but any value is accepted. |
+
+### `ReplicaStruct`
+
+| Field | Type     | Required | Default | Description            |
+| ----- | -------- | -------- | ------- | ---------------------- |
+| `min` | `*int32` | No       | `0`     | Minimum replica count. |
+| `max` | `*int32` | No       | `100`   | Maximum replica count. |
+
+### `ScalingMetricSpec`
+
+`concurrency` and `requestRate` are mutually exclusive.
+Setting both produces undefined behavior.
+This differs from [InterceptorRoute](../interceptorroute/), which allows both to be set simultaneously.
+
+| Field         | Type                                               | Required | Default | Description                                             |
+| ------------- | -------------------------------------------------- | -------- | ------- | ------------------------------------------------------- |
+| `concurrency` | [`*ConcurrencyMetricSpec`](#concurrencymetricspec) | No       |         | Scale based on concurrent requests.                     |
+| `requestRate` | [`*RateMetricSpec`](#ratemetricspec)               | No       |         | Scale based on average request rate over a time window. |
+
+### `ConcurrencyMetricSpec`
+
+| Field         | Type  | Required | Default | Description                                  |
+| ------------- | ----- | -------- | ------- | -------------------------------------------- |
+| `targetValue` | `int` | No       | `100`   | Target concurrent request count per replica. |
+
+### `RateMetricSpec`
+
+| Field         | Type       | Required | Default | Description                            |
+| ------------- | ---------- | -------- | ------- | -------------------------------------- |
+| `targetValue` | `int`      | No       | `100`   | Target request rate per replica.       |
+| `window`      | `Duration` | No       | `1m`    | Time window for rate calculation.      |
+| `granularity` | `Duration` | No       | `1s`    | Time granularity for rate calculation. |
+
+### `ColdStartTimeoutFailoverRef`
+
+| Field            | Type     | Required | Default | Description                                             |
+| ---------------- | -------- | -------- | ------- | ------------------------------------------------------- |
+| `service`        | `string` | Yes      |         | Name of the failover Service to route to.               |
+| `port`           | `int32`  | No       |         | Port number on the failover Service.                    |
+| `portName`       | `string` | No       |         | Named port on the failover Service.                     |
+| `timeoutSeconds` | `int32`  | No       | `30`    | Seconds to wait before routing to the failover service. |
+
+**Validation:** Exactly one of `port` or `portName` must be set.
+
+### `HTTPScaledObjectTimeoutsSpec`
+
+| Field            | Type       | Required | Default                               | Description                                                                                                       |
+| ---------------- | ---------- | -------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `conditionWait`  | `Duration` | No       | Global `KEDA_CONDITION_WAIT_TIMEOUT`  | Time to wait for the backing workload to reach 1 or more replicas before connecting and sending the HTTP request. |
+| `responseHeader` | `Duration` | No       | Global `KEDA_RESPONSE_HEADER_TIMEOUT` | Time to wait for response headers after the HTTP request is sent to the backing application.                      |
+
+## `status`
+
+| Field            | Type                 | Description                                          |
+| ---------------- | -------------------- | ---------------------------------------------------- |
+| `targetWorkload` | `string`             | Resolved target workload reference.                  |
+| `targetService`  | `string`             | Resolved target service reference.                   |
+| `conditions`     | `[]metav1.Condition` | Conditions of the HTTPScaledObject. Keyed by `type`. |
+
+### Condition types
+
+| Type    | Description                                                           |
+| ------- | --------------------------------------------------------------------- |
+| `Ready` | Whether the HTTPScaledObject is fully reconciled and routing traffic. |

--- a/content/http-add-on/0.14/reference/interceptorroute.md
+++ b/content/http-add-on/0.14/reference/interceptorroute.md
@@ -1,0 +1,143 @@
++++
+title = "InterceptorRoute"
+description = "Field-by-field API reference for the InterceptorRoute custom resource"
++++
+
+|                 |                        |
+| --------------- | ---------------------- |
+| **API version** | `http.keda.sh/v1beta1` |
+| **Kind**        | `InterceptorRoute`     |
+| **Scope**       | Namespaced             |
+
+## Example
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  target:
+    service: my-app-svc
+    port: 8080
+  rules:
+    - hosts:
+        - app.example.com
+      paths:
+        - value: /api
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+```
+
+## `spec`
+
+| Field           | Type                                                    | Required | Default | Description                                                        |
+| --------------- | ------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------ |
+| `target`        | [`TargetRef`](#targetref)                               | Yes      |         | Backend service to route traffic to.                               |
+| `rules`         | [`[]RoutingRule`](#routingrule)                         | No       |         | Routing rules that define how requests are matched to this target. |
+| `scalingMetric` | [`ScalingMetricSpec`](#scalingmetricspec)               | Yes      |         | Metric configuration for autoscaling.                              |
+| `coldStart`     | [`ColdStartSpec`](#coldstartspec)                       | No       |         | Cold start behavior when scaling from zero.                        |
+| `timeouts`      | [`InterceptorRouteTimeouts`](#interceptorroutetimeouts) | No       |         | Timeout configuration for request handling.                        |
+
+For usage guidance, see [Configure Routing Rules](../../user-guide/configure-routing/) and [Configure Scaling Metrics](../../user-guide/configure-scaling/).
+
+### `TargetRef`
+
+Identifies a Service to route traffic to.
+Exactly one of `port` or `portName` must be set.
+
+| Field      | Type     | Required | Default | Description                                                                   |
+| ---------- | -------- | -------- | ------- | ----------------------------------------------------------------------------- |
+| `service`  | `string` | Yes      |         | Name of the Kubernetes Service. Minimum length: 1.                            |
+| `port`     | `int32`  | No       |         | Port number on the Service (1--65535). Mutually exclusive with `portName`.    |
+| `portName` | `string` | No       |         | Named port on the Service. Minimum length: 1. Mutually exclusive with `port`. |
+
+**Validation:** Exactly one of `port` or `portName` must be set.
+Setting both or neither produces a validation error.
+
+### `RoutingRule`
+
+Defines a set of matching criteria for routing requests.
+All specified fields within a single rule use AND semantics (host AND path AND headers must match).
+Multiple rules use OR semantics (any rule can match).
+
+| Field     | Type                            | Required | Default | Description                                                                                                                                                                                                                                           |
+| --------- | ------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hosts`   | `[]string`                      | No       |         | Hostnames to match. Wildcard patterns (e.g., `*.example.com`) are supported. A single `*` acts as a catch-all. Exact matches take priority over wildcards; more specific wildcards (e.g., `*.bar.example.com`) take priority over less specific ones. |
+| `paths`   | [`[]PathMatch`](#pathmatch)     | No       |         | Path prefixes to match. When multiple paths match, the longest prefix wins.                                                                                                                                                                           |
+| `headers` | [`[]HeaderMatch`](#headermatch) | No       |         | Headers that must all match the request (AND semantics).                                                                                                                                                                                              |
+
+### `PathMatch`
+
+| Field   | Type     | Required | Default | Description                                                                        |
+| ------- | -------- | -------- | ------- | ---------------------------------------------------------------------------------- |
+| `value` | `string` | Yes      |         | Path prefix to match against. The longest matching prefix wins. Minimum length: 1. |
+
+### `HeaderMatch`
+
+| Field   | Type      | Required | Default | Description                                                                                    |
+| ------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `name`  | `string`  | Yes      |         | Name of the HTTP header. Minimum length: 1.                                                    |
+| `value` | `*string` | No       |         | Value to match against (exact match). If omitted, matches any value for the given header name. |
+
+### `ScalingMetricSpec`
+
+Defines what metric drives autoscaling.
+At least one of `concurrency` or `requestRate` must be set.
+When both are set, both metrics are reported and KEDA scales based on whichever demands more replicas.
+
+| Field         | Type                                               | Required | Default | Description                              |
+| ------------- | -------------------------------------------------- | -------- | ------- | ---------------------------------------- |
+| `concurrency` | [`*ConcurrencyTargetSpec`](#concurrencytargetspec) | No       |         | Scale based on concurrent request count. |
+| `requestRate` | [`*RequestRateTargetSpec`](#requestratetargetspec) | No       |         | Scale based on request rate.             |
+
+**Validation:** At least one of `concurrency` or `requestRate` must be set.
+
+### `ConcurrencyTargetSpec`
+
+| Field         | Type    | Required | Default | Description                                              |
+| ------------- | ------- | -------- | ------- | -------------------------------------------------------- |
+| `targetValue` | `int32` | Yes      |         | Target concurrent request count per replica. Minimum: 1. |
+
+### `RequestRateTargetSpec`
+
+| Field         | Type       | Required | Default | Description                                                    |
+| ------------- | ---------- | -------- | ------- | -------------------------------------------------------------- |
+| `targetValue` | `int32`    | Yes      |         | Target request rate per replica. Minimum: 1.                   |
+| `window`      | `Duration` | No       | `1m`    | Sliding time window over which the request rate is calculated. |
+| `granularity` | `Duration` | No       | `1s`    | Bucket size for rate calculation within the window.            |
+
+### `ColdStartSpec`
+
+Configures behavior while the target is not ready (scaling from zero).
+
+| Field      | Type                       | Required | Default | Description                                                                                     |
+| ---------- | -------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `fallback` | [`*TargetRef`](#targetref) | Yes      |         | Fallback service to route to when the target is scaling from zero and the wait timeout expires. |
+
+**Validation:** The `fallback` field must be set.
+
+### `InterceptorRouteTimeouts`
+
+Configures per-route request handling timeouts.
+When a field is unset, the global interceptor timeout configuration (`KEDA_HTTP_*_TIMEOUT` environment variables) is used.
+
+| Field            | Type        | Required | Default                                    | Description                                                                                                                                                                                                                                                              |
+| ---------------- | ----------- | -------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `readiness`      | `*Duration` | No       | Global `KEDA_HTTP_READINESS_TIMEOUT`       | Time to wait for the backend to become ready (e.g., scale from zero). Set to `0s` to disable the dedicated readiness deadline so the full request budget is available for cold starts. When a fallback service is configured and this is `0s`, a 30s default is applied. |
+| `request`        | `*Duration` | No       | Global `KEDA_HTTP_REQUEST_TIMEOUT`         | Total time allowed for the entire request lifecycle. Set to `0s` to disable the request deadline.                                                                                                                                                                        |
+| `responseHeader` | `*Duration` | No       | Global `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT` | Maximum time to wait for response headers from the backend after the request has been sent. Does not include cold-start wait time. Set to `0s` to disable the response header deadline.                                                                                  |
+
+## `status`
+
+| Field        | Type                 | Description                                          |
+| ------------ | -------------------- | ---------------------------------------------------- |
+| `conditions` | `[]metav1.Condition` | Conditions of the InterceptorRoute. Keyed by `type`. |
+
+### Condition types
+
+| Type    | Description                                                           |
+| ------- | --------------------------------------------------------------------- |
+| `Ready` | Whether the InterceptorRoute is fully reconciled and routing traffic. |

--- a/content/http-add-on/0.14/reference/metrics.md
+++ b/content/http-add-on/0.14/reference/metrics.md
@@ -1,0 +1,82 @@
++++
+title = "Metrics"
+description = "Reference for all Prometheus metrics exposed by the HTTP Add-on"
++++
+
+The interceptor exposes metrics via OpenTelemetry, with a Prometheus-compatible endpoint enabled by default.
+
+## Endpoint configuration
+
+| Setting | Default    | Description                                    |
+| ------- | ---------- | ---------------------------------------------- |
+| Port    | `2223`     | Configurable via `OTEL_PROM_EXPORTER_PORT`.    |
+| Path    | `/metrics` | Standard Prometheus scrape path.               |
+| Enabled | `true`     | Configurable via `OTEL_PROM_EXPORTER_ENABLED`. |
+
+The interceptor also supports OTLP metric export.
+See [Environment Variables](../environment-variables/#metrics) for configuration.
+
+## Metrics
+
+### Request count
+
+|                          |                                                    |
+| ------------------------ | -------------------------------------------------- |
+| **Prometheus name**      | `interceptor_request_count_total`                  |
+| **OTel instrument name** | `interceptor.request.count`                        |
+| **Type**                 | Counter                                            |
+| **Description**          | Total requests processed by the interceptor proxy. |
+
+**Labels:**
+
+| Label             | Description                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `code`            | HTTP response status code (integer).                                                                                      |
+| `method`          | HTTP request method. Non-standard methods are normalized to `_OTHER` (see [Method normalization](#method-normalization)). |
+| `route_name`      | Name of the matched InterceptorRoute or HTTPScaledObject.                                                                 |
+| `route_namespace` | Namespace of the matched route resource.                                                                                  |
+
+### Request concurrency
+
+|                          |                                                        |
+| ------------------------ | ------------------------------------------------------ |
+| **Prometheus name**      | `interceptor_request_concurrency`                      |
+| **OTel instrument name** | `interceptor.request.concurrency`                      |
+| **Type**                 | UpDownCounter (gauge)                                  |
+| **Description**          | Requests currently in-flight at the interceptor proxy. |
+
+**Labels:**
+
+| Label             | Description                                               |
+| ----------------- | --------------------------------------------------------- |
+| `route_name`      | Name of the matched InterceptorRoute or HTTPScaledObject. |
+| `route_namespace` | Namespace of the matched route resource.                  |
+
+### Request duration
+
+|                          |                                                 |
+| ------------------------ | ----------------------------------------------- |
+| **Prometheus name**      | `interceptor_request_duration_seconds`          |
+| **OTel instrument name** | `interceptor.request.duration`                  |
+| **Type**                 | Histogram                                       |
+| **Unit**                 | Seconds                                         |
+| **Description**          | Time from request received to response written. |
+
+**Bucket boundaries:** `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.25`, `0.5`, `0.75`, `1`, `2.5`, `5`, `7.5`, `10` (following the [OTel HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/)).
+
+**Labels:**
+
+| Label             | Description                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `code`            | HTTP response status code (integer).                                                                                      |
+| `method`          | HTTP request method. Non-standard methods are normalized to `_OTHER` (see [Method normalization](#method-normalization)). |
+| `route_name`      | Name of the matched InterceptorRoute or HTTPScaledObject.                                                                 |
+| `route_namespace` | Namespace of the matched route resource.                                                                                  |
+
+## Method normalization
+
+The `method` label accepts the following standard HTTP methods without modification:
+
+`CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`
+
+All other method values are replaced with `_OTHER` to prevent unbounded label cardinality.

--- a/content/http-add-on/0.14/user-guide/_index.md
+++ b/content/http-add-on/0.14/user-guide/_index.md
@@ -1,0 +1,14 @@
++++
+title = "User Guide"
+description = "Autoscaling, routing, and timeout configuration for HTTP applications"
+weight = 300
++++
+
+Guides for application developers using the HTTP Add-on to autoscale their services.
+
+- **[Autoscale an App](autoscale-an-app/)** — Create a ScaledObject and InterceptorRoute for your service.
+- **[Configure Cold-Start Behavior](configure-cold-start/)** — Fallback services and cold-start response headers.
+- **[Configure Ingress](configure-ingress/)** — Point your Gateway API or Ingress at the interceptor proxy.
+- **[Configure Routing Rules](configure-routing/)** — Host, path, and header matching.
+- **[Configure Scaling Metrics](configure-scaling/)** — Choose between concurrency and request rate metrics.
+- **[Configure Timeouts](configure-timeouts/)** — Per-route timeout overrides.

--- a/content/http-add-on/0.14/user-guide/autoscale-an-app.md
+++ b/content/http-add-on/0.14/user-guide/autoscale-an-app.md
@@ -1,0 +1,132 @@
++++
+title = "Autoscale an App"
+description = "ScaledObject and InterceptorRoute configuration for autoscaling an HTTP service"
++++
+
+This guide walks you through the two resources needed to autoscale an existing HTTP service with the KEDA HTTP Add-on: an `InterceptorRoute` and a KEDA `ScaledObject`.
+
+## Prerequisites
+
+- The HTTP Add-on is [installed](../operations/installation/) in your cluster.
+- You have an existing Deployment (or other workload) and a Service for your HTTP application.
+
+## Step 1: Create an InterceptorRoute
+
+The `InterceptorRoute` tells the interceptor how to route requests to your service and what scaling metrics to report.
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: <your-app>
+  namespace: <your-namespace>
+spec:
+  target:
+    service: <your-service>
+    port: 80
+  rules:
+    - hosts:
+        - <your-hostname>
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+```
+
+Key fields:
+
+- **`target.service`** / **`target.port`** — The Kubernetes Service and port to route traffic to.
+- **`rules[].hosts`** — Hostnames to match against the HTTP `Host` header. This must match what callers send (see [Step 4](#step-4-route-traffic-through-the-interceptor)):
+  - External traffic: your public hostname (e.g., `app.example.com`).
+  - In-cluster traffic: the service name callers use (e.g., `<your-service>-proxy`).
+  - Wildcards like `*.example.com` are supported.
+- **`scalingMetric.concurrency.targetValue`** — Target concurrent requests per replica. KEDA scales replicas so each handles approximately this many concurrent requests.
+
+## Step 2: Create a ScaledObject
+
+The `ScaledObject` tells KEDA how to scale your workload.
+It references the HTTP Add-on's scaler using the `external-push` trigger type.
+
+> **Create the ScaledObject after the InterceptorRoute.** When KEDA reconciles a ScaledObject with an `external-push` trigger, it calls the scaler's `GetMetricSpec` endpoint. If the InterceptorRoute does not exist yet, the scaler returns an empty metric spec and KEDA falls back to a default CPU metric in the HPA, which prevents scale-up from working.
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: <your-app>
+  namespace: <your-namespace>
+spec:
+  scaleTargetRef:
+    name: <your-deployment>
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  cooldownPeriod: 300
+  triggers:
+    - type: external-push
+      metadata:
+        scalerAddress: keda-add-ons-http-external-scaler.keda:9090
+        interceptorRoute: <your-app>
+```
+
+Key fields:
+
+- **`scaleTargetRef.name`** — The name of the Deployment (or StatefulSet, etc.) to scale.
+- **`minReplicaCount`** — Set to `0` for scale-to-zero, or higher to keep a minimum number of replicas running.
+- **`maxReplicaCount`** — Upper bound for the number of replicas.
+- **`cooldownPeriod`** — Seconds to wait before scaling down after traffic stops (default: `300`).
+- **`scalerAddress`** — The HTTP Add-on scaler gRPC service address. If KEDA is installed in a namespace other than `keda`, adjust accordingly.
+- **`interceptorRoute`** — Must match the `metadata.name` of the InterceptorRoute created in the previous step.
+
+## Step 3: Verify
+
+1. Check that the ScaledObject is ready:
+
+   ```shell
+   kubectl get scaledobject <your-app> -n <your-namespace>
+   ```
+
+   The `READY` column should show `True`.
+
+2. Check that the InterceptorRoute is ready:
+
+   ```shell
+   kubectl get interceptorroute <your-app> -n <your-namespace>
+   ```
+
+   The `READY` column should show `True`.
+
+## Step 4: Route Traffic Through the Interceptor
+
+For autoscaling to work, traffic must flow through the interceptor instead of directly to your application.
+This applies to both in-cluster and external traffic.
+
+### In-cluster traffic
+
+If other services in your cluster call your application directly, redirect them to the interceptor proxy service (`keda-add-ons-http-interceptor-proxy` in the `keda` namespace).
+
+Create an `ExternalName` service in your application's namespace so callers can reach the interceptor:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: <your-service>-proxy
+  namespace: <your-namespace>
+spec:
+  type: ExternalName
+  externalName: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+  ports:
+    - port: 8080
+```
+
+Update callers to use `<your-service>-proxy` instead of `<your-service>`.
+The `hosts` in your InterceptorRoute must include the hostname that callers use in the `Host` header — typically the service name (e.g., `<your-service>-proxy` or `<your-service>-proxy.<your-namespace>.svc.cluster.local`).
+
+### External traffic
+
+For traffic entering the cluster from outside, configure your ingress or gateway to point at the interceptor proxy service instead of your application.
+See [Configure Ingress](../configure-ingress/) for Gateway API, Ingress, and Istio examples.
+
+## What's Next
+
+- **[Configure Routing Rules](../configure-routing/)** — Add path prefixes, wildcards, or header matching.
+- **[Configure Scaling Metrics](../configure-scaling/)** — Switch to request rate or use both concurrency and rate metrics.

--- a/content/http-add-on/0.14/user-guide/configure-cold-start.md
+++ b/content/http-add-on/0.14/user-guide/configure-cold-start.md
@@ -1,0 +1,51 @@
++++
+title = "Configure Cold-Start Behavior"
+description = "Fallback services and response headers for cold-start scenarios"
++++
+
+When a request arrives for a backend that has been scaled to zero, the interceptor holds the request until the backend becomes ready.
+You can configure a fallback service and a readiness timeout to control what happens if the backend takes too long to start.
+
+## Cold-start fallback
+
+When the readiness timeout expires during a cold start, the interceptor returns an error by default.
+To serve requests from a fallback service instead, configure the `coldStart.fallback` field:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+  coldStart:
+    fallback:
+      service: <your-fallback-service>
+      port: <your-fallback-port>
+  timeouts:
+    readiness: 5s
+```
+
+When a fallback is configured but the readiness timeout is `0s` (disabled), a 30-second default readiness timeout is applied automatically.
+This prevents the fallback from never being triggered.
+
+## Cold-start response header
+
+The interceptor adds an `X-KEDA-HTTP-Cold-Start` response header to indicate whether a cold start occurred:
+
+- `X-KEDA-HTTP-Cold-Start: true` — the request triggered a scale-from-zero.
+- `X-KEDA-HTTP-Cold-Start: false` — the backend was already running.
+
+This header is enabled by default.
+To disable it, see [Configure the Interceptor](../operations/configure-interceptor/#cold-start-response-header).
+
+## What's Next
+
+- [How Scaling Works](../concepts/scaling/) — cold-start mechanics and scale-from-zero behavior.
+- [Configure Timeouts](../configure-timeouts/) — per-route timeout overrides.
+- [InterceptorRoute Reference](../reference/interceptorroute/) — field details for `coldStart`.

--- a/content/http-add-on/0.14/user-guide/configure-ingress.md
+++ b/content/http-add-on/0.14/user-guide/configure-ingress.md
@@ -1,0 +1,150 @@
++++
+title = "Configure Ingress"
+description = "Gateway API and Ingress configuration for interceptor proxy traffic"
++++
+
+For the HTTP Add-on to intercept and scale your HTTP traffic, external requests must be routed to the **interceptor proxy service** (`keda-add-ons-http-interceptor-proxy`) instead of directly to your application.
+The interceptor then forwards requests to your application based on the InterceptorRoute configuration.
+
+The HTTP Add-on is ingress-agnostic — it works with any ingress controller or Gateway API implementation.
+
+## Using Gateway API
+
+[Gateway API](https://gateway-api.sigs.k8s.io/) is the recommended approach for new Kubernetes clusters.
+
+### Step 1: Create an HTTPRoute
+
+Create an HTTPRoute that sends traffic to the interceptor proxy service:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <your-app>
+  namespace: <your-namespace>
+spec:
+  parentRefs:
+    - name: <your-gateway>
+      namespace: <gateway-namespace>
+  hostnames:
+    - <your-hostname>
+  rules:
+    - backendRefs:
+        - name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
+          port: 8080
+```
+
+The `hostnames` in the HTTPRoute should match the `hosts` in your InterceptorRoute so the interceptor can route the request correctly.
+
+### Step 2: Create a ReferenceGrant
+
+Cross-namespace backend references require a `ReferenceGrant` in the `keda` namespace.
+This grants the HTTPRoute's namespace permission to reference the interceptor service:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-httproute-to-interceptor
+  namespace: keda
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: <your-namespace>
+  to:
+    - group: ""
+      kind: Service
+      name: keda-add-ons-http-interceptor-proxy
+```
+
+If your HTTPRoute is in the same namespace as the interceptor (e.g., `keda`), you do not need a ReferenceGrant.
+
+## Using Kubernetes Ingress
+
+Create an Ingress resource that routes traffic to the interceptor proxy service:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: <your-app>
+  namespace: keda
+spec:
+  rules:
+    - host: <your-hostname>
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: keda-add-ons-http-interceptor-proxy
+                port:
+                  number: 8080
+```
+
+The Ingress resource should be in the same namespace as the interceptor service (default: `keda`).
+If your Ingress must live in a different namespace, create an `ExternalName` Service to reference the interceptor across namespaces.
+
+## Using Istio
+
+Add the interceptor proxy service as a destination in your Istio `VirtualService`:
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: <your-app>
+  namespace: <your-namespace>
+spec:
+  hosts:
+    - <your-hostname>
+  gateways:
+    - <your-gateway>
+  http:
+    - route:
+        - destination:
+            host: keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local
+            port:
+              number: 8080
+```
+
+The `host` field uses the fully qualified service name because the VirtualService and the interceptor are in different namespaces.
+
+> **Note:** Creating the ReferenceGrant shown in the Gateway API section is not required for Istio — Istio's VirtualService uses DNS-based service discovery, not Kubernetes cross-namespace backend references.
+
+## Verifying Traffic Flow
+
+1. Confirm the interceptor proxy service exists:
+
+   ```shell
+   kubectl get svc keda-add-ons-http-interceptor-proxy -n keda
+   ```
+
+2. Find your ingress endpoint.
+   For Gateway API, check the Gateway's address:
+
+   ```shell
+   kubectl get gateway <your-gateway> -n <gateway-namespace> -o jsonpath='{.status.addresses[0].value}'
+   ```
+
+   For Ingress, check the Ingress address:
+
+   ```shell
+   kubectl get ingress <your-app> -n keda -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+   ```
+
+3. Send a test request:
+
+   ```shell
+   curl http://<ingress-address>/
+   ```
+
+4. Verify the request reached your application by checking your application logs or response.
+
+## What's Next
+
+- [Architecture](../concepts/architecture/) — Understand how the interceptor fits into the request flow.
+- [Autoscale an App](../autoscale-an-app/) — Create the ScaledObject and InterceptorRoute resources.

--- a/content/http-add-on/0.14/user-guide/configure-routing.md
+++ b/content/http-add-on/0.14/user-guide/configure-routing.md
@@ -1,0 +1,148 @@
++++
+title = "Configure Routing Rules"
+description = "Host, path, and header matching rules on an InterceptorRoute"
++++
+
+An `InterceptorRoute` uses **rules** to match incoming requests to a target service.
+Each rule can match on hostnames, path prefixes, and headers.
+A request that matches any rule in the list is routed to the target.
+
+## Single host
+
+Route all traffic for a single hostname:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+  rules:
+    - hosts:
+        - api.example.com
+```
+
+## Multiple hosts
+
+Route traffic for several hostnames to the same target:
+
+```yaml
+spec:
+  rules:
+    - hosts:
+        - api.example.com
+        - api.staging.example.com
+```
+
+## Wildcard hosts
+
+Use a wildcard prefix to match any subdomain.
+`*.example.com` matches `foo.example.com`, `bar.baz.example.com`, and so on.
+
+```yaml
+spec:
+  rules:
+    - hosts:
+        - "*.example.com"
+```
+
+A single `*` acts as a catch-all that matches every hostname.
+
+When multiple wildcard patterns match a request, more specific wildcards take priority.
+For example, `*.bar.example.com` wins over `*.example.com`.
+Exact matches always take priority over wildcards.
+
+## Path prefixes
+
+Add path prefixes to narrow a rule to specific URL paths:
+
+```yaml
+spec:
+  rules:
+    - hosts:
+        - api.example.com
+      paths:
+        - value: /api/v1
+        - value: /api/v2
+```
+
+When multiple path prefixes match, the longest prefix wins.
+A request to `/api/v1/users` matches `/api/v1` over `/api`.
+
+## Header matching
+
+Headers use AND semantics — all specified headers must match for the rule to apply.
+
+### Match by exact value
+
+```yaml
+spec:
+  rules:
+    - hosts:
+        - api.example.com
+      headers:
+        - name: X-Route
+          value: canary
+```
+
+### Match by presence
+
+Omit the `value` field to match any request that includes the header, regardless of its value:
+
+```yaml
+spec:
+  rules:
+    - hosts:
+        - api.example.com
+      headers:
+        - name: X-Route
+```
+
+## Multiple rules
+
+An `InterceptorRoute` can have multiple rules.
+A request matching **any** rule is routed to the same target:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+  rules:
+    - hosts:
+        - api.example.com
+      paths:
+        - value: /api
+    - hosts:
+        - admin.example.com
+```
+
+In this example, requests to `api.example.com/api/*` and `admin.example.com/*` both route to the same service.
+
+## Routing priority
+
+When rules from different `InterceptorRoute` resources overlap, the interceptor evaluates them in priority order:
+
+1. Exact host matches beat wildcards.
+2. More specific wildcards beat less specific ones.
+3. Longer path prefixes beat shorter ones.
+4. Header-matching rules beat rules without headers.
+
+For a detailed explanation, see [How Routing Works](../concepts/routing/).
+
+## What's Next
+
+- [InterceptorRoute Reference](../reference/interceptorroute/) — complete field definitions for rules, hosts, paths, and headers.

--- a/content/http-add-on/0.14/user-guide/configure-scaling.md
+++ b/content/http-add-on/0.14/user-guide/configure-scaling.md
@@ -1,0 +1,107 @@
++++
+title = "Configure Scaling Metrics"
+description = "Autoscaling metric configuration on an InterceptorRoute"
++++
+
+The `scalingMetric` field on an `InterceptorRoute` determines what metric drives autoscaling.
+You can scale based on concurrent request count, request rate, or both.
+At least one metric must be set.
+
+## Concurrency metric
+
+Scale based on the number of in-flight requests per replica:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+```
+
+The add-on targets `targetValue` concurrent requests per replica.
+When the total concurrent requests across all replicas exceeds `replicas * targetValue`, KEDA scales up.
+
+| Field         | Required | Description                                  |
+| ------------- | -------- | -------------------------------------------- |
+| `targetValue` | Yes      | Target concurrent request count per replica. |
+
+## Request rate metric
+
+Scale based on requests per second, averaged over a sliding window:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    requestRate:
+      targetValue: 100
+      window: 1m
+      granularity: 1s
+```
+
+| Field         | Required | Description                                                                                                                   |
+| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `targetValue` | Yes      | Target requests per second per replica.                                                                                       |
+| `window`      | `1m`     | Sliding time window over which the average request rate is calculated.                                                        |
+| `granularity` | `1s`     | Bucket size within the window. Smaller granularity gives more responsive scaling at the cost of higher sensitivity to bursts. |
+
+## Using both metrics
+
+An `InterceptorRoute` can set both `concurrency` and `requestRate`.
+KEDA scales to whichever metric demands more replicas.
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    concurrency:
+      targetValue: 50
+    requestRate:
+      targetValue: 200
+```
+
+This is useful when you want to handle both sustained throughput (rate) and bursty traffic (concurrency).
+
+## Scaling boundaries and cooldown
+
+Minimum and maximum replica counts and cooldown are set on the KEDA `ScaledObject`, not the `InterceptorRoute`:
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: my-app
+spec:
+  scaleTargetRef:
+    name: <your-deployment>
+  minReplicaCount: 0 # 0 enables scale-to-zero
+  maxReplicaCount: 10
+  cooldownPeriod: 300 # seconds before scaling to zero after traffic stops
+```
+
+Setting `minReplicaCount: 0` enables scale-to-zero.
+The `cooldownPeriod` controls how long KEDA waits after the last request before scaling the workload down to zero replicas.
+
+## What's Next
+
+- [How Scaling Works](../concepts/scaling/) — the full scaling mechanics, including scale-to-zero and cold starts.
+- [InterceptorRoute Reference](../reference/interceptorroute/) — field details for `scalingMetric`, `concurrency`, and `requestRate`.

--- a/content/http-add-on/0.14/user-guide/configure-timeouts.md
+++ b/content/http-add-on/0.14/user-guide/configure-timeouts.md
@@ -1,0 +1,60 @@
++++
+title = "Configure Timeouts"
+description = "Per-route timeout configuration"
++++
+
+You can override the cluster-wide timeout defaults on individual routes using the `InterceptorRoute` spec.
+For global timeout defaults, see [Configure the Interceptor](../operations/configure-interceptor/#timeouts).
+
+## Timeout types
+
+| Timeout             | Description                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Request**         | Total deadline for the entire request lifecycle, from arrival to response completion.                                                |
+| **Response header** | Maximum time to wait for the backend to send response headers after the request is forwarded. Does not include cold-start wait time. |
+| **Readiness**       | Maximum time to wait for the backend to become ready during a cold start (scale from zero).                                          |
+
+## Per-route overrides
+
+Override timeouts for a specific route via the `InterceptorRoute` spec:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: <your-service>
+    port: <your-port>
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+  timeouts:
+    request: 60s
+    responseHeader: 30s
+    readiness: 10s
+```
+
+### Override semantics
+
+- When a timeout field is **omitted** (not set) in the `InterceptorRoute`, the global default applies.
+- When a timeout field is set to **`0s`**, that timeout is disabled for this route.
+- When a timeout field is set to a **positive value**, it overrides the global default for this route.
+
+## Timeout errors
+
+When a timeout is exceeded, the interceptor returns one of these HTTP status codes:
+
+| Condition                                        | HTTP status           |
+| ------------------------------------------------ | --------------------- |
+| Request timeout exceeded                         | `504 Gateway Timeout` |
+| Response header timeout exceeded                 | `504 Gateway Timeout` |
+| Readiness timeout exceeded (no fallback)         | `504 Gateway Timeout` |
+| Backend error (non-timeout failure, no fallback) | `502 Bad Gateway`     |
+
+## What's Next
+
+- [Configure Cold-Start Behavior](../configure-cold-start/) — fallback services and cold-start response headers.
+- [Configure the Interceptor](../operations/configure-interceptor/#timeouts) — global timeout defaults.
+- [InterceptorRoute Reference](../reference/interceptorroute/) — field details for `timeouts`.

--- a/content/http-add-on/_index.md
+++ b/content/http-add-on/_index.md
@@ -1,0 +1,4 @@
+---
+build:
+  render: false
+---

--- a/layouts/http-add-on/list.html
+++ b/layouts/http-add-on/list.html
@@ -1,0 +1,3 @@
+{{ define "main" -}}
+  {{ partial "article.html" . }}
+{{ end -}}

--- a/layouts/http-add-on/single.html
+++ b/layouts/http-add-on/single.html
@@ -1,0 +1,3 @@
+{{ define "main" -}}
+  {{ partial "article.html" . }}
+{{ end -}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,7 +1,8 @@
 {{ $docsLatest := index site.Params.versions.docs 0 -}}
+{{ $httpAddonLatest := index (index site.Params.versions "http-add-on") 0 -}}
 
-/docs     /docs/{{ $docsLatest }}     301!
-/docs/latest/*     /docs/{{ $docsLatest }}/:splat
+/docs            /docs/{{ $docsLatest }}     302
+/docs/latest/*   /docs/{{ $docsLatest }}/:splat     302
 
 {{ $topLevel := slice "scalers" "faq" "troubleshooting" "operate" "concepts" "deploy" -}}
 {{ range $name := $topLevel -}}
@@ -9,6 +10,9 @@
 {{ $name | printf "/%-29s" }}  /docs/{{ $docsLatest }}/{{ $name }}     301!
 {{ $docp | printf "/%-29s" }}  /docs/{{ $docsLatest }}/{{ $name }}/:splat
 {{ end -}}
+
+/http-add-on             /http-add-on/{{ $httpAddonLatest }}     302
+/http-add-on/latest/*    /http-add-on/{{ $httpAddonLatest }}/:splat     302
 
 {{ $scalers    := where site.RegularPages "Section" "scalers" -}}
 {{- range $scalers -}}

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -27,6 +27,8 @@
             {{ $url := "" }}
             {{ if (hasPrefix .URL "/docs") }}
             {{ $url = replaceRE "/docs" (printf "/docs/%s" $docsL) .URL }}
+            {{ else if (hasPrefix .URL "/http-add-on/") }}
+            {{ $url = replace .URL "/http-add-on/" "/http-add-on/latest/" }}
             {{ else }}
             {{ $url = .URL }}
             {{ end }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,5 +1,5 @@
 {{ $here           := .RelPermalink }}
-{{ $docs           :=  where site.Sections "Section" "docs" }}
+{{ $docs           :=  where site.Sections "Section" .Section }}
 {{ $currentSection := .CurrentSection }}
 {{ $root           := .FirstSection }}
 {{ $thisVersion    := index (split .File.Path "/") 1 }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -5,8 +5,6 @@
 {{ $docs     := site.Menus.docs }}
 {{ $social   := site.Params.social }}
 {{ $scalers  := where site.RegularPages ".CurrentSection.Title" "Scalers" }}
-{{ $versions := site.Params.versions.docs }}
-{{ $latest   := index $versions 0 }}
 <nav id="mainnav" style="padding:10px" class="navbar is-transparent has-background-pattern is-fixed-top" role="navigation" aria-label="main navigation" x-data="{ open: false, scrolled: false }" @scroll.window="scrolled = window.scrollY > $el.offsetHeight" :class="{ 'scrolled': scrolled }">
   <div class="container">
     <div class="navbar-brand is-left-padded" style="align-items: end;">
@@ -45,12 +43,12 @@
         </div>
         
         {{ define "main_nav_item" }}
-        {{ $versions := site.Params.versions.docs }}
-        {{ $latest   := index $versions 0 }}
-        {{ $url := replaceRE "/docs" (printf "/docs/%s" $latest) .URL }}
+        {{ $url := replace .URL "/docs" "/docs/latest" }}
+        {{ $url  = replace $url "/http-add-on/" "/http-add-on/latest/" }}
         {{ $isExternal := hasPrefix .URL "http" }}
+        {{ if .Params.prependDivider }}<hr class="navbar-divider">{{ end }}
         <div class="navbar-item is-size-5-desktop has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless"{{ with .URL }} href="{{ $url }}"{{ end }} {{ if $isExternal }} target="_blank"{{ end }}>
+          <a class="navbar-link is-arrowless"{{ with $url }} href="{{ . }}"{{ end }} {{ if $isExternal }} target="_blank"{{ end }}>
             <span>
               {{ .Name }}
             </span>
@@ -79,8 +77,10 @@
         {{ range $docs }}
         {{ $isExternal := hasPrefix .URL "http" }}
         {{ if .HasChildren }}
+        {{ $url := replace .URL "/docs" "/docs/latest" }}
+        {{ $url  = replace $url "/http-add-on/" "/http-add-on/latest/" }}
         <div class="docs-menu--desktop navbar-item is-size-5-desktop has-dropdown is-hoverable">
-          <a class="navbar-link is-arrowless"{{ with .URL }} href="{{ . }}{{ $latest }}"{{ end }}>
+          <a class="navbar-link is-arrowless"{{ with $url }} href="{{ . }}"{{ end }}>
             <span>
               {{ .Name }}
             </span>
@@ -91,8 +91,10 @@
 
           <div class="navbar-dropdown is-radiusless">
             {{ range .Children }}
-            {{ $url := replaceRE "/docs" (printf "/docs/%s" $latest) .URL }}
             {{ $isExternal := hasPrefix .URL "http" }}
+            {{ $url := replace .URL "/docs" "/docs/latest" }}
+            {{ $url  = replace $url "/http-add-on/" "/http-add-on/latest/" }}
+            {{ if .Params.prependDivider }}<hr class="navbar-divider">{{ end }}
             <a class="navbar-item" href="{{ $url }}"{{ if $isExternal }} target="_blank"{{ end }}>
               <span>
                 {{ .Name }}


### PR DESCRIPTION
Add the HTTP Add-on docs based on the existing docs from the addon repo but greatly improved and extended, e.g. including a HTTPSO->IR migration guide.
References to the addon were added to the navbar and the KEDA docs in the sidebar.

The plan is that the HTTP Add-on docs will be removed immediately after merging this, the new docs contain everything relevant IMO (=almost everything from the old docs).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] add http addon to buttons on main page
- [x] consider referencing developer docs or including them, see https://github.com/kedacore/http-add-on/blob/main/docs/developing.md or CONTRIBUTING.md

Fixes #548 
Fixes https://github.com/kedacore/http-add-on/issues/1516
