### PR TITLE
chore: configure renovate for monthly PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,35 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    // See https://docs.renovatebot.com/presets-config/#configbest-practices
+    "config:best-practices",
+    "customManagers:githubActionsVersions",
+    "schedule:monthly",
+    ":gitSignOff",
+    ":prHourlyLimitNone",
+  ],
+  commitBodyTable: true,
+  labels: ["dependencies"],
+  // Experimental: OSV-based vulnerability alerts for direct dependencies
+  osvVulnerabilityAlerts: true,
+  postUpdateOptions: ["npmDedupe"],
+  packageRules: [
+    {
+      matchManagers: ["github-actions"],
+      groupName: "GitHub Actions",
+    },
+    {
+      matchManagers: ["npm"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "npm Dependencies (non-major)",
+    },
+    {
+      matchFileNames: [".devcontainer/**"],
+      pinDigests: false,
+    },
+  ],
+  vulnerabilityAlerts: {
+    enabled: true,
+    addLabels: ["security"],
+  },
+}


### PR DESCRIPTION
Enable automated dependency updates with monthly schedule, grouped npm minor/patch PRs, and vulnerability alerts.
Groups are configured to reduce dependency upgrade noise - fine granular groups can always be created later.

Not sure if we want that, I usually prefer renovate over dependabot - config is based on the HTTP Addon Repo.

### Changes
- Add Renovate config with best-practices preset
- Group GitHub Actions updates into a single PR
- Group npm non-major updates into a single PR
- Enable npmDedupe and OSV vulnerability alerts


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

