### PR TITLE
fix: make HTTP Add-on and blog pages searchable via DocSearch

### DIFF
--- a/assets/js/docsearch.js
+++ b/assets/js/docsearch.js
@@ -1,15 +1,32 @@
 import docsearch from "@docsearch/js";
 import * as params from "@params";
 
-const latest = params.latest;
-let currentVersion = latest;
-
-// Extract docs version from URL path (/docs/{version}/...).
-// Non-docs pages default to the latest version for search filtering.
-const pathSegments = window.location.pathname.split("/");
-if (pathSegments[1] === "docs") {
-  currentVersion = pathSegments[2];
+function meta(name) {
+  const element = document.querySelector(`meta[name="docsearch:${name}"]`);
+  return element ? element.content : "";
 }
+
+const currentProduct = meta("product");
+const currentVersion = meta("version");
+
+// Start with the latest version of each product (from Hugo config),
+// then override the current product with the version we're actually viewing.
+const versions = {
+  docs: params.latestDocs,
+  "http-add-on": params.latestHttpAddon,
+};
+if (currentProduct in versions && currentVersion) {
+  versions[currentProduct] = currentVersion;
+}
+
+// Build a compound filter so results from both products are always discoverable,
+// each scoped to the version the user is currently viewing.
+const parts = Object.entries(versions).map(
+  ([product, version]) => `(product:"${product}" AND version:${version})`,
+);
+// Always include blog posts in the search results
+parts.push("product:blog");
+const filters = parts.join(" OR ");
 
 try {
   docsearch({
@@ -18,7 +35,7 @@ try {
     indices: [
       {
         name: params.indexName,
-        searchParameters: { facetFilters: [`version: ${currentVersion}`] },
+        searchParameters: { filters: filters },
       },
     ],
     container: "#navbar-search",

--- a/layouts/partials/blog/post-hero.html
+++ b/layouts/partials/blog/post-hero.html
@@ -14,11 +14,12 @@
 {{ errorf "no author specified in the post you created in content/%s" .File.Path }}
 {{ end }}
 
+<span class="docsearch-lvl0" hidden>Blog</span>
 <section class="hero is-dark is-medium has-background-pattern">
   <div class="hero-body">
     <div class="container">
       <p class="title is-size-1 is-size-2-mobile has-text-weight-bold is-spaced">
-        {{ $title }}
+        <span class="title-text">{{ $title }}</span>
       </p>
 
       <p class="subtitle is-size-2 is-size-3-mobile">

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -9,6 +9,8 @@
 {{ $latest        := index (index site.Params.versions .Section) 0 }}
 {{ $isLatest      := eq $version $latest }}
 {{ $isNextVersion := not (in (index site.Params.versions .Section) $version) }}
+{{ $productNames  := dict "docs" "KEDA" "http-add-on" "HTTP Add-on" }}
+{{ $productName   := index $productNames .Section }}
 
 <!-- Check if latest version of this page exists -->
 {{ $latestUrl := replaceRE $version $latest .RelPermalink }}
@@ -19,11 +21,12 @@
   {{ end }}
 {{ end }}
 
+<span class="docsearch-lvl0" hidden>{{ $productName }} v{{ $version }}</span>
 <section class="hero">
   <div class="hero-body">
     <div class="container">
       <p class="title is-size-1 is-size-2-mobile has-text-weight-bold{{ if $desc }} is-spaced{{ end }}">
-        {{ $title }}
+        <span class="title-text">{{ $title }}</span>
         <sup>
           {{ if $isLatest }}
           <span class="tag is-success">Latest</span>

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -10,8 +10,11 @@
 {{ end }}
 
 {{/* DocSearch */}}
-{{ $latest := index site.Params.versions.docs 0 }}
-{{ $docsearchOpts := dict "targetPath" "js/docsearch.js" "params" (dict "latest" $latest "apiKey" site.Params.docsearch.apiKey "appId" site.Params.docsearch.appId "indexName" site.Params.docsearch.indexName) }}
+{{ $latestDocs := index site.Params.versions.docs 0 }}
+{{ $latestHttpAddon := "" }}
+{{ with index site.Params.versions "http-add-on" }}{{ $latestHttpAddon = index . 0 }}{{ end }}
+{{ $dsParams := dict "latestDocs" $latestDocs "latestHttpAddon" $latestHttpAddon "apiKey" site.Params.docsearch.apiKey "appId" site.Params.docsearch.appId "indexName" site.Params.docsearch.indexName }}
+{{ $docsearchOpts := dict "targetPath" "js/docsearch.js" "params" $dsParams }}
 {{ $docsearch := resources.Get "js/docsearch.js" | js.Build $docsearchOpts }}
 {{ if $inDevMode }}
 <script src="{{ $docsearch.RelPermalink }}" defer></script>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -24,8 +24,9 @@ When $version is a released version that is not the latest,
 add a "noindex" meta tag to exclude it from search engines.
 Unreleased and latest versions remain indexable.
 */}}
-{{ if and (ne $version "") (eq .Section "docs") }}
-{{ $isOldVersion := and (in site.Params.versions.docs $version) (ne $version $latestVersion) }}
+{{ $sectionVersions := index site.Params.versions .Section }}
+{{ if and (ne $version "") $sectionVersions }}
+{{ $isOldVersion := and (in $sectionVersions $version) (ne $version (index $sectionVersions 0)) }}
 {{ if $isOldVersion }}
 <meta name="robots" content="noindex">
 {{ end }}
@@ -39,6 +40,7 @@ Unreleased and latest versions remain indexable.
 <meta name="twitter:image:alt" content="{{ $imgAlt }}">
 
 <meta name="docsearch:language" content="en" />
+<meta name="docsearch:product" content="{{ .Section }}" />
 <meta name="docsearch:version" content="{{ $version }}" />
 
 {{/* OpenGraph metadata */}}


### PR DESCRIPTION
DocSearch filtered results by a single version facet, which only worked for KEDA docs pages. HTTP Add-on and blog pages were excluded because their version values never matched the docs version filter.

### Before and After
If my understanding is correct, this is the before and after:
<img width="515" height="450" alt="image" src="https://github.com/user-attachments/assets/dbf34928-fc39-480a-a2cf-78a270b3c4da" />


### Changes 
- Add docsearch:product meta tag to distinguish docs, http-add-on, and blog records in the Algolia index
- Switch from facetFilters to a compound filters expression that scopes each product to its own version while always including blog
- Read current product/version from DOM meta tags instead of parsing URL paths
- Make the noindex logic section-aware so future old HTTP Add-on versions get excluded from search engines
- Add hidden .docsearch-lvl0 elements to hero templates so search results are grouped by product and version (e.g., "KEDA v2.19")
- Wrap hero title text in .title-text span to exclude badge text ("Latest", "Click here for latest") from search index
	- See `"value": "penp3nAutoscale</span> an App\nLatest",` from example below for example

The Algolia crawler config also needs updating (applied manually) followed by a reindex **after the merge (I will change that)**:
```diff
--- a/crawler.ts
+++ b/crawler.ts
@@ recordProps
-  lvl0: {
-    selectors: ".hero .title",
-    defaultValue: "KEDA",
-  },
-  lvl1: ".hero .title",
+  lvl0: {
+    selectors: ".docsearch-lvl0",
+    defaultValue: "KEDA",
+  },
+  lvl1: ".hero .title-text",
@@ initialIndexSettings.keda
-  attributesForFaceting: ["type", "lang", "language", "version"],
+  attributesForFaceting: ["type", "lang", "language", "version", "product"],
```

### Example that shows the filter works (without product as not indexed yet)
```console
❯ curl "https://3IFB1FERQT-dsn.algolia.net/1/indexes/keda?query=autoscale&filters=version:2.19%20OR%20version:0.14&hitsPerPage=5&attributesToRetrieve=url,version" \
  -H "X-Algolia-Application-Id: 3IFB1FERQT" \
  -H "X-Algolia-API-Key: 0e8dd1123a0df5e715fc587ee0930782" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3177  100  3177    0     0  42357      0 --:--:-- --:--:-- --:--:-- 42932
{
  "hits": [
    {
      "version": [
        "0.14"
      ],
      "url": "https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/",
      "objectID": "0-https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/",
      "_highlightResult": {
        "hierarchy": {
          "lvl0": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl1": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          }
        }
      }
    },
    {
      "version": [
        "0.14"
      ],
      "url": "https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/#prerequisites",
      "objectID": "2-https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/",
      "_highlightResult": {
        "hierarchy": {
          "lvl0": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl1": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl2": {
            "value": "Prerequisites",
            "matchLevel": "none",
            "matchedWords": []
          }
        }
      }
    },
    {
      "version": [
        "0.14"
      ],
      "url": "https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/#step-1-create-an-interceptorroute",
      "objectID": "4-https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/",
      "_highlightResult": {
        "hierarchy": {
          "lvl0": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl1": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl2": {
            "value": "Step 1: Create an InterceptorRoute",
            "matchLevel": "none",
            "matchedWords": []
          }
        }
      }
    },
    {
      "version": [
        "0.14"
      ],
      "url": "https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/#step-2-create-a-scaledobject",
      "objectID": "6-https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/",
      "_highlightResult": {
        "hierarchy": {
          "lvl0": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl1": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl2": {
            "value": "Step 2: Create a ScaledObject",
            "matchLevel": "none",
            "matchedWords": []
          }
        }
      }
    },
    {
      "version": [
        "0.14"
      ],
      "url": "https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/#step-3-verify",
      "objectID": "8-https://keda.sh/http-add-on/0.14/user-guide/autoscale-an-app/",
      "_highlightResult": {
        "hierarchy": {
          "lvl0": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl1": {
            "value": "penp3nAutoscale</span> an App\nLatest",
            "matchLevel": "full",
            "fullyHighlighted": false,
            "matchedWords": [
              "autoscale"
            ]
          },
          "lvl2": {
            "value": "Step 3: Verify",
            "matchLevel": "none",
            "matchedWords": []
          }
        }
      }
    }
  ],
  "nbHits": 71,
  "page": 0,
  "nbPages": 15,
  "hitsPerPage": 5,
  "exhaustiveNbHits": false,
  "exhaustiveTypo": false,
  "exhaustive": {
    "nbHits": false,
    "typo": false
  },
  "query": "autoscale",
  "params": "query=autoscale&filters=version:2.19%20OR%20version:0.14&hitsPerPage=5&attributesToRetrieve=url,version",
  "renderingContent": {},
  "processingTimeMS": 5,
  "processingTimingsMS": {
    "_request": {
      "roundTrip": 20
    },
    "fetch": {
      "query": 4,
      "total": 5
    },
    "total": 5
  },
  "serverTimeMS": 6
}
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

See https://github.com/kedacore/http-add-on/issues/1516
