### PR TITLE
fix: use composite tag facet for DocSearch filtering

### DIFF
--- a/assets/js/docsearch.js
+++ b/assets/js/docsearch.js
@@ -6,27 +6,23 @@ function meta(name) {
   return element ? element.content : "";
 }
 
+const currentTag = meta("tag");
 const currentProduct = meta("product");
-const currentVersion = meta("version");
 
-// Start with the latest version of each product (from Hugo config),
-// then override the current product with the version we're actually viewing.
-const versions = {
-  docs: params.latestDocs,
-  "http-add-on": params.latestHttpAddon,
+// Each tag encodes product + version in one value (e.g. "docs-2.19").
+// This avoids needing a cross-attribute filter like (product AND version)
+// which Algolia's filter syntax does not support in OR groups.
+const tags = {
+  docs: "docs-" + params.latestDocs,
+  "http-add-on": "http-add-on-" + params.latestHttpAddon,
 };
-if (currentProduct in versions && currentVersion) {
-  versions[currentProduct] = currentVersion;
+if (currentProduct in tags && currentTag) {
+  tags[currentProduct] = currentTag;
 }
 
-// Build a compound filter so results from both products are always discoverable,
-// each scoped to the version the user is currently viewing.
-const parts = Object.entries(versions).map(
-  ([product, version]) => `(product:"${product}" AND version:${version})`,
-);
-// Always include blog posts in the search results
-parts.push("product:blog");
-const filters = parts.join(" OR ");
+const facetFilters = Object.values(tags)
+  .map((tag) => "tag:" + tag)
+  .concat("tag:blog");
 
 try {
   docsearch({
@@ -35,7 +31,7 @@ try {
     indices: [
       {
         name: params.indexName,
-        searchParameters: { filters: filters },
+        searchParameters: { facetFilters: [facetFilters] },
       },
     ],
     container: "#navbar-search",

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -8,8 +8,11 @@
 {{ $img           := "img/logos/keda-icon-color.png" | absURL }}
 {{ $imgAlt        := printf "%s color logo" site.Title }}
 {{ $locale        := site.Params.locale }}
+{{ $sectionVersions := index site.Params.versions .Section }}
 {{ $version       := "" }}
+{{ if $sectionVersions }}
 {{ with .File }}{{ $version = index (split .Path "/") 1 }}{{ end }}
+{{ end }}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
@@ -24,8 +27,7 @@ When $version is a released version that is not the latest,
 add a "noindex" meta tag to exclude it from search engines.
 Unreleased and latest versions remain indexable.
 */}}
-{{ $sectionVersions := index site.Params.versions .Section }}
-{{ if and (ne $version "") $sectionVersions }}
+{{ if ne $version "" }}
 {{ $isOldVersion := and (in $sectionVersions $version) (ne $version (index $sectionVersions 0)) }}
 {{ if $isOldVersion }}
 <meta name="robots" content="noindex">
@@ -39,9 +41,12 @@ Unreleased and latest versions remain indexable.
 <meta name="twitter:image" content="{{ $img }}">
 <meta name="twitter:image:alt" content="{{ $imgAlt }}">
 
+{{ $tag := .Section }}
+{{ if ne $version "" }}{{ $tag = printf "%s-%s" .Section $version }}{{ end }}
 <meta name="docsearch:language" content="en" />
 <meta name="docsearch:product" content="{{ .Section }}" />
 <meta name="docsearch:version" content="{{ $version }}" />
+<meta name="docsearch:tag" content="{{ $tag }}" />
 
 {{/* OpenGraph metadata */}}
 <meta property="og:url" content="{{ $url }}">


### PR DESCRIPTION
Algolia's filter syntax does not support (A AND B) OR (C AND D), which broke cross-product version filtering. Encoding product + version into a single "tag" facet value (e.g. "docs-2.19") sidesteps this by using a simple OR-based facetFilters array. This seems to be the common pattern for solving this, docusaurus does it like that as well.

Algolia guys [say](https://github.com/algolia/algoliasearch-client-php/issues/385#issuecomment-376578590) the original problem exists as they want to prevent performance problems, solution is usually adjusting indexing which is what we do here.

Also scopes $version extraction to sections that actually have versions configured, preventing blog filenames from being treated as versions.



### Changes
- Switch docsearch.js from filters to facetFilters with composite tags
- Add docsearch:tag meta tag to meta.html
- Guard $version extraction with $sectionVersions check

Crawler config change (applied manually by me after the merge):
- ~Add "tag" to attributesForFaceting~ - done
- Reindex again afterwards

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

See https://github.com/kedacore/http-add-on/issues/1516