### PR TITLE
Document OTEL empty upstream response metric

### DIFF
--- a/content/docs/2.20/integrations/opentelemetry.md
+++ b/content/docs/2.20/integrations/opentelemetry.md
@@ -40,6 +40,7 @@ The following metrics are being gathered:
 | `keda.scaler.metrics.latency.seconds` | The latency of retrieving current metric from each scaler. |
 | `keda.scaler.errors` | The number of errors that have occurred for each scaler. |
 | `keda.scaler.errors.total` | The total number of errors encountered for all scalers. |
+| `keda.scaler.empty.upstream.responses` | The number of times a scaler query returned an empty result from its upstream source, such as a Prometheus query returning no results. |
 | `keda.scaled.object.errors` | The number of errors that have occurred for each ScaledObject. |
 | `keda.scaled.job.errors` | The number of errors that have occurred for each ScaledJob. |
 | `keda.resource.registered.count` | Total number of KEDA custom resources per namespace for each custom resource type (CRD). |
@@ -47,6 +48,8 @@ The following metrics are being gathered:
 | `keda.internal.scale.loop.latency.seconds` | Total deviation between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. |
 | `keda.cloudeventsource.events.emitted.count` | Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state. |
 | `keda.cloudeventsource.events.queued` | The number of events that are in the emitting queue. |
+
+The `keda.scaler.empty.upstream.responses` metric includes the `namespace`, `scaledResource`, `triggerName`, `metricName`, `resourceType`, and `ignoreNullValues` attributes so you can identify which scaler emitted the empty upstream response.
 
 #### Deprecated metrics
 

--- a/content/docs/2.20/integrations/opentelemetry.md
+++ b/content/docs/2.20/integrations/opentelemetry.md
@@ -49,8 +49,6 @@ The following metrics are being gathered:
 | `keda.cloudeventsource.events.emitted.count` | Measured emitted cloudevents with destination of this emitted event (eventsink) and emitted state. |
 | `keda.cloudeventsource.events.queued` | The number of events that are in the emitting queue. |
 
-The `keda.scaler.empty.upstream.responses` metric includes the `namespace`, `scaledResource`, `triggerName`, `metricName`, `resourceType`, and `ignoreNullValues` attributes so you can identify which scaler emitted the empty upstream response.
-
 #### Deprecated metrics
 
 The following metrics are exposed as well, but are deprecated and will be removed in KEDA v2.16.


### PR DESCRIPTION
## Summary

Adds documentation for the OpenTelemetry metric introduced by kedacore/keda#7671:
- `keda.scaler.empty.upstream.responses`
- documents that it is emitted when a scaler query returns an empty upstream result
- documents the emitted attributes: `namespace`, `scaledResource`, `triggerName`, `metricName`, `resourceType`, and `ignoreNullValues`

Requested from the review thread on kedacore/keda#7671: https://github.com/kedacore/keda/pull/7671#issuecomment-4322442887
