### PR TITLE
docs: document awsExternalId parameter for cross-account AssumeRole

### DIFF
--- a/content/docs/2.20/authentication-providers/aws.md
+++ b/content/docs/2.20/authentication-providers/aws.md
@@ -214,7 +214,6 @@ spec:
   podIdentity:
     externalID: "YOUR_UNIQUE_EXTERNAL_ID"
     roleArn: "arn:aws:iam::ACCOUNT:role/WORKLOAD_ROLE"
-    
 ```
 
 > ℹ️ **NOTE:** `externalId` is optional. If not set, KEDA calls `AssumeRole` without an ExternalId, which is the default behavior. `externalId` is only applied to `AssumeRole` — `AssumeRoleWithWebIdentity` does not accept an ExternalId parameter.

--- a/content/docs/2.20/authentication-providers/aws.md
+++ b/content/docs/2.20/authentication-providers/aws.md
@@ -175,3 +175,59 @@ This policy attached to KEDA's role will allow KEDA to assume other roles, now y
   ]
 }
 ```
+
+#### Cross-account isolation with ExternalId
+
+In multi-tenant environments where a shared KEDA operator assumes roles in different accounts, you can enforce [confused deputy protection](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) by requiring an `ExternalId` in the workload role's trust policy.
+
+Add the `sts:ExternalId` condition to the workload role's trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::ACCOUNT:role/KEDA_ROLE_NAME"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "YOUR_UNIQUE_EXTERNAL_ID"
+        }
+      }
+    }
+  ]
+}
+```
+
+Then pass the `awsExternalId` via `TriggerAuthentication.secretTargetRef` alongside `awsRoleArn`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-aws-creds
+  namespace: my-namespace
+type: Opaque
+stringData:
+  AWS_ROLE_ARN: "arn:aws:iam::ACCOUNT:role/WORKLOAD_ROLE"
+  AWS_EXTERNAL_ID: "YOUR_UNIQUE_EXTERNAL_ID"
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: aws-trigger-auth
+  namespace: my-namespace
+spec:
+  secretTargetRef:
+    - parameter: awsRoleArn
+      name: keda-aws-creds
+      key: AWS_ROLE_ARN
+    - parameter: awsExternalId
+      name: keda-aws-creds
+      key: AWS_EXTERNAL_ID
+```
+
+> ℹ️ **NOTE:** `awsExternalId` is optional. If not set, KEDA calls `AssumeRole` without an ExternalId, which is the default behavior. `awsExternalId` is only applied to `AssumeRole` — `AssumeRoleWithWebIdentity` does not accept an ExternalId parameter.

--- a/content/docs/2.20/authentication-providers/aws.md
+++ b/content/docs/2.20/authentication-providers/aws.md
@@ -202,32 +202,19 @@ Add the `sts:ExternalId` condition to the workload role's trust policy:
 }
 ```
 
-Then pass the `awsExternalId` via `TriggerAuthentication.secretTargetRef` alongside `awsRoleArn`:
+Then pass the `externalId` via `TriggerAuthentication.podIdentity.externalID` alongside `roleArn`:
 
 ```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: keda-aws-creds
-  namespace: my-namespace
-type: Opaque
-stringData:
-  AWS_ROLE_ARN: "arn:aws:iam::ACCOUNT:role/WORKLOAD_ROLE"
-  AWS_EXTERNAL_ID: "YOUR_UNIQUE_EXTERNAL_ID"
----
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: aws-trigger-auth
   namespace: my-namespace
 spec:
-  secretTargetRef:
-    - parameter: awsRoleArn
-      name: keda-aws-creds
-      key: AWS_ROLE_ARN
-    - parameter: awsExternalId
-      name: keda-aws-creds
-      key: AWS_EXTERNAL_ID
+  podIdentity:
+    externalID: "YOUR_UNIQUE_EXTERNAL_ID"
+    roleArn: "arn:aws:iam::ACCOUNT:role/WORKLOAD_ROLE"
+    
 ```
 
-> ℹ️ **NOTE:** `awsExternalId` is optional. If not set, KEDA calls `AssumeRole` without an ExternalId, which is the default behavior. `awsExternalId` is only applied to `AssumeRole` — `AssumeRoleWithWebIdentity` does not accept an ExternalId parameter.
+> ℹ️ **NOTE:** `externalId` is optional. If not set, KEDA calls `AssumeRole` without an ExternalId, which is the default behavior. `externalId` is only applied to `AssumeRole` — `AssumeRoleWithWebIdentity` does not accept an ExternalId parameter.


### PR DESCRIPTION
Added documentation for the new `awsExternalId` parameter in `TriggerAuthentication`, which enables confused deputy protection for multi-tenant environments where a shared KEDA operator assumes roles in different AWS accounts.

Added under "Using KEDA role to assume workload role using AssumeRole" in the AWS auth provider page (`docs/2.20/authentication-providers/aws.md`), with:
 - Trust policy example with `sts:ExternalId` condition
 - TriggerAuthentication example using `secretTargetRef`
 - Note that `awsExternalId` is optional and only applies to `AssumeRole` (not `AssumeRoleWithWebIdentity`)

 ### Checklist
 - [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to kedacore/keda#7665