### PR TITLE
chore(ci): simplify npm cache configuration in check-links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,16 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Create NPM cache-hash input file
-        run: |
-          mkdir -p tmp
-          jq '{devDependencies, engines, gitHubActionCacheKey}' package.json > tmp/package-ci.json
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: npm
-          cache-dependency-path: tmp/package-ci.json
 
       - run: npm install --omit=optional
 


### PR DESCRIPTION
The custom cache-hash step extracted a subset of package.json fields into a temporary file for the cache key. Using the default package-lock.json is simpler.

Changes:
- Remove "Create NPM cache-hash input file" step
- Remove custom cache-dependency-path from setup-node

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
