### PR TITLE
fix: reduce unused whitespace and allow scrollable tables

### DIFF
--- a/assets/sass/content.sass
+++ b/assets/sass/content.sass
@@ -1,3 +1,9 @@
+.doc-hero
+  margin-bottom: 1.5rem
+
+  .title sup
+    line-height: 0
+
 .content
   a sup
     margin-left: 0.1rem
@@ -7,6 +13,12 @@
 
   .highlight
     margin-bottom: 1rem
+
+  // Allow horizontal scrolling for larger tables
+  table
+    display: block
+    overflow-x: auto
+    max-width: 100%
 
   &.is-constrained
     max-width: 90ch

--- a/assets/sass/nav.sass
+++ b/assets/sass/nav.sass
@@ -10,7 +10,6 @@
   justify-content: space-between
 
 .nav
-  padding-top: 5rem
   padding-bottom: 2rem
 
   &-subsection

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -183,8 +183,6 @@ $hero-body-padding: 4rem 1.5rem
   border-bottom: 4px solid $primary
 
 .title
-  line-height: 1.5
-
   .icon
     margin-left: 0.75rem
 
@@ -246,9 +244,6 @@ hr
 
 .is-info-light
 	background: hsl(206, 70%, 96%)
-	
-.section 
-	padding: 4rem 1.5rem
 
 .badge
   border: 1px solid #dbdbdb

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,10 +1,10 @@
-<div class="container">
-  <div class="columns is-variable is-8">
-    <div class="column is-one-quarter is-hidden-touch">
+<div class="container section">
+  <div class="columns is-variable is-8-desktop is-0-touch">
+    <div class="column is-one-quarter-desktop is-hidden-touch">
       {{ partial "nav.html" . }}
     </div>
 
-    <div class="column is-three-quarters is-content-column">
+    <div class="column is-three-quarters-desktop is-content-column">
       {{ partial "docs/hero.html" . }}
       {{ partial "content.html" . }}
     </div>

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,28 +1,26 @@
 {{ $notice   := .Params.notice }}
 {{ $isScaler := eq .CurrentSection.Title "Scalers" }}
 {{ $index := eq .File.LogicalName "_index.md"}}
-<section class="section">
-  <div class="container">
-    <div class="content is-medium is-constrained has-bottom-margin">
-      {{ with $notice }}
-      <article class="message is-warning">
-        <div class="message-header">
-          <p class="is-size-5 is-size-6-mobile">
-            Notice
-          </p>
-        </div>
-        <div class="message-body">
-          {{ . }}
-        </div>
-      </article>
-      {{ end }}
+<section>
+  <div class="content is-medium is-constrained has-bottom-margin">
+    {{ with $notice }}
+    <article class="message is-warning">
+      <div class="message-header">
+        <p class="is-size-5 is-size-6-mobile">
+          Notice
+        </p>
+      </div>
+      <div class="message-body">
+        {{ . }}
+      </div>
+    </article>
+    {{ end }}
 
-      {{ .Content | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" `${1} <a class="headline-hash" href="#${2}"><span class="icon hashlink"><i class="fas fa-hashtag"></i></span></a>${3}` | safeHTML }}
+    {{ .Content | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" `${1} <a class="headline-hash" href="#${2}"><span class="icon hashlink"><i class="fas fa-hashtag"></i></span></a>${3}` | safeHTML }}
 
-      {{ if and ($isScaler) ($index) }}
-      {{ partial "scaler-layout" . }}
-      {{ end }}
-    </div>
+    {{ if and ($isScaler) ($index) }}
+    {{ partial "scaler-layout" . }}
+    {{ end }}
   </div>
 </section>
 

--- a/layouts/partials/docs/hero.html
+++ b/layouts/partials/docs/hero.html
@@ -22,90 +22,88 @@
 {{ end }}
 
 <span class="docsearch-lvl0" hidden>{{ $productName }} v{{ $version }}</span>
-<section class="hero">
-  <div class="hero-body">
-    <div class="container">
-      <p class="title is-size-1 is-size-2-mobile has-text-weight-bold{{ if $desc }} is-spaced{{ end }}">
-        <span class="title-text">{{ $title }}</span>
-        <sup>
-          {{ if $isLatest }}
-          <span class="tag is-success">Latest</span>
-          {{ else if and (not $isNextVersion) $latestPageExists }}
-          <a href="{{ $latestUrl }}">
-            <span class="tag is-warning">Click here for latest</span>
-          </a>
-          {{ end }}
-        </sup>
-      </p>
-
-      {{ with $desc }}
-      <p class="subtitle">
-        {{ . }}
-      </p>
+<section class="doc-hero">
+  <p class="title is-size-1 is-size-2-mobile has-text-weight-bold{{ if $desc }} is-spaced{{ end }}">
+    <span class="title-text">{{ $title }}</span>
+    <sup>
+      {{ if $isLatest }}
+      <span class="tag is-success">Latest</span>
+      {{ else if and (not $isNextVersion) $latestPageExists }}
+      <a href="{{ $latestUrl }}">
+        <span class="tag is-warning">Click here for latest</span>
+      </a>
       {{ end }}
+    </sup>
+  </p>
 
-      <div class="field">
-        <p class="control">
-          <div class="tags are-medium">
-            {{ with $availability }}
-            <span class="tag">
-              Availability:&nbsp;<span class="has-text-weight-bold">{{ . }}</span>
-            </span>
-            {{ end }}
+  {{ with $desc }}
+  <p class="subtitle">
+    {{ . }}
+  </p>
+  {{ end }}
 
-            {{ with $maintainer }}
-            <span class="tag is-outlined">
-              Maintainer:&nbsp;<span class="has-text-weight-bold">{{ . }}</span>
-            </span>
-            {{ end }}
+  {{ if or $availability $maintainer (and $isScaler (not $isSectionRoot)) }}
+  <div class="field">
+    <p class="control">
+      <div class="tags are-medium">
+        {{ with $availability }}
+        <span class="tag">
+          Availability:&nbsp;<span class="has-text-weight-bold">{{ . }}</span>
+        </span>
+        {{ end }}
 
-            {{ if and $isScaler (not $isSectionRoot) }}
-            {{ $url := printf "https://github.com/kedacore/keda/blob/main/pkg/scalers/%s.go" .Params.go_file }}
-            <div class="tag is-black">
-              <span class="icon">
-                <i class="fab fa-github"></i>
-              </span>
-              <a class="has-text-light" href="{{ $url }}" target="_blank">
-                Scaler code
-              </a>
-            </div>
-            {{ end }}
-          </div>
-        </p>
-      </div>
+        {{ with $maintainer }}
+        <span class="tag is-outlined">
+          Maintainer:&nbsp;<span class="has-text-weight-bold">{{ . }}</span>
+        </span>
+        {{ end }}
 
-      <div class="buttons are-small are-spaced">
-        {{ partial "doc-version-selector.html" . }}
-
-        <a class="button is-dark is-outlined" href="{{ $src }}" target="_blank">
+        {{ if and $isScaler (not $isSectionRoot) }}
+        {{ $url := printf "https://github.com/kedacore/keda/blob/main/pkg/scalers/%s.go" .Params.go_file }}
+        <div class="tag is-black">
           <span class="icon">
             <i class="fab fa-github"></i>
           </span>
-          <span>
-            Suggest a change
-          </span>
-        </a>
+          <a class="has-text-light" href="{{ $url }}" target="_blank">
+            Scaler code
+          </a>
+        </div>
+        {{ end }}
       </div>
-      
-      {{ if and (not $isLatest) $latestPageExists }}
-      <article class="message is-warning">
-        <div class="message-header">
-          <p>Warning</p>  
-        </div>
-        <div class="message-body">
-          You are currently viewing v{{ $version }} of the documentation and it is not the latest. For the most recent documentation, kindly <a href="{{ $latestUrl }}"> click here.</a>
-        </div>
-      </article>
-      {{ else if and (not $isLatest) (not $isNextVersion) }}
-      <article class="message is-info">
-        <div class="message-header">
-          <p>Notice</p>  
-        </div>
-        <div class="message-body">
-          This page does not exist in the latest version ({{ $latest }}). It may have been deprecated or replaced. Check the <a href="/{{ .Section }}/{{ $latest }}/">{{ $latest }} documentation</a> for alternatives.
-        </div>
-      </article>
-      {{ end }}
-    </div>
+    </p>
   </div>
+  {{ end }}
+
+  <div class="buttons are-small are-spaced">
+    {{ partial "doc-version-selector.html" . }}
+
+    <a class="button is-dark is-outlined" href="{{ $src }}" target="_blank">
+      <span class="icon">
+        <i class="fab fa-github"></i>
+      </span>
+      <span>
+        Suggest a change
+      </span>
+    </a>
+  </div>
+
+  {{ if and (not $isLatest) $latestPageExists }}
+  <article class="message is-warning">
+    <div class="message-header">
+      <p>Warning</p>
+    </div>
+    <div class="message-body">
+      You are currently viewing v{{ $version }} of the documentation and it is not the latest. For the most recent documentation, kindly <a href="{{ $latestUrl }}"> click here.</a>
+    </div>
+  </article>
+  {{ else if and (not $isLatest) (not $isNextVersion) }}
+  <article class="message is-info">
+    <div class="message-header">
+      <p>Notice</p>
+    </div>
+    <div class="message-body">
+      This page does not exist in the latest version ({{ $latest }}). It may have been deprecated or replaced. Check the <a href="/{{ .Section }}/{{ $latest }}/">{{ $latest }} documentation</a> for alternatives.
+    </div>
+  </article>
+  {{ end }}
 </section>


### PR DESCRIPTION
The actual space for the docs is currently quite small due do the sidebar and a lot of unused whitespace. Font size is also quite large IMO but let's keep that at least for now.
In larger tables content is also truncated, see https://keda.sh/docs/2.19/reference/events/ .

For the reviewer: changes in layouts/partials/docs/hero.html are mostly whitespace, might make sense to review with the following: 
<img width="554" height="377" alt="image" src="https://github.com/user-attachments/assets/fd4ecc82-f7c9-4132-b0e1-6b29ee1afb3e" />


### Before and After

<img width="2072" height="665" alt="image" src="https://github.com/user-attachments/assets/981ec45e-cacd-4469-a66a-6eb209c309c4" />

<img width="1160" height="824" alt="image" src="https://github.com/user-attachments/assets/a65b1044-ca46-42aa-ac17-3b91b94c01de" />


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
