### PR TITLE
fix(http-add-on): rename KEDAHTTP_OPERATOR_EXTERNAL_SCALER_* env vars to KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_*

### DIFF
--- a/content/http-add-on/0.14/reference/environment-variables.md
+++ b/content/http-add-on/0.14/reference/environment-variables.md
@@ -95,8 +95,8 @@ When set, they take precedence over their replacements.
 
 | Variable                                            | Default      | Description                                                                         |
 | --------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
-| `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE`         | _(required)_ | Name of the Kubernetes Service for the external scaler.                             |
-| `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT`            | `8091`       | Port for the external scaler Service.                                               |
+| `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE`        | _(required)_ | Name of the Kubernetes Service for the external scaler.                             |
+| `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT`           | `8091`       | Port for the external scaler Service.                                               |
 | `KEDA_HTTP_OPERATOR_NAMESPACE`                      | `""`         | Namespace in which the operator is running.                                         |
 | `KEDA_HTTP_OPERATOR_WATCH_NAMESPACE`                | `""`         | Namespace to watch for resources. Empty watches all namespaces.                     |
 | `KEDA_HTTP_OPERATOR_LEADER_ELECTION_LEASE_DURATION` | _(unset)_    | Leader election lease duration. When unset, the controller-runtime default is used. |


### PR DESCRIPTION
Rename `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT` environment variables to `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT` in the HTTP Add-on docs, fixing the missing underscore after `KEDA` to be consistent with all other `KEDA_HTTP_OPERATOR_*` variables.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes kedacore/http-add-on#1623