### PR TITLE
docs(http-add-on): document TLS SNI certificate selection

### DIFF
--- a/content/http-add-on/0.14/operations/configure-tls.md
+++ b/content/http-add-on/0.14/operations/configure-tls.md
@@ -26,23 +26,45 @@ The Secret must contain `tls.crt` and `tls.key` entries.
 
 ## TLS settings
 
-| Helm value                         | Env var                                 | Default                        | Description                                                              |
-| ---------------------------------- | --------------------------------------- | ------------------------------ | ------------------------------------------------------------------------ |
-| `interceptor.tls.enabled`          | `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`                        | Enable TLS on the proxy.                                                 |
-| `interceptor.tls.port`             | `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`                         | Port the TLS proxy listens on.                                           |
-| `interceptor.tls.certSecret`       | —                                       | `keda-tls-certs`               | Name of the Kubernetes Secret containing the TLS certificate and key.    |
-| `interceptor.tls.certPath`         | `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt`               | Path to the certificate file.                                            |
-| `interceptor.tls.keyPath`          | `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key`               | Path to the private key file.                                            |
-| `interceptor.tls.minVersion`       | `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | Go default (TLS 1.2)           | Minimum TLS version (`"1.2"` or `"1.3"`).                                |
-| `interceptor.tls.maxVersion`       | `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | Go default (highest supported) | Maximum TLS version (`"1.2"` or `"1.3"`).                                |
-| `interceptor.tls.cipherSuites`     | `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | Go defaults                    | Comma-separated list of cipher suite names.                              |
-| `interceptor.tls.curvePreferences` | `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | Go defaults                    | Comma-separated list of elliptic curve names (e.g., `X25519,CurveP256`). |
-| `interceptor.tls.skipVerify`       | `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`                        | Skip TLS verification for upstream (backend) connections.                |
+| Helm value                         | Env var                                 | Default                        | Description                                                                                                                     |
+| ---------------------------------- | --------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `interceptor.tls.enabled`          | `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`                        | Enable TLS on the proxy.                                                                                                        |
+| `interceptor.tls.port`             | `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`                         | Port the TLS proxy listens on.                                                                                                  |
+| `interceptor.tls.certSecret`       | —                                       | `keda-tls-certs`               | Name of the Kubernetes Secret containing the TLS certificate and key.                                                           |
+| `interceptor.tls.certPath`         | `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt`               | Path to the certificate file.                                                                                                   |
+| `interceptor.tls.keyPath`          | `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key`               | Path to the private key file.                                                                                                   |
+| —                                  | `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`                           | Comma-separated list of directories with additional cert/key pairs for [SNI-based selection](#sni-based-certificate-selection). |
+| `interceptor.tls.minVersion`       | `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | Go default (TLS 1.2)           | Minimum TLS version (`"1.2"` or `"1.3"`).                                                                                       |
+| `interceptor.tls.maxVersion`       | `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | Go default (highest supported) | Maximum TLS version (`"1.2"` or `"1.3"`).                                                                                       |
+| `interceptor.tls.cipherSuites`     | `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | Go defaults                    | Comma-separated list of cipher suite names.                                                                                     |
+| `interceptor.tls.curvePreferences` | `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | Go defaults                    | Comma-separated list of elliptic curve names (e.g., `X25519,CurveP256`).                                                        |
+| `interceptor.tls.skipVerify`       | `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`                        | Skip TLS verification for upstream (backend) connections.                                                                       |
 
 ## SNI-based certificate selection
 
-The interceptor supports SNI-based certificate selection when multiple certificate/key pairs are loaded via the `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` environment variable.
-Set this to a comma-separated list of paths containing additional certificate/key pairs.
+The interceptor supports serving different TLS certificates from a single TLS listener using Server Name Indication (SNI).
+To enable this, set `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` to a comma-separated list of directories containing additional certificate/key pairs.
+
+### Certificate selection flow
+
+During the TLS handshake, the interceptor selects a certificate as follows:
+
+1. It looks for an exact match between the client's SNI hostname and a certificate SAN (DNS name or IP address) from the certificates loaded from `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`.
+2. If no SNI-specific certificate matches, it falls back to the default certificate from `KEDA_HTTP_PROXY_TLS_CERT_PATH` / `KEDA_HTTP_PROXY_TLS_KEY_PATH`.
+3. If no default certificate is configured either, the handshake fails.
+
+### Certificate store file naming
+
+Each directory in `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` is walked recursively.
+Certificate and key files are paired by matching their full file path after stripping the suffix.
+The supported suffixes are `.crt` or `.pem` for certificates and `.key` or `-key.pem` for private keys:
+
+| Suffixes          | Example certificate | Example key   |
+| ----------------- | ------------------- | ------------- |
+| `.crt`/`.key`     | `app.crt`           | `app.key`     |
+| `.pem`/`-key.pem` | `app.pem`           | `app-key.pem` |
+
+Every certificate file must have a corresponding key file — a missing key causes a startup error.
 
 ## What's Next
 

--- a/content/http-add-on/0.14/reference/environment-variables.md
+++ b/content/http-add-on/0.14/reference/environment-variables.md
@@ -43,18 +43,18 @@ When set, they take precedence over their replacements.
 
 ### TLS
 
-| Variable                                | Default          | Description                                                                                     |
-| --------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`          | Enable TLS on the proxy server.                                                                 |
-| `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt` | Path to the TLS certificate file.                                                               |
-| `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key` | Path to the TLS private key file.                                                               |
-| `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`             | Comma-separated list of paths to certificate/key pairs.                                         |
-| `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`          | Skip TLS verification for upstream connections.                                                 |
-| `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`           | Port for the TLS proxy server.                                                                  |
-| `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | `""`             | Minimum TLS version (`1.2` or `1.3`). Empty uses the Go default (TLS 1.2).                      |
-| `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | `""`             | Maximum TLS version (`1.2` or `1.3`). Empty uses the highest version supported by `crypto/tls`. |
-| `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | `""`             | Comma-separated list of TLS cipher suite names. Empty uses Go defaults.                         |
-| `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | `""`             | Comma-separated list of elliptic curve names. Empty uses Go defaults.                           |
+| Variable                                | Default          | Description                                                                                                                                                                 |
+| --------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`          | Enable TLS on the proxy server.                                                                                                                                             |
+| `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt` | Path to the TLS certificate file.                                                                                                                                           |
+| `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key` | Path to the TLS private key file.                                                                                                                                           |
+| `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`             | Comma-separated list of directories containing additional certificate/key pairs for [SNI-based selection](../../operations/configure-tls/#sni-based-certificate-selection). |
+| `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`          | Skip TLS verification for upstream connections.                                                                                                                             |
+| `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`           | Port for the TLS proxy server.                                                                                                                                              |
+| `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | `""`             | Minimum TLS version (`1.2` or `1.3`). Empty uses the Go default (TLS 1.2).                                                                                                  |
+| `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | `""`             | Maximum TLS version (`1.2` or `1.3`). Empty uses the highest version supported by `crypto/tls`.                                                                             |
+| `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | `""`             | Comma-separated list of TLS cipher suite names. Empty uses Go defaults.                                                                                                     |
+| `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | `""`             | Comma-separated list of elliptic curve names. Empty uses Go defaults.                                                                                                       |
 
 ### Metrics
 

--- a/content/http-add-on/0.15/operations/configure-tls.md
+++ b/content/http-add-on/0.15/operations/configure-tls.md
@@ -26,23 +26,45 @@ The Secret must contain `tls.crt` and `tls.key` entries.
 
 ## TLS settings
 
-| Helm value                         | Env var                                 | Default                        | Description                                                              |
-| ---------------------------------- | --------------------------------------- | ------------------------------ | ------------------------------------------------------------------------ |
-| `interceptor.tls.enabled`          | `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`                        | Enable TLS on the proxy.                                                 |
-| `interceptor.tls.port`             | `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`                         | Port the TLS proxy listens on.                                           |
-| `interceptor.tls.certSecret`       | —                                       | `keda-tls-certs`               | Name of the Kubernetes Secret containing the TLS certificate and key.    |
-| `interceptor.tls.certPath`         | `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt`               | Path to the certificate file.                                            |
-| `interceptor.tls.keyPath`          | `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key`               | Path to the private key file.                                            |
-| `interceptor.tls.minVersion`       | `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | Go default (TLS 1.2)           | Minimum TLS version (`"1.2"` or `"1.3"`).                                |
-| `interceptor.tls.maxVersion`       | `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | Go default (highest supported) | Maximum TLS version (`"1.2"` or `"1.3"`).                                |
-| `interceptor.tls.cipherSuites`     | `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | Go defaults                    | Comma-separated list of cipher suite names.                              |
-| `interceptor.tls.curvePreferences` | `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | Go defaults                    | Comma-separated list of elliptic curve names (e.g., `X25519,CurveP256`). |
-| `interceptor.tls.skipVerify`       | `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`                        | Skip TLS verification for upstream (backend) connections.                |
+| Helm value                         | Env var                                 | Default                        | Description                                                                                                                     |
+| ---------------------------------- | --------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `interceptor.tls.enabled`          | `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`                        | Enable TLS on the proxy.                                                                                                        |
+| `interceptor.tls.port`             | `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`                         | Port the TLS proxy listens on.                                                                                                  |
+| `interceptor.tls.certSecret`       | —                                       | `keda-tls-certs`               | Name of the Kubernetes Secret containing the TLS certificate and key.                                                           |
+| `interceptor.tls.certPath`         | `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt`               | Path to the certificate file.                                                                                                   |
+| `interceptor.tls.keyPath`          | `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key`               | Path to the private key file.                                                                                                   |
+| —                                  | `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`                           | Comma-separated list of directories with additional cert/key pairs for [SNI-based selection](#sni-based-certificate-selection). |
+| `interceptor.tls.minVersion`       | `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | Go default (TLS 1.2)           | Minimum TLS version (`"1.2"` or `"1.3"`).                                                                                       |
+| `interceptor.tls.maxVersion`       | `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | Go default (highest supported) | Maximum TLS version (`"1.2"` or `"1.3"`).                                                                                       |
+| `interceptor.tls.cipherSuites`     | `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | Go defaults                    | Comma-separated list of cipher suite names.                                                                                     |
+| `interceptor.tls.curvePreferences` | `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | Go defaults                    | Comma-separated list of elliptic curve names (e.g., `X25519,CurveP256`).                                                        |
+| `interceptor.tls.skipVerify`       | `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`                        | Skip TLS verification for upstream (backend) connections.                                                                       |
 
 ## SNI-based certificate selection
 
-The interceptor supports SNI-based certificate selection when multiple certificate/key pairs are loaded via the `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` environment variable.
-Set this to a comma-separated list of paths containing additional certificate/key pairs.
+The interceptor supports serving different TLS certificates from a single TLS listener using Server Name Indication (SNI).
+To enable this, set `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` to a comma-separated list of directories containing additional certificate/key pairs.
+
+### Certificate selection flow
+
+During the TLS handshake, the interceptor selects a certificate as follows:
+
+1. It looks for an exact match between the client's SNI hostname and a certificate SAN (DNS name or IP address) from the certificates loaded from `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`.
+2. If no SNI-specific certificate matches, it falls back to the default certificate from `KEDA_HTTP_PROXY_TLS_CERT_PATH` / `KEDA_HTTP_PROXY_TLS_KEY_PATH`.
+3. If no default certificate is configured either, the handshake fails.
+
+### Certificate store file naming
+
+Each directory in `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS` is walked recursively.
+Certificate and key files are paired by matching their full file path after stripping the suffix.
+The supported suffixes are `.crt` or `.pem` for certificates and `.key` or `-key.pem` for private keys:
+
+| Suffixes          | Example certificate | Example key   |
+| ----------------- | ------------------- | ------------- |
+| `.crt`/`.key`     | `app.crt`           | `app.key`     |
+| `.pem`/`-key.pem` | `app.pem`           | `app-key.pem` |
+
+Every certificate file must have a corresponding key file — a missing key causes a startup error.
 
 ## What's Next
 

--- a/content/http-add-on/0.15/reference/environment-variables.md
+++ b/content/http-add-on/0.15/reference/environment-variables.md
@@ -43,18 +43,18 @@ When set, they take precedence over their replacements.
 
 ### TLS
 
-| Variable                                | Default          | Description                                                                                     |
-| --------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`          | Enable TLS on the proxy server.                                                                 |
-| `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt` | Path to the TLS certificate file.                                                               |
-| `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key` | Path to the TLS private key file.                                                               |
-| `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`             | Comma-separated list of paths to certificate/key pairs.                                         |
-| `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`          | Skip TLS verification for upstream connections.                                                 |
-| `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`           | Port for the TLS proxy server.                                                                  |
-| `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | `""`             | Minimum TLS version (`1.2` or `1.3`). Empty uses the Go default (TLS 1.2).                      |
-| `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | `""`             | Maximum TLS version (`1.2` or `1.3`). Empty uses the highest version supported by `crypto/tls`. |
-| `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | `""`             | Comma-separated list of TLS cipher suite names. Empty uses Go defaults.                         |
-| `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | `""`             | Comma-separated list of elliptic curve names. Empty uses Go defaults.                           |
+| Variable                                | Default          | Description                                                                                                                                                                 |
+| --------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KEDA_HTTP_PROXY_TLS_ENABLED`           | `false`          | Enable TLS on the proxy server.                                                                                                                                             |
+| `KEDA_HTTP_PROXY_TLS_CERT_PATH`         | `/certs/tls.crt` | Path to the TLS certificate file.                                                                                                                                           |
+| `KEDA_HTTP_PROXY_TLS_KEY_PATH`          | `/certs/tls.key` | Path to the TLS private key file.                                                                                                                                           |
+| `KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS`  | `""`             | Comma-separated list of directories containing additional certificate/key pairs for [SNI-based selection](../../operations/configure-tls/#sni-based-certificate-selection). |
+| `KEDA_HTTP_PROXY_TLS_SKIP_VERIFY`       | `false`          | Skip TLS verification for upstream connections.                                                                                                                             |
+| `KEDA_HTTP_PROXY_TLS_PORT`              | `8443`           | Port for the TLS proxy server.                                                                                                                                              |
+| `KEDA_HTTP_PROXY_TLS_MIN_VERSION`       | `""`             | Minimum TLS version (`1.2` or `1.3`). Empty uses the Go default (TLS 1.2).                                                                                                  |
+| `KEDA_HTTP_PROXY_TLS_MAX_VERSION`       | `""`             | Maximum TLS version (`1.2` or `1.3`). Empty uses the highest version supported by `crypto/tls`.                                                                             |
+| `KEDA_HTTP_PROXY_TLS_CIPHER_SUITES`     | `""`             | Comma-separated list of TLS cipher suite names. Empty uses Go defaults.                                                                                                     |
+| `KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES` | `""`             | Comma-separated list of elliptic curve names. Empty uses Go defaults.                                                                                                       |
 
 ### Metrics
 


### PR DESCRIPTION
The SNI section was a stub with no details about how certificate selection works or what file naming conventions are expected.

### Changes
- Document the 3-step certificate selection flow (SNI match, default cert fallback, handshake failure)
- Document certificate store file naming and extension pairing rules
- Add KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS to the TLS settings table
- Update env var description to clarify it takes directories, not files

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes https://github.com/kedacore/http-add-on/issues/1600
Supersedes https://github.com/kedacore/http-add-on/pull/1609
