### PR TITLE
docs(http-add-on): add coldStart.placeholder docs

### DIFF
--- a/content/http-add-on/0.14/operations/migrate-httpscaledobject-to-interceptorroute.md
+++ b/content/http-add-on/0.14/operations/migrate-httpscaledobject-to-interceptorroute.md
@@ -98,8 +98,9 @@ spec:
     port: 8080
   coldStart:
     fallback:
-      service: fallback-svc
-      port: 8080
+      service:
+        name: fallback-svc
+        port: 8080
   rules:
     - hosts:
         - app.example.com
@@ -229,9 +230,9 @@ NAMESPACE=default
 | `spec.scaleTargetRef.service`                     | `spec.target.service`                                   |
 | `spec.scaleTargetRef.port`                        | `spec.target.port`                                      |
 | `spec.scaleTargetRef.portName`                    | `spec.target.portName`                                  |
-| `spec.coldStartTimeoutFailoverRef.service`        | `spec.coldStart.fallback.service`                       |
-| `spec.coldStartTimeoutFailoverRef.port`           | `spec.coldStart.fallback.port`                          |
-| `spec.coldStartTimeoutFailoverRef.portName`       | `spec.coldStart.fallback.portName`                      |
+| `spec.coldStartTimeoutFailoverRef.service`        | `spec.coldStart.fallback.service.name`                  |
+| `spec.coldStartTimeoutFailoverRef.port`           | `spec.coldStart.fallback.service.port`                  |
+| `spec.coldStartTimeoutFailoverRef.portName`       | `spec.coldStart.fallback.service.portName`              |
 | `spec.coldStartTimeoutFailoverRef.timeoutSeconds` | `spec.timeouts.readiness` (as `Duration`, e.g. `"30s"`) |
 | `spec.scalingMetric.concurrency.targetValue`      | `spec.scalingMetric.concurrency.targetValue`            |
 | `spec.scalingMetric.requestRate.targetValue`      | `spec.scalingMetric.requestRate.targetValue`            |

--- a/content/http-add-on/0.14/reference/interceptorroute.md
+++ b/content/http-add-on/0.14/reference/interceptorroute.md
@@ -113,11 +113,28 @@ When both are set, both metrics are reported and KEDA scales based on whichever 
 
 Configures behavior while the target is not ready (scaling from zero).
 
-| Field      | Type                       | Required | Default | Description                                                                                     |
-| ---------- | -------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `fallback` | [`*TargetRef`](#targetref) | Yes      |         | Fallback service to route to when the target is scaling from zero and the wait timeout expires. |
+| Field      | Type                                       | Required | Default | Description                                                                                          |
+| ---------- | ------------------------------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `fallback` | [`*ColdStartFallback`](#coldstartfallback) | Yes      |         | Fallback service to route to when the target is scaling from zero and the readiness timeout expires. |
 
 **Validation:** The `fallback` field must be set.
+
+### `ColdStartFallback`
+
+| Field     | Type                         | Required | Default | Description                                       |
+| --------- | ---------------------------- | -------- | ------- | ------------------------------------------------- |
+| `service` | [`*ServiceRef`](#serviceref) | No       |         | Kubernetes Service to use as the fallback target. |
+
+### `ServiceRef`
+
+| Field      | Type     | Required | Default | Description                                                                   |
+| ---------- | -------- | -------- | ------- | ----------------------------------------------------------------------------- |
+| `name`     | `string` | Yes      |         | Name of the Kubernetes Service. Minimum length: 1.                            |
+| `port`     | `int32`  | No       |         | Port number on the Service (1--65535). Mutually exclusive with `portName`.    |
+| `portName` | `string` | No       |         | Named port on the Service. Minimum length: 1. Mutually exclusive with `port`. |
+
+**Validation:** Exactly one of `port` or `portName` must be set.
+Setting both or neither produces a validation error.
 
 ### `InterceptorRouteTimeouts`
 

--- a/content/http-add-on/0.14/user-guide/configure-cold-start.md
+++ b/content/http-add-on/0.14/user-guide/configure-cold-start.md
@@ -25,8 +25,9 @@ spec:
       targetValue: 100
   coldStart:
     fallback:
-      service: <your-fallback-service>
-      port: <your-fallback-port>
+      service:
+        name: <your-fallback-service>
+        port: <your-fallback-port>
   timeouts:
     readiness: 5s
 ```

--- a/content/http-add-on/0.15/operations/migrate-httpscaledobject-to-interceptorroute.md
+++ b/content/http-add-on/0.15/operations/migrate-httpscaledobject-to-interceptorroute.md
@@ -98,8 +98,9 @@ spec:
     port: 8080
   coldStart:
     fallback:
-      service: fallback-svc
-      port: 8080
+      service:
+        name: fallback-svc
+        port: 8080
   rules:
     - hosts:
         - app.example.com
@@ -229,9 +230,9 @@ NAMESPACE=default
 | `spec.scaleTargetRef.service`                     | `spec.target.service`                                   |
 | `spec.scaleTargetRef.port`                        | `spec.target.port`                                      |
 | `spec.scaleTargetRef.portName`                    | `spec.target.portName`                                  |
-| `spec.coldStartTimeoutFailoverRef.service`        | `spec.coldStart.fallback.service`                       |
-| `spec.coldStartTimeoutFailoverRef.port`           | `spec.coldStart.fallback.port`                          |
-| `spec.coldStartTimeoutFailoverRef.portName`       | `spec.coldStart.fallback.portName`                      |
+| `spec.coldStartTimeoutFailoverRef.service`        | `spec.coldStart.fallback.service.name`                  |
+| `spec.coldStartTimeoutFailoverRef.port`           | `spec.coldStart.fallback.service.port`                  |
+| `spec.coldStartTimeoutFailoverRef.portName`       | `spec.coldStart.fallback.service.portName`              |
 | `spec.coldStartTimeoutFailoverRef.timeoutSeconds` | `spec.timeouts.readiness` (as `Duration`, e.g. `"30s"`) |
 | `spec.scalingMetric.concurrency.targetValue`      | `spec.scalingMetric.concurrency.targetValue`            |
 | `spec.scalingMetric.requestRate.targetValue`      | `spec.scalingMetric.requestRate.targetValue`            |

--- a/content/http-add-on/0.15/reference/interceptorroute.md
+++ b/content/http-add-on/0.15/reference/interceptorroute.md
@@ -113,11 +113,61 @@ When both are set, both metrics are reported and KEDA scales based on whichever 
 
 Configures behavior while the target is not ready (scaling from zero).
 
-| Field      | Type                       | Required | Default | Description                                                                                     |
-| ---------- | -------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `fallback` | [`*TargetRef`](#targetref) | Yes      |         | Fallback service to route to when the target is scaling from zero and the wait timeout expires. |
+| Field         | Type                                             | Required | Default | Description                                                                                          |
+| ------------- | ------------------------------------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `fallback`    | [`*ColdStartFallback`](#coldstartfallback)       | No       |         | Fallback service to route to when the target is scaling from zero and the readiness timeout expires. |
+| `placeholder` | [`*ColdStartPlaceholder`](#coldstartplaceholder) | No       |         | Placeholder response to serve while the target has no ready endpoints.                               |
 
-**Validation:** The `fallback` field must be set.
+**Validation:** At least one of `fallback` or `placeholder` must be set.
+
+When both are configured, the placeholder response is returned immediately while the backend scales up.
+If the backend does not become ready within the readiness timeout, the fallback service is used.
+
+### `ColdStartFallback`
+
+| Field     | Type                         | Required | Default | Description                                       |
+| --------- | ---------------------------- | -------- | ------- | ------------------------------------------------- |
+| `service` | [`*ServiceRef`](#serviceref) | No       |         | Kubernetes Service to use as the fallback target. |
+
+### `ServiceRef`
+
+| Field      | Type     | Required | Default | Description                                                                   |
+| ---------- | -------- | -------- | ------- | ----------------------------------------------------------------------------- |
+| `name`     | `string` | Yes      |         | Name of the Kubernetes Service. Minimum length: 1.                            |
+| `port`     | `int32`  | No       |         | Port number on the Service (1--65535). Mutually exclusive with `portName`.    |
+| `portName` | `string` | No       |         | Named port on the Service. Minimum length: 1. Mutually exclusive with `port`. |
+
+**Validation:** Exactly one of `port` or `portName` must be set.
+Setting both or neither produces a validation error.
+
+### `ColdStartPlaceholder`
+
+| Field      | Type                                 | Required | Default | Description                                                                    |
+| ---------- | ------------------------------------ | -------- | ------- | ------------------------------------------------------------------------------ |
+| `response` | [`*StaticResponse`](#staticresponse) | Yes      |         | Static response to return immediately when the backend has no ready endpoints. |
+
+### `StaticResponse`
+
+Defines a static HTTP response.
+
+| Field               | Type                                   | Required | Default | Description                                                                                                                                                   |
+| ------------------- | -------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `statusCode`        | `int32`                                | No       | `503`   | HTTP status code (100--599).                                                                                                                                  |
+| `body`              | `*string`                              | No       |         | Inline response body. Maximum length: 32,768 characters. Mutually exclusive with `bodyFromConfigMap`.                                                         |
+| `bodyFromConfigMap` | [`*ConfigMapKeyRef`](#configmapkeyref) | No       |         | Response body from a ConfigMap in the same namespace. The ConfigMap must have the label `http.keda.sh/response-body: "true"`. Mutually exclusive with `body`. |
+| `headers`           | `map[string]string`                    | No       |         | HTTP response headers.                                                                                                                                        |
+
+**Validation:** At most one of `body` or `bodyFromConfigMap` may be set.
+If neither is set, the response has an empty body.
+
+### `ConfigMapKeyRef`
+
+References a key within a ConfigMap.
+
+| Field  | Type     | Required | Default | Description                                                                                                                                                                                                                           |
+| ------ | -------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` | `string` | Yes      |         | Name of the ConfigMap. Minimum length: 1.                                                                                                                                                                                             |
+| `key`  | `string` | No       |         | Key within the ConfigMap. When omitted, the key is derived from the request path (without leading `/`, defaulting to `index.html` for `/`). Content-Type is auto-detected from the file extension unless explicitly set in `headers`. |
 
 ### `InterceptorRouteTimeouts`
 

--- a/content/http-add-on/0.15/user-guide/configure-cold-start.md
+++ b/content/http-add-on/0.15/user-guide/configure-cold-start.md
@@ -1,10 +1,91 @@
 +++
 title = "Configure Cold-Start Behavior"
-description = "Fallback services and response headers for cold-start scenarios"
+description = "Placeholder responses, fallback services, and response headers for cold-start scenarios"
 +++
 
 When a request arrives for a backend that has been scaled to zero, the interceptor holds the request until the backend becomes ready.
-You can configure a fallback service and a readiness timeout to control what happens if the backend takes too long to start.
+You can configure a placeholder response, a fallback service, or both to control what happens during a cold start.
+
+## Placeholder response
+
+The interceptor can return a static HTTP response immediately while the backend scales up, instead of holding the request.
+Configure the `coldStart.placeholder` field to enable this:
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: my-app-svc
+    port: 8080
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+  coldStart:
+    placeholder:
+      response:
+        body: "<h1>Loading...</h1>"
+        headers:
+          Content-Type: text/html
+          Refresh: "5"
+        statusCode: 503
+```
+
+The `Refresh` header tells the browser to reload the page after 5 seconds, so the user automatically sees the real page once the backend is ready.
+
+### Response body from a ConfigMap
+
+For larger or more complex responses, store the body in a ConfigMap in the same namespace instead of inline.
+The ConfigMap must have the label `http.keda.sh/response-body: "true"`.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: placeholder-page
+  labels:
+    http.keda.sh/response-body: "true"
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <h1>Loading, please wait...</h1>
+      </body>
+    </html>
+---
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: my-app-svc
+    port: 8080
+  scalingMetric:
+    concurrency:
+      targetValue: 100
+  coldStart:
+    placeholder:
+      response:
+        bodyFromConfigMap:
+          name: placeholder-page
+          key: index.html
+        headers:
+          Refresh: "5"
+        statusCode: 503
+```
+
+When the `key` is omitted, it is derived from the request path (without the leading `/`, defaulting to `index.html` for `/`).
+This lets a single ConfigMap serve different files for different paths.
+The `Content-Type` header is auto-detected from the key's file extension unless explicitly set in `headers`.
+
+### Placeholder defaults
+
+- **Status code:** defaults to `503` when not specified.
+- **Body:** defaults to an empty body when neither `body` nor `bodyFromConfigMap` is set.
 
 ## Cold-start fallback
 
@@ -25,14 +106,36 @@ spec:
       targetValue: 100
   coldStart:
     fallback:
-      service: <your-fallback-service>
-      port: <your-fallback-port>
+      service:
+        name: <your-fallback-service>
+        port: <your-fallback-port>
   timeouts:
     readiness: 5s
 ```
 
 When a fallback is configured but the readiness timeout is `0s` (disabled), a 30-second default readiness timeout is applied automatically.
 This prevents the fallback from never being triggered.
+
+## Combining placeholder and fallback
+
+You can configure both a placeholder response and a fallback service.
+When both are set, the placeholder response is returned immediately while the backend scales up.
+If the backend does not become ready within the readiness timeout, subsequent requests are routed to the fallback service.
+
+```yaml
+coldStart:
+  placeholder:
+    response:
+      body: "<h1>Loading...</h1>"
+      headers:
+        Content-Type: text/html
+        Refresh: "5"
+      statusCode: 503
+  fallback:
+    service:
+      name: fallback-svc
+      port: 8080
+```
 
 ## Cold-start response header
 


### PR DESCRIPTION
Document the new coldStart.placeholder feature that returns static HTTP responses immediately during scale-from-zero instead of blocking requests.

### Changes
- Add ColdStartPlaceholder, StaticResponse, ConfigMapKeyRef to InterceptorRoute reference
- Update ColdStartSpec validation (fallback no longer required)
- Add placeholder section to cold-start user guide with inline and ConfigMap examples

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/http-add-on/pull/1626
