### PR TITLE
feat(http-add-on): document graceful shutdown configuration

### DIFF
--- a/content/http-add-on/0.15/operations/configure-interceptor.md
+++ b/content/http-add-on/0.15/operations/configure-interceptor.md
@@ -49,6 +49,33 @@ Configure the interceptor's connection pool for backend services:
 | `interceptor.maxIdleConns`        | `KEDA_HTTP_MAX_IDLE_CONNS`          | `1000`  | Maximum idle connections across all backend services. Increase this if you proxy to many backends.                |
 | `interceptor.maxIdleConnsPerHost` | `KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST` | `200`   | Maximum idle connections per backend. Increase this if you observe frequent connection establishments under load. |
 
+## Graceful shutdown
+
+During rolling updates, scale-downs, or node drains, the interceptor drains in-flight requests instead of terminating them immediately.
+When an interceptor pod is deleted, Kubernetes triggers EndpointSlice removal and sends SIGTERM in parallel.
+The interceptor's shutdown sequence on SIGTERM is:
+
+1. The readiness probe returns 503, signaling the pod is no longer ready to receive traffic (e.g. for external load balancers that health-check the pod directly).
+2. The interceptor keeps serving for `shutdownDelay`, allowing endpoint removal to propagate to all nodes.
+3. The proxy listener closes and the interceptor waits up to `drainTimeout` for in-flight requests (including WebSocket connections) to complete.
+4. Infrastructure components (admin server, metrics, routing table) shut down and the pod exits.
+
+| Helm value                                  | Env var                    | Default | Description                                                                                                    |
+| ------------------------------------------- | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
+| `interceptor.shutdownDelay`                 | `KEDA_HTTP_SHUTDOWN_DELAY` | `5s`    | Time between SIGTERM and closing the proxy listener. Increase this if clients still hit the pod after SIGTERM. |
+| `interceptor.drainTimeout`                  | `KEDA_HTTP_DRAIN_TIMEOUT`  | `30s`   | Maximum time to wait for in-flight requests to complete. `0` waits indefinitely.                               |
+| `interceptor.terminationGracePeriodSeconds` | —                          | `45`    | Time Kubernetes waits before sending SIGKILL.                                                                  |
+
+Ensure `terminationGracePeriodSeconds` is at least `shutdownDelay + drainTimeout` to avoid SIGKILL before drain completes.
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.shutdownDelay=10s \
+  --set interceptor.drainTimeout=120s \
+  --set interceptor.terminationGracePeriodSeconds=135
+```
+
 ## Interceptor scaling
 
 The interceptor itself is auto-scaled by KEDA via a `ScaledObject` created by the Helm chart.

--- a/content/http-add-on/0.15/reference/environment-variables.md
+++ b/content/http-add-on/0.15/reference/environment-variables.md
@@ -19,6 +19,13 @@ These are set via the `extraEnvs` Helm value for each component or directly in t
 | `KEDA_HTTP_ENABLE_COLD_START_HEADER`                | `true`       | When enabled, the interceptor adds the `X-KEDA-HTTP-Cold-Start` response header.              |
 | `KEDA_HTTP_LOG_REQUESTS`                            | `false`      | Enable logging of incoming requests.                                                          |
 
+### Graceful shutdown
+
+| Variable                   | Default | Description                                                                                                                                                                                     |
+| -------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KEDA_HTTP_SHUTDOWN_DELAY` | `5s`    | Time between receiving SIGTERM and closing the proxy listener. The readiness probe returns 503 immediately, but the server keeps serving, giving Kubernetes time to propagate endpoint removal. |
+| `KEDA_HTTP_DRAIN_TIMEOUT`  | `30s`   | Maximum time to wait for in-flight requests to complete after the proxy listener closes. `0` waits indefinitely (bounded only by `terminationGracePeriodSeconds`).                              |
+
 ### Timeouts
 
 | Variable                            | Default | Description                                                                                                                                                                                                                                         |


### PR DESCRIPTION
Document the KEDA_HTTP_SHUTDOWN_DELAY and KEDA_HTTP_DRAIN_TIMEOUT env vars for configuring connection draining during pod termination.

Changes:
- Add graceful shutdown section to configure-interceptor.md with shutdown sequence, config table, and Helm example
- Add KEDA_HTTP_SHUTDOWN_DELAY and KEDA_HTTP_DRAIN_TIMEOUT to the environment variables reference

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to:
- https://github.com/kedacore/http-add-on/pull/1648
- https://github.com/kedacore/http-add-on/issues/1636
