### PR TITLE
docs: fix HTTP Add-on link in setupscaler documentation

### DIFF
--- a/content/docs/2.19/setupscaler.md
+++ b/content/docs/2.19/setupscaler.md
@@ -26,7 +26,7 @@ KEDA supports various scalers that correspond to different event sources or trig
 
 1. Visit the [KEDA Scalers documentation](../scalers/) and browse through the list of available scalers.
 2. Identify the scaler that matches the event source you want to use for scaling your application. For example:
-   - If you want to scale based on incoming HTTP traffic, you would need the [HTTP Add-on](https://kedacore.github.io/http-add-on/).
+   - If you want to scale based on incoming HTTP traffic, you would need the [HTTP Add-on](https://github.com/kedacore/http-add-on).
 
      > **Note:**
      > The HTTP Add-on is still in beta stage and may not provide the full functionality or stability expected in a production environment.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

## Description

This PR fixes an incorrect URL in `content/docs/2.19/setupscaler.md`.

The documentation currently links the HTTP Add-on to:

https://kedacore.github.io/http-add-on/

The link has been updated to the HTTP Add-on GitHub repository:

https://github.com/kedacore/http-add-on

This ensures users are directed to the project's primary source, documentation, and installation instructions.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #