### PR TITLE
docs(http-add-on): document supported architectures

### DIFF
--- a/content/http-add-on/0.15/operations/installation.md
+++ b/content/http-add-on/0.15/operations/installation.md
@@ -9,6 +9,7 @@ weight = 1
 Before installing the HTTP Add-on, ensure you have:
 
 - A Kubernetes cluster (tested against the three most recent minor versions)
+  - Supported architectures: `amd64`, `arm64`, or `s390x` (CI-tested on `amd64` and `arm64`)
 - [Helm 3](https://helm.sh/docs/intro/install/)
 - KEDA core installed ([deployment guide](https://keda.sh/docs/deploy/))
 


### PR DESCRIPTION
Add supported architectures to 0.15 installation prerequisites

Copy pasted from the related PR:
> Simply cross building for s390x is IMO good enough as well as we don't expect that our quite normal go code suddenly would not work on that platform anymore.
> We test amd64 and arm64 in CI already, it is extremely unlikely that s390x would not work considering we dont use any unsafe/C code or anything archtiecture specific.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

See https://github.com/kedacore/http-add-on/pull/1663
