### PR TITLE
feat(http-add-on): document HTTP/2 and gRPC support

### DIFF
--- a/content/http-add-on/0.15/concepts/architecture.md
+++ b/content/http-add-on/0.15/concepts/architecture.md
@@ -34,6 +34,9 @@ It performs three functions:
 2. **Counting** — Tracks the number of concurrent (in-flight) requests and total request counts per route. These counters are the raw data the scaler uses to compute scaling metrics.
 3. **Buffering** — During cold starts (when a backend has zero replicas), the interceptor holds the request open while waiting for the backend to become ready. Once at least one pod is available, the request is forwarded. If the backend does not become ready within the readiness timeout, the interceptor returns an error or routes to a fallback service if configured.
 
+The interceptor supports HTTP/1.1, HTTP/2 (both h2c and h2 over TLS), gRPC, and WebSocket connections.
+Protocol detection is automatic — the interceptor matches the outbound protocol to whatever the client used on the inbound connection.
+
 The interceptor forwards requests to the backend's Kubernetes Service, relying on standard Kubernetes service load balancing for distribution across pods.
 
 The interceptor deployment is itself auto-scaled by KEDA via a ScaledObject created by the Helm chart.

--- a/content/http-add-on/0.15/reference/environment-variables.md
+++ b/content/http-add-on/0.15/reference/environment-variables.md
@@ -29,7 +29,6 @@ These are set via the `extraEnvs` Helm value for each component or directly in t
 | `KEDA_HTTP_CONNECT_TIMEOUT`         | `500ms` | Per-attempt TCP dial timeout. Bounded by the request context deadline.                                                                                                                                                                              |
 | `KEDA_HTTP_MAX_IDLE_CONNS`          | `1000`  | Maximum idle connections in the connection pool across all backend services.                                                                                                                                                                        |
 | `KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST` | `200`   | Maximum idle connections per backend service.                                                                                                                                                                                                       |
-| `KEDA_HTTP_FORCE_HTTP2`             | `false` | Whether to force HTTP/2 for all proxied requests.                                                                                                                                                                                                   |
 
 #### Deprecated timeout variables
 


### PR DESCRIPTION
Remove the now-unnecessary KEDA_HTTP_FORCE_HTTP2 env var from the reference docs and add protocol support info to the architecture page.





### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


Depends on https://github.com/kedacore/http-add-on/pull/1658