### PR TITLE
docs: add scaler observability for http-add-on 0.15

### DIFF
--- a/content/http-add-on/0.15/operations/configure-observability.md
+++ b/content/http-add-on/0.15/operations/configure-observability.md
@@ -1,14 +1,14 @@
 +++
 title = "Configure Observability"
-description = "Prometheus metrics, OpenTelemetry tracing, and request logging configuration for the interceptor"
+description = "Prometheus metrics, OpenTelemetry tracing, and request logging configuration for the interceptor and scaler"
 +++
 
-The interceptor exposes metrics and tracing data to help monitor HTTP traffic and scaling behavior.
-All observability settings are configured via environment variables, set through the `interceptor.extraEnvs` Helm value.
+The interceptor and the external scaler expose metrics and tracing data to help monitor HTTP traffic and scaling behavior.
+Both components share the same set of observability environment variables, configured through the `interceptor.extraEnvs` and `scaler.extraEnvs` Helm values respectively.
 
 ## Prometheus metrics
 
-The interceptor exposes Prometheus metrics at `/metrics` on port `2223`.
+Both the interceptor and the scaler expose Prometheus metrics at `/metrics` on port `2223`.
 This is enabled by default.
 
 | Env var                      | Default | Description                               |
@@ -20,17 +20,22 @@ See [Metrics Reference](../../reference/metrics/) for the full list of metrics a
 
 ## OpenTelemetry tracing
 
-Enable distributed tracing via OTLP:
+Enable distributed tracing via OTLP.
+The following example enables tracing for both the interceptor and the scaler:
 
 ```shell
 helm upgrade http-add-on kedacore/keda-add-ons-http \
   --namespace keda \
   --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_TRACES_ENABLED=true \
   --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc \
-  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317 \
+  --set scaler.extraEnvs.OTEL_EXPORTER_OTLP_TRACES_ENABLED=true \
+  --set scaler.extraEnvs.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc \
+  --set scaler.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317
 ```
 
-The interceptor uses W3C TraceContext and Baggage propagation.
+Both components use W3C TraceContext and Baggage propagation.
+The scaler additionally instruments all gRPC server calls via `otelgrpc` when tracing is enabled.
 
 | Env var                              | Default   | Description                                             |
 | ------------------------------------ | --------- | ------------------------------------------------------- |
@@ -48,7 +53,9 @@ Enable OTLP metrics export alongside or instead of Prometheus:
 helm upgrade http-add-on kedacore/keda-add-ons-http \
   --namespace keda \
   --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_METRICS_ENABLED=true \
-  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317
+  --set interceptor.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317 \
+  --set scaler.extraEnvs.OTEL_EXPORTER_OTLP_METRICS_ENABLED=true \
+  --set scaler.extraEnvs.OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-otel-collector>:4317
 ```
 
 | Env var                              | Default | Description                                         |
@@ -60,7 +67,7 @@ helm upgrade http-add-on kedacore/keda-add-ons-http \
 
 ## Request logging
 
-Enable Combined Log Format request logging:
+Enable Combined Log Format request logging (interceptor only):
 
 ```shell
 helm upgrade http-add-on kedacore/keda-add-ons-http \

--- a/content/http-add-on/0.15/reference/environment-variables.md
+++ b/content/http-add-on/0.15/reference/environment-variables.md
@@ -79,6 +79,8 @@ When set, they take precedence over their replacements.
 
 ## Scaler
 
+### Serving
+
 | Variable                                            | Default      | Description                                                                         |
 | --------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
 | `KEDA_HTTP_SCALER_PORT`                             | `8080`       | Port for the KEDA-compatible gRPC external scaler interface.                        |
@@ -89,7 +91,27 @@ When set, they take precedence over their replacements.
 | `KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD` | `60m`        | Resync interval for the controller-runtime cache.                                   |
 | `KEDA_HTTP_QUEUE_TICK_DURATION`                     | `500ms`      | Duration between queue polling ticks.                                               |
 | `KEDA_HTTP_SCALER_STREAM_INTERVAL_MS`               | `200`        | Interval in milliseconds between stream ticks for `IsActive` communication to KEDA. |
-| `PROFILING_BIND_ADDRESS`                            | `""`         | Address (`host:port`) for the pprof endpoint. Empty disables profiling.             |
+
+### Metrics
+
+| Variable                             | Default | Description                                          |
+| ------------------------------------ | ------- | ---------------------------------------------------- |
+| `OTEL_PROM_EXPORTER_ENABLED`         | `true`  | Enable the Prometheus metrics exporter.              |
+| `OTEL_PROM_EXPORTER_PORT`            | `2223`  | Port for the Prometheus-compatible metrics endpoint. |
+| `OTEL_EXPORTER_OTLP_METRICS_ENABLED` | `false` | Enable the OTLP metrics exporter.                    |
+
+### Tracing
+
+| Variable                             | Default   | Description                                                                  |
+| ------------------------------------ | --------- | ---------------------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_TRACES_ENABLED`  | `false`   | Enable OpenTelemetry trace export.                                           |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | `console` | Trace exporter protocol. Must be one of: `console`, `http/protobuf`, `grpc`. |
+
+### Profiling
+
+| Variable                 | Default | Description                                                             |
+| ------------------------ | ------- | ----------------------------------------------------------------------- |
+| `PROFILING_BIND_ADDRESS` | `""`    | Address (`host:port`) for the pprof endpoint. Empty disables profiling. |
 
 ## Operator
 

--- a/content/http-add-on/0.15/reference/metrics.md
+++ b/content/http-add-on/0.15/reference/metrics.md
@@ -3,7 +3,7 @@ title = "Metrics"
 description = "Reference for all Prometheus metrics exposed by the HTTP Add-on"
 +++
 
-The interceptor exposes metrics via OpenTelemetry, with a Prometheus-compatible endpoint enabled by default.
+The interceptor and the external scaler expose metrics via OpenTelemetry, with a Prometheus-compatible endpoint enabled by default on each component.
 
 ## Endpoint configuration
 
@@ -13,10 +13,10 @@ The interceptor exposes metrics via OpenTelemetry, with a Prometheus-compatible 
 | Path    | `/metrics` | Standard Prometheus scrape path.               |
 | Enabled | `true`     | Configurable via `OTEL_PROM_EXPORTER_ENABLED`. |
 
-The interceptor also supports OTLP metric export.
+Both components also support OTLP metric export.
 See [Environment Variables](../environment-variables/#metrics) for configuration.
 
-## Metrics
+## Interceptor metrics
 
 ### Request count
 
@@ -73,10 +73,42 @@ See [Environment Variables](../environment-variables/#metrics) for configuration
 | `route_name`      | Name of the matched InterceptorRoute or HTTPScaledObject.                                                                 |
 | `route_namespace` | Namespace of the matched route resource.                                                                                  |
 
-## Method normalization
+### Method normalization
 
 The `method` label accepts the following standard HTTP methods without modification:
 
 `CONNECT`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`
 
 All other method values are replaced with `_OTHER` to prevent unbounded label cardinality.
+
+## Scaler metrics
+
+### Pinger fetch duration
+
+|                          |                                                                            |
+| ------------------------ | -------------------------------------------------------------------------- |
+| **Prometheus name**      | `scaler_pinger_fetch_duration_seconds`                                     |
+| **OTel instrument name** | `scaler.pinger.fetch.duration`                                             |
+| **Type**                 | Histogram                                                                  |
+| **Unit**                 | Seconds                                                                    |
+| **Description**          | Duration of a queue pinger fetch cycle across all interceptor pods.        |
+
+**Bucket boundaries:** `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.25`, `0.5`, `0.75`, `1`, `2.5`, `5`
+
+### Pinger fetch errors
+
+|                          |                                          |
+| ------------------------ | ---------------------------------------- |
+| **Prometheus name**      | `scaler_pinger_fetch_errors_total`       |
+| **OTel instrument name** | `scaler.pinger.fetch.errors`             |
+| **Type**                 | Counter                                  |
+| **Description**          | Total failed queue pinger fetch cycles.  |
+
+### Pinger endpoints
+
+|                          |                                                              |
+| ------------------------ | ------------------------------------------------------------ |
+| **Prometheus name**      | `scaler_pinger_endpoints`                                    |
+| **OTel instrument name** | `scaler.pinger.endpoints`                                    |
+| **Type**                 | Gauge                                                        |
+| **Description**          | Number of interceptor endpoints the scaler is polling.       |


### PR DESCRIPTION
Document the OpenTelemetry metrics and tracing support added to the external scaler component in [kedacore/http-add-on#1634](https://github.com/kedacore/http-add-on/pull/1634).

The scaler now shares the same OTEL environment variables as the interceptor (Prometheus exporter, OTLP metrics, OTLP traces). This PR updates three doc pages to reflect that:

- **`operations/configure-observability.md`** — broadened scope to cover both interceptor and scaler, updated Helm examples to include `scaler.extraEnvs`, noted scaler's `otelgrpc` gRPC instrumentation.
- **`reference/metrics.md`** — added "Scaler metrics" section with three new metrics (`scaler.pinger.fetch.duration`, `scaler.pinger.fetch.errors`, `scaler.pinger.endpoints`), renamed existing section to "Interceptor metrics".
- **`reference/environment-variables.md`** — added Metrics, Tracing, and Profiling subsections to the Scaler section, mirroring the Interceptor layout.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Part of kedacore/http-add-on#965