### PR TITLE
docs(http-add-on): document appProtocol-based protocol selection

### DIFF
--- a/content/http-add-on/0.15/concepts/architecture.md
+++ b/content/http-add-on/0.15/concepts/architecture.md
@@ -35,7 +35,8 @@ It performs three functions:
 3. **Buffering** — During cold starts (when a backend has zero replicas), the interceptor holds the request open while waiting for the backend to become ready. Once at least one pod is available, the request is forwarded. If the backend does not become ready within the readiness timeout, the interceptor returns an error or routes to a fallback service if configured.
 
 The interceptor supports HTTP/1.1, HTTP/2 (both h2c and h2 over TLS), gRPC, and WebSocket connections.
-Protocol detection is automatic — the interceptor matches the outbound protocol to whatever the client used on the inbound connection.
+For cleartext backends, the interceptor defaults to HTTP/1.1 unless the target Service port sets `appProtocol: kubernetes.io/h2c`, which switches the backend connection to HTTP/2 cleartext (required for gRPC).
+For TLS backends, the protocol is negotiated automatically via ALPN.
 
 The interceptor forwards requests to the backend's Kubernetes Service, relying on standard Kubernetes service load balancing for distribution across pods.
 

--- a/content/http-add-on/0.15/reference/interceptorroute.md
+++ b/content/http-add-on/0.15/reference/interceptorroute.md
@@ -57,6 +57,15 @@ Exactly one of `port` or `portName` must be set.
 **Validation:** Exactly one of `port` or `portName` must be set.
 Setting both or neither produces a validation error.
 
+**Protocol selection:** The interceptor determines the backend protocol by inspecting the [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field on the matching Service port:
+
+| `appProtocol` value      | Backend protocol            |
+| ------------------------ | --------------------------- |
+| _(unset or other value)_ | HTTP/1.1                    |
+| `kubernetes.io/h2c`      | HTTP/2 cleartext (for gRPC) |
+
+For TLS backends, the protocol is negotiated automatically via ALPN regardless of `appProtocol`.
+
 ### `RoutingRule`
 
 Defines a set of matching criteria for routing requests.

--- a/content/http-add-on/0.15/reference/metrics.md
+++ b/content/http-add-on/0.15/reference/metrics.md
@@ -85,30 +85,30 @@ All other method values are replaced with `_OTHER` to prevent unbounded label ca
 
 ### Pinger fetch duration
 
-|                          |                                                                            |
-| ------------------------ | -------------------------------------------------------------------------- |
-| **Prometheus name**      | `scaler_pinger_fetch_duration_seconds`                                     |
-| **OTel instrument name** | `scaler.pinger.fetch.duration`                                             |
-| **Type**                 | Histogram                                                                  |
-| **Unit**                 | Seconds                                                                    |
-| **Description**          | Duration of a queue pinger fetch cycle across all interceptor pods.        |
+|                          |                                                                     |
+| ------------------------ | ------------------------------------------------------------------- |
+| **Prometheus name**      | `scaler_pinger_fetch_duration_seconds`                              |
+| **OTel instrument name** | `scaler.pinger.fetch.duration`                                      |
+| **Type**                 | Histogram                                                           |
+| **Unit**                 | Seconds                                                             |
+| **Description**          | Duration of a queue pinger fetch cycle across all interceptor pods. |
 
 **Bucket boundaries:** `0.005`, `0.01`, `0.025`, `0.05`, `0.075`, `0.1`, `0.25`, `0.5`, `0.75`, `1`, `2.5`, `5`
 
 ### Pinger fetch errors
 
-|                          |                                          |
-| ------------------------ | ---------------------------------------- |
-| **Prometheus name**      | `scaler_pinger_fetch_errors_total`       |
-| **OTel instrument name** | `scaler.pinger.fetch.errors`             |
-| **Type**                 | Counter                                  |
-| **Description**          | Total failed queue pinger fetch cycles.  |
+|                          |                                         |
+| ------------------------ | --------------------------------------- |
+| **Prometheus name**      | `scaler_pinger_fetch_errors_total`      |
+| **OTel instrument name** | `scaler.pinger.fetch.errors`            |
+| **Type**                 | Counter                                 |
+| **Description**          | Total failed queue pinger fetch cycles. |
 
 ### Pinger endpoints
 
-|                          |                                                              |
-| ------------------------ | ------------------------------------------------------------ |
-| **Prometheus name**      | `scaler_pinger_endpoints`                                    |
-| **OTel instrument name** | `scaler.pinger.endpoints`                                    |
-| **Type**                 | Gauge                                                        |
-| **Description**          | Number of interceptor endpoints the scaler is polling.       |
+|                          |                                                        |
+| ------------------------ | ------------------------------------------------------ |
+| **Prometheus name**      | `scaler_pinger_endpoints`                              |
+| **OTel instrument name** | `scaler.pinger.endpoints`                              |
+| **Type**                 | Gauge                                                  |
+| **Description**          | Number of interceptor endpoints the scaler is polling. |

--- a/content/http-add-on/0.15/user-guide/autoscale-an-app.md
+++ b/content/http-add-on/0.15/user-guide/autoscale-an-app.md
@@ -35,6 +35,7 @@ spec:
 Key fields:
 
 - **`target.service`** / **`target.port`** — The Kubernetes Service and port to route traffic to.
+  - For gRPC or HTTP/2 backends, set `appProtocol: kubernetes.io/h2c` on the Service port ([details](../../reference/interceptorroute/#targetref)).
 - **`rules[].hosts`** — Hostnames to match against the HTTP `Host` header. This must match what callers send (see [Step 4](#step-4-route-traffic-through-the-interceptor)):
   - External traffic: your public hostname (e.g., `app.example.com`).
   - In-cluster traffic: the service name callers use (e.g., `<your-service>-proxy`).


### PR DESCRIPTION
- Update architecture to explain appProtocol-based protocol selection
- Add protocol selection table to InterceptorRoute TargetRef reference
- Add gRPC/h2c note to autoscale guide
- Fix trailing whitespace in metrics tables

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/http-add-on/pull/1678
