### PR TITLE
docs(http-add-on): document static route support

### DIFF
--- a/content/http-add-on/0.16/concepts/routing.md
+++ b/content/http-add-on/0.16/concepts/routing.md
@@ -95,7 +95,18 @@ A request that matches any one of these rules is routed to the InterceptorRoute'
 
 This allows a single InterceptorRoute to serve traffic for multiple hostnames or path patterns without requiring separate resources for each.
 
+## Static Routes
+
+An InterceptorRoute can define static routes — sub-routes that serve a static response without triggering autoscaling.
+Matched requests are not counted toward scaling metrics and will not trigger autoscaling.
+Static routes use the same matching dimensions (hosts, paths, headers) as regular routing rules.
+
+A typical use case is a health check endpoint that should return `200 OK` when the backend is scaled to zero, without waking it up.
+
+For configuration details, see [Configure Static Routes](../../user-guide/configure-static-routes/).
+
 ## What's Next
 
 - [Configure Routing Rules](../../user-guide/configure-routing/) — YAML examples for host, path, and header matching.
+- [Configure Static Routes](../../user-guide/configure-static-routes/) — Health checks, maintenance pages, and other non-scaling paths.
 - [InterceptorRoute Reference](../../reference/interceptorroute/) — Complete field definitions for routing rules.

--- a/content/http-add-on/0.16/concepts/scaling.md
+++ b/content/http-add-on/0.16/concepts/scaling.md
@@ -40,9 +40,14 @@ For example, with a concurrency target of 100 and a current concurrency of 250, 
 
 This calculation happens within the Kubernetes HPA based on the metrics and targets that KEDA provides.
 
+## Requests Excluded from Scaling
+
+Requests that match a static route are not counted toward scaling metrics and will not trigger autoscaling.
+See [Configure Static Routes](../../user-guide/configure-static-routes/) for details.
+
 ## How Metrics Flow
 
-1. A request arrives at the interceptor, which counts it.
+1. A request arrives at the interceptor, which counts it (unless it matches a [static route](../../user-guide/configure-static-routes/)).
 2. The scaler periodically polls all interceptor pods to collect per-route request counts.
 3. The scaler aggregates concurrency across pods and computes request rate for each route.
 4. KEDA queries the scaler for current metrics and determines the desired replica count.

--- a/content/http-add-on/0.16/reference/interceptorroute.md
+++ b/content/http-add-on/0.16/reference/interceptorroute.md
@@ -29,17 +29,25 @@ spec:
   scalingMetric:
     concurrency:
       targetValue: 100
+  staticRoutes:
+    - rules:
+        - paths:
+            - value: /healthz
+      response:
+        statusCode: 200
+        body: "OK"
 ```
 
 ## `spec`
 
-| Field           | Type                                                    | Required | Default | Description                                                        |
-| --------------- | ------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------ |
-| `target`        | [`TargetRef`](#targetref)                               | Yes      |         | Backend service to route traffic to.                               |
-| `rules`         | [`[]RoutingRule`](#routingrule)                         | No       |         | Routing rules that define how requests are matched to this target. |
-| `scalingMetric` | [`ScalingMetricSpec`](#scalingmetricspec)               | Yes      |         | Metric configuration for autoscaling.                              |
-| `coldStart`     | [`ColdStartSpec`](#coldstartspec)                       | No       |         | Cold start behavior when scaling from zero.                        |
-| `timeouts`      | [`InterceptorRouteTimeouts`](#interceptorroutetimeouts) | No       |         | Timeout configuration for request handling.                        |
+| Field           | Type                                                    | Required | Default | Description                                                         |
+| --------------- | ------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------- |
+| `target`        | [`TargetRef`](#targetref)                               | Yes      |         | Backend service to route traffic to.                                |
+| `rules`         | [`[]RoutingRule`](#routingrule)                         | No       |         | Routing rules that define how requests are matched to this target.  |
+| `scalingMetric` | [`ScalingMetricSpec`](#scalingmetricspec)               | Yes      |         | Metric configuration for autoscaling.                               |
+| `staticRoutes`  | [`[]StaticRoute`](#staticroute)                         | No       |         | Routes that serve a static response without triggering autoscaling. |
+| `coldStart`     | [`ColdStartSpec`](#coldstartspec)                       | No       |         | Cold start behavior when scaling from zero.                         |
+| `timeouts`      | [`InterceptorRouteTimeouts`](#interceptorroutetimeouts) | No       |         | Timeout configuration for request handling.                         |
 
 For usage guidance, see [Configure Routing Rules](../../user-guide/configure-routing/) and [Configure Scaling Metrics](../../user-guide/configure-scaling/).
 
@@ -117,6 +125,27 @@ When both are set, both metrics are reported and KEDA scales based on whichever 
 | `targetValue` | `int32`    | Yes      |         | Target request rate per replica. Minimum: 1.                   |
 | `window`      | `Duration` | No       | `1m`    | Sliding time window over which the request rate is calculated. |
 | `granularity` | `Duration` | No       | `1s`    | Bucket size for rate calculation within the window.            |
+
+### `StaticRoute`
+
+Defines a route that serves a static response without triggering autoscaling.
+When the backend is running, matched requests are forwarded to it by default (configurable via `responseMode`).
+When the backend is scaled to zero, a configurable static response is returned instead.
+
+| Field          | Type                                | Required | Default           | Description                                                                                 |
+| -------------- | ----------------------------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------- |
+| `rules`        | [`[]RoutingRule`](#routingrule)     | Yes      |                   | Matching rules for this static route. A request matching any rule is handled by this route. |
+| `response`     | [`StaticResponse`](#staticresponse) | Yes      |                   | Static response to return.                                                                  |
+| `responseMode` | `string`                            | No       | `WhenUnavailable` | When to serve the static response. See [response modes](#static-route-response-modes).      |
+
+#### Static route response modes
+
+| Mode              | Behavior                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `WhenUnavailable` | Forward to the backend when it has ready endpoints; return the static response only when the backend is down. |
+| `Always`          | Always return the static response, even when the backend is running.                                          |
+
+For usage guidance, see [Configure Static Routes](../../user-guide/configure-static-routes/).
 
 ### `ColdStartSpec`
 

--- a/content/http-add-on/0.16/user-guide/_index.md
+++ b/content/http-add-on/0.16/user-guide/_index.md
@@ -11,4 +11,5 @@ Guides for application developers using the HTTP Add-on to autoscale their servi
 - **[Configure Ingress](configure-ingress/)** — Point your Gateway API or Ingress at the interceptor proxy.
 - **[Configure Routing Rules](configure-routing/)** — Host, path, and header matching.
 - **[Configure Scaling Metrics](configure-scaling/)** — Choose between concurrency and request rate metrics.
+- **[Configure Static Routes](configure-static-routes/)** — Serve static responses for requests that should not trigger autoscaling.
 - **[Configure Timeouts](configure-timeouts/)** — Per-route timeout overrides.

--- a/content/http-add-on/0.16/user-guide/configure-static-routes.md
+++ b/content/http-add-on/0.16/user-guide/configure-static-routes.md
@@ -1,0 +1,143 @@
++++
+title = "Configure Static Routes"
+description = "Serve static responses for health checks, maintenance pages, and other paths that should not trigger autoscaling"
++++
+
+Some requests such as external health probes should never trigger autoscaling.
+When the backend is scaled to zero, these requests still need a sensible response.
+Static routes let you define paths on an InterceptorRoute that serve a configurable static response without waking up the backend.
+
+## Health check passthrough
+
+A common use case is a load balancer that probes `/healthz`.
+When the app is running, the probe should reach the real backend.
+When the app is scaled to zero, the interceptor returns a static `200 OK` instead of triggering a scale-up.
+
+```yaml
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: my-app-svc
+    port: 8080
+  scalingMetric:
+    requestRate:
+      targetValue: 100
+  staticRoutes:
+    - rules:
+        - paths:
+            - value: /healthz
+      response:
+        statusCode: 200
+        body: "OK"
+```
+
+With the default `responseMode: WhenUnavailable`, the interceptor forwards `/healthz` to the backend when it has ready endpoints.
+When the backend is down, the static response is returned.
+
+## Maintenance page
+
+Serve a maintenance page when the backend is unavailable, without triggering a scale-up.
+With `responseMode: Always`, the static response is returned even when the backend is running which is useful e.g. for a planned downtime.
+
+For larger response bodies, store the content in a ConfigMap instead of inline.
+The ConfigMap must have the label `http.keda.sh/response-body: "true"`.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maintenance-page
+  labels:
+    http.keda.sh/response-body: "true"
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+      <body><h1>Under maintenance</h1></body>
+    </html>
+---
+apiVersion: http.keda.sh/v1beta1
+kind: InterceptorRoute
+metadata:
+  name: my-app
+spec:
+  target:
+    service: my-app-svc
+    port: 8080
+  scalingMetric:
+    requestRate:
+      targetValue: 100
+  staticRoutes:
+    - rules:
+        - paths:
+            - value: /
+      responseMode: Always
+      response:
+        bodyFromConfigMap:
+          name: maintenance-page
+          key: index.html
+        headers:
+          Content-Type: text/html
+        statusCode: 503
+```
+
+When `key` is omitted, it is derived from the request path (without the leading `/`, defaulting to `index.html` for `/`).
+The `Content-Type` header is auto-detected from the key's file extension unless explicitly set in `headers`.
+
+## Multiple static routes
+
+You can define multiple static routes on a single InterceptorRoute.
+They are evaluated in list order; the first matching route wins.
+
+```yaml
+staticRoutes:
+  - rules:
+      - paths:
+          - value: /healthz
+    response:
+      statusCode: 200
+      body: "OK"
+  - rules:
+      - paths:
+          - value: /old-api
+    responseMode: Always
+    response:
+      statusCode: 307
+      headers:
+        Location: /api
+```
+
+## Response modes
+
+The `responseMode` field controls when the static response is served:
+
+| Mode              | Behavior                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `WhenUnavailable` | Forward to the backend when it has ready endpoints; return the static response only when the backend is down. |
+| `Always`          | Always return the static response, even when the backend is running.                                          |
+
+The default is `WhenUnavailable`, which suits health checks that should reach the real backend when it is available.
+Use `Always` for redirects or paths that should never reach the backend.
+
+## Matching rules
+
+Static routes use the same matching rules as the top-level `rules` field on an InterceptorRoute: hosts, path prefixes, and headers.
+Multiple rules within a single static route use OR semantics — a request matching any rule is handled by that static route.
+
+For details on host, path, and header matching, see [Configure Routing Rules](../configure-routing/).
+
+## Static routes vs. cold-start placeholders
+
+Static routes and [cold-start placeholders](../configure-cold-start/) both serve static responses, but for different purposes:
+
+- **Cold-start placeholders** respond to requests that _should_ trigger scaling. The placeholder is a temporary response while the backend starts up.
+- **Static routes** respond to requests that should _never_ trigger scaling. Depending on `responseMode`, the static response is served when the backend is unavailable or unconditionally.
+
+## What's Next
+
+- [InterceptorRoute Reference](../reference/interceptorroute/) — field details for `staticRoutes`.
+- [How Routing Works](../concepts/routing/) — request matching and priority order.
+- [How Scaling Works](../concepts/scaling/) — metrics, scale-to-zero, and cold starts.


### PR DESCRIPTION
Static routes serve configurable static responses for requests that should not trigger autoscaling, such as external health checks or maintenance pages.
When the backend is running, matched requests are forwarded by default (unless `responseMode: Always` is set); when scaled to zero, the static response is returned.

### Changes
- Add new user guide for configuring static routes
- Add StaticRoute type and response modes to InterceptorRoute reference
- Add static routes section to routing and scaling concept pages
- Add static routes to user guide index


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to https://github.com/kedacore/http-add-on/pull/1689