### PR TITLE
docs: document metric server performance metrics

### DIFF
--- a/content/docs/2.21/integrations/opentelemetry.md
+++ b/content/docs/2.21/integrations/opentelemetry.md
@@ -50,6 +50,8 @@ The following metrics are being gathered:
 | `keda.cloudeventsource.events.queued` | The number of events that are in the emitting queue. |
 | `keda.scaler.http.requests.count` | Total number of outbound HTTP requests issued during scaler metric collection. |
 | `keda.scaler.http.request.duration.seconds` | Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric collection. |
+| `keda.metricsservice.get_metrics.requests.count` | Total number of GetMetrics gRPC requests handled by the operator for the metrics server. |
+| `keda.metricsservice.get_metrics.duration.seconds` | Histogram of the duration in seconds of GetMetrics gRPC requests handled by the operator for the metrics server. |
 
 #### Deprecated metrics
 
@@ -59,3 +61,14 @@ The following metrics are exposed as well, but are deprecated and will be remove
 | `keda.resource.totals` | Total number of KEDA custom resources per namespace for each custom resource type (CRD). |
 | `keda.trigger.totals` | Total number of triggers per trigger type. |
 | `keda.internal.scale.loop.latency` | Total deviation (in milliseconds) between the expected execution time and the actual execution time for the scaling loop. This latency could be produced due to accumulated scalers latencies or high load. This is an internal metric. |
+
+### Metrics Server
+
+The KEDA Metrics Adapter supports outputting performance metrics to the OpenTelemetry collector. The parameter `--enable-opentelemetry-metrics=true` needs to be set. KEDA will push metrics to the OpenTelemetry collector specified by the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. `OTEL_EXPORTER_OTLP_PROTOCOL` will also be used to choose HTTP or GRPC client.
+
+The following metrics are being gathered:
+
+| Metric | Description |
+| ------ | ----------- |
+| `keda.external_metrics_provider.requests.count` | Total number of external metric requests served to the Kubernetes HPA. |
+| `keda.external_metrics_provider.request.duration.seconds` | Histogram of the duration in seconds of external metric requests served to the Kubernetes HPA. |

--- a/content/docs/2.21/integrations/prometheus.md
+++ b/content/docs/2.21/integrations/prometheus.md
@@ -27,6 +27,8 @@ The KEDA Operator exposes Prometheus metrics which can be scraped on port `8080`
 - `keda_cloudeventsource_events_queued` - The number of events that are in the emitting queue.
 - `keda_scaler_http_requests_total` - Total number of outbound HTTP requests issued during scaler metric collection.
 - `keda_scaler_http_request_duration_seconds` - Histogram of the duration in seconds of outbound HTTP requests issued during scaler metric collection.
+- `keda_metricsservice_get_metrics_requests_total` - Total number of GetMetrics gRPC requests handled by the operator for the metrics server, labeled by outcome.
+- `keda_metricsservice_get_metrics_duration_seconds` - Histogram of the duration in seconds of GetMetrics gRPC requests handled by the operator for the metrics server.
 - `keda_internal_metricsservice_grpc_server_started_total` - Total number of RPCs started on the server.
 - `keda_internal_metricsservice_grpc_server_handled_total` - Total number of RPCs completed on the server, regardless of success or failure.
 - `keda_internal_metricsservice_grpc_server_msg_received_total` - Total number of RPC stream messages received on the server.
@@ -52,6 +54,8 @@ The KEDA Metrics Adapter exposes Prometheus metrics which can be scraped on port
 - `keda_internal_metricsservice_grpc_client_msg_received_total` - Total number of RPC stream messages received by the client.
 - `keda_internal_metricsservice_grpc_client_msg_sent_total` - Total number of gRPC stream messages sent by the client.
 - `keda_internal_metricsservice_grpc_client_handling_seconds` - Histogram of response latency (seconds) of the gRPC until it is finished by the application.
+- `keda_external_metrics_provider_requests_total` - Total number of external metric requests served to the Kubernetes HPA, labeled by outcome.
+- `keda_external_metrics_provider_request_duration_seconds` - Histogram of the duration in seconds of external metric requests served to the Kubernetes HPA.
 - Metrics exposed by the `Operator SDK` framework as explained [here](https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#metrics).
 - Metrics exposed (prepended with `apiserver_`) by [Kubernetes API Server](https://kubernetes.io/docs/reference/instrumentation/metrics/)
 


### PR DESCRIPTION
## Summary

Document new Prometheus and OpenTelemetry metrics introduced for metric server performance observability:

- **Operator**: `keda_metricsservice_get_metrics_*` / `keda.metricsservice.get_metrics.*` for GetMetrics gRPC handling
- **Metrics Server**: `keda_external_metrics_provider_*` / `keda.external_metrics_provider.*` for HPA external metric requests, including the new `--enable-opentelemetry-metrics` flag on the adapter

## Relates to

- kedacore/keda#3120

## Test plan

- [x] Verified metric names match KEDA implementation
- [x] Updated both `prometheus.md` and `opentelemetry.md` under `content/docs/2.21/integrations/`

