### PR TITLE
Fix typo in scaledjob-spec.md

### DIFF
--- a/content/docs/2.0/concepts/scaling-jobs.md
+++ b/content/docs/2.0/concepts/scaling-jobs.md
@@ -126,7 +126,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.1/concepts/scaling-jobs.md
+++ b/content/docs/2.1/concepts/scaling-jobs.md
@@ -126,7 +126,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.10/concepts/scaling-jobs.md
+++ b/content/docs/2.10/concepts/scaling-jobs.md
@@ -162,7 +162,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.11/concepts/scaling-jobs.md
+++ b/content/docs/2.11/concepts/scaling-jobs.md
@@ -164,7 +164,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.12/concepts/scaling-jobs.md
+++ b/content/docs/2.12/concepts/scaling-jobs.md
@@ -164,7 +164,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.13/concepts/scaling-jobs.md
+++ b/content/docs/2.13/concepts/scaling-jobs.md
@@ -167,7 +167,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.14/concepts/scaling-jobs.md
+++ b/content/docs/2.14/concepts/scaling-jobs.md
@@ -167,7 +167,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.14/reference/scaledjob-spec.md
+++ b/content/docs/2.14/reference/scaledjob-spec.md
@@ -158,7 +158,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.15/reference/scaledjob-spec.md
+++ b/content/docs/2.15/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.16/reference/scaledjob-spec.md
+++ b/content/docs/2.16/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.17/reference/scaledjob-spec.md
+++ b/content/docs/2.17/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.18/reference/scaledjob-spec.md
+++ b/content/docs/2.18/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.19/reference/scaledjob-spec.md
+++ b/content/docs/2.19/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.2/concepts/scaling-jobs.md
+++ b/content/docs/2.2/concepts/scaling-jobs.md
@@ -126,7 +126,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.20/reference/scaledjob-spec.md
+++ b/content/docs/2.20/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.21/reference/scaledjob-spec.md
+++ b/content/docs/2.21/reference/scaledjob-spec.md
@@ -156,7 +156,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, `accurate`, 
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.3/concepts/scaling-jobs.md
+++ b/content/docs/2.3/concepts/scaling-jobs.md
@@ -126,7 +126,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.4/concepts/scaling-jobs.md
+++ b/content/docs/2.4/concepts/scaling-jobs.md
@@ -130,7 +130,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.5/concepts/scaling-jobs.md
+++ b/content/docs/2.5/concepts/scaling-jobs.md
@@ -145,7 +145,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.6/concepts/scaling-jobs.md
+++ b/content/docs/2.6/concepts/scaling-jobs.md
@@ -145,7 +145,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.7/concepts/scaling-jobs.md
+++ b/content/docs/2.7/concepts/scaling-jobs.md
@@ -145,7 +145,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.8/concepts/scaling-jobs.md
+++ b/content/docs/2.8/concepts/scaling-jobs.md
@@ -162,7 +162,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >

--- a/content/docs/2.9/concepts/scaling-jobs.md
+++ b/content/docs/2.9/concepts/scaling-jobs.md
@@ -162,7 +162,7 @@ Select a Scaling Strategy. Possible values are `default`, `custom`, or `accurate
  >```go
  >maxScale = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
  >```
- >That means it will use the value of `queueLength` divided by `targetAvarageValue` unless it is exceeding the `MaxReplicaCount`.
+ >That means it will use the value of `queueLength` divided by `targetAverageValue` unless it is exceeding the `MaxReplicaCount`.
 >
 >`RunningJobCount` represents the number of jobs that are currently running or have not finished yet.
 >


### PR DESCRIPTION
spelling mistake: 
targetAvarageValue -> targetAverageValue

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
