### PR TITLE
docs(temporal): document includeRunningWorkflowCount and workflowTaskQueueForCount

### DIFF
--- a/content/docs/2.21/scalers/temporal.md
+++ b/content/docs/2.21/scalers/temporal.md
@@ -25,6 +25,8 @@ triggers:
       buildId: 1.0.0 # deprecated, use workerDeploymentBuildId
       selectAllActive: "false" # deprecated
       selectUnversioned: "false" # deprecated
+      includeRunningWorkflowCount: "false" # optional
+      workflowTaskQueueForCount: "" # optional
       minConnectTimeout: "5" # optional
       unsafeSsl: "false" # optional
       tlsServerName: "custom-tls-servername" # optional
@@ -44,6 +46,8 @@ triggers:
 - `buildId` - *Deprecated.* Build IDs identify Worker versions under the legacy Rules-Based Versioning APIs, which the Temporal server has deprecated since December 2024 and will stop supporting soon. Use `workerDeploymentName` and `workerDeploymentBuildId` instead. (Optional)
 - `selectAllActive` - *Deprecated.* Include all active versions under the legacy Rules-Based Versioning APIs. Use `workerDeploymentName` / `workerDeploymentBuildId` instead. (Default: `false`, Optional)
 - `selectUnversioned` - *Deprecated.* Include the unversioned queue under the legacy Rules-Based Versioning APIs. Use `workerDeploymentName` / `workerDeploymentBuildId` instead. (Default: `false`, Optional)
+- `includeRunningWorkflowCount` - When set to `true`, the scaler stays active if there are running workflows on the task queue even after the backlog drains to zero. This is useful for preventing premature scale-down when workers are fast and the backlog is often empty. It only affects the activity decision (`isActive`); the reported metric value is still the backlog count. See [Preventing premature scale-down](#preventing-premature-scale-down-with-includerunningworkflowcount) below for behavior details and important caveats. (Default: `false`, Optional)
+- `workflowTaskQueueForCount` - Overrides which task queue is used for the running-workflow visibility count when `includeRunningWorkflowCount` is enabled. Useful when scaling activity workers off a workflow-owned queue: set `taskQueue` to the activity queue and `workflowTaskQueueForCount` to the workflow queue whose in-flight workflows should keep the activity workers alive. Has no effect if `includeRunningWorkflowCount` is `false`. (Optional)
 - `apiKeyFromEnv` - API key for authentication similar to `apiKey`, but read from an environment variable (Optional)
 - `minConnectTimeout` - This is the minimum amount of time we are willing to give a connection to complete. (Default:`5`, Optional)
 - `unsafeSsl` - Whether to allow unsafe SSL (Default: `false`, Optional)
@@ -144,3 +148,53 @@ spec:
       workerDeploymentName: my-worker
       workerDeploymentBuildId: v2.0.0
 ```
+
+### Preventing premature scale-down with `includeRunningWorkflowCount`
+
+When workers are fast and the backlog is often momentarily zero, the default backlog-only signal can cause the HPA to scale workers down while workflows are still executing. Enabling `includeRunningWorkflowCount` keeps the scaler active for as long as there are running workflows on the task queue, even when the backlog is below the activation threshold.
+
+The reported metric value is unaffected. The setting only changes the activity decision (whether the scaler reports `isActive`), which controls whether the HPA is allowed to scale to zero.
+
+For `workerDeploymentName` scalers, the check first consults the Worker Deployment Version status returned by `DescribeWorkerDeploymentVersion`:
+
+- `DRAINING` versions stay active without a visibility query. Temporal keeps replaying pinned workflows on draining versions and tracks completion server-side; issuing a `CountWorkflow` here would just duplicate that signal at risk of a false negative during eventual consistency.
+- `DRAINED`, `INACTIVE`, and unspecified versions are treated as inactive; they will scale down when the backlog reaches zero.
+- `CURRENT` and `RAMPING` versions fall through to a scoped `CountWorkflow` query, scoping by `TemporalWorkerDeploymentVersion = '<deploymentName>:<buildId>'`.
+
+For unversioned scalers (no `workerDeploymentName`), the visibility query additionally scopes by `TemporalWorkerDeploymentVersion is null`, so it does not pick up workflows owned by versioned workers on the same task queue.
+
+**Activity-worker scaling.** Activity workers polling an activity-only task queue see no running workflows on their queue even when workflows are actively executing on a separate workflow queue. If you want your activity workers to stay alive while workflows are in flight, set `workflowTaskQueueForCount` to the workflow task queue whose in-flight workflows should keep the activity workers alive.
+
+**Example:**
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: my-activity-worker-scaledobject
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: my-activity-worker
+  minReplicaCount: 0
+  maxReplicaCount: 5
+  triggers:
+  - type: temporal
+    metadata:
+      namespace: default
+      taskQueue: "my-activity-queue"
+      targetQueueSize: "10"
+      endpoint: temporal-frontend.temporal.svc.cluster.local:7233
+      includeRunningWorkflowCount: "true"
+      workflowTaskQueueForCount: "my-workflow-queue"
+```
+
+#### Caveats
+
+The running-workflow-count signal is intentionally an approximation. It should not be relied on as a strict guarantee of correct behavior; workloads that require strict guarantees should combine this trigger with a worker-utilization metric.
+
+- **Activity-only workers.** By default, the check looks at the same task queue the scaler is scaling. If your activity workers poll a queue that never has running workflows on it (e.g. an activity-only task queue), the check will find nothing to keep the workers alive. Use `workflowTaskQueueForCount` to point at the workflow queue whose in-flight workflows should keep the activity workers awake.
+- **Visibility is eventually consistent.** Temporal's visibility store is updated asynchronously by the history service. A workflow that has just started may not appear in `CountWorkflow` results for a few seconds. There is no SLA on this delay; under load or during history-service backpressure it can be significantly longer.
+- **`CountWorkflow` is approximate.** The Temporal Visibility Count API is [documented as returning an approximate count](https://docs.temporal.io/visibility#count-workflow-by-executionstatus), not an exact one. Do not treat the returned count as authoritative.
+- **Visibility rate limiting.** All Visibility APIs, including `Count`, are subject to a per-namespace frontend rate limit (roughly ~10 RPS per namespace per frontend instance in default configurations). Scalers with very short polling intervals or many trigger instances against the same namespace can exhaust this budget, causing the check to fall back to backlog-only.
+


### PR DESCRIPTION
Documentation for the two new Temporal scaler fields introduced in kedacore/keda#7460:

- `includeRunningWorkflowCount` — opt-in flag that keeps the scaler active if running workflows exist on the task queue even after the backlog drains to zero. Only affects the activity decision; the reported metric value is unchanged.
- `workflowTaskQueueForCount` — optional override for the task queue used by the running-workflow visibility count. Enables activity-worker scaling by pointing at the workflow queue whose in-flight workflows should keep the activity workers alive.

Changes to `content/docs/2.21/scalers/temporal.md`:

1. Both fields added to the YAML example and the parameter list.
2. New "Preventing premature scale-down with `includeRunningWorkflowCount`" section documenting:
   - The Worker Deployment Version status short-circuit (`DRAINING` stays active without visibility; `DRAINED`/`INACTIVE`/`UNSPECIFIED` scale down; `CURRENT`/`RAMPING` fall through to `CountWorkflow`).
   - Version-scoped visibility query using `TemporalWorkerDeploymentVersion = 'name:buildId'` (colon delimiter, v1.32+ Temporal servers).
   - Unversioned scoping via `TemporalWorkerDeploymentVersion is null` to avoid picking up versioned workers' workflows on the same queue.
   - Activity-worker configuration pattern using `workflowTaskQueueForCount`, with example YAML.
3. Caveats sub-subsection covering the four documented limitations: activity-only worker scoping, visibility eventual consistency, `CountWorkflow` approximation, and the ~10 RPS per-namespace visibility rate limit.

Refs kedacore/keda#7460.