### PR TITLE
docs: fix broken links in scaler docs

### DIFF
--- a/content/docs/2.21/scalers/aws-kinesis.md
+++ b/content/docs/2.21/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/2.21/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.21/scalers/kubernetes-workload.md
+++ b/content/docs/2.21/scalers/kubernetes-workload.md
@@ -28,7 +28,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
 
 When `groupByNode` is enabled, KEDA groups matching non-terminated pods by node and excludes matching pods without a node assignment. For example, if `7` matching pods are found and `2` of them run on the same node, the scaler reports `6`.
 

--- a/content/docs/2.21/scalers/rabbitmq-queue.md
+++ b/content/docs/2.21/scalers/rabbitmq-queue.md
@@ -115,7 +115,7 @@ For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD
 
 #### OAuth2 authentication
 
-For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD with the `oauth2` spec. See the [OAuth2 authentication provider documentation](https://keda.sh/docs/2.21/authentication-providers/oauth/) for the full `TriggerAuthentication.spec.oauth2` schema. In this case, the `username:password` part in the host URI should be omitted. Currently, only HTTP protocol is supported.
+For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD with the `oauth2` spec. See the [OAuth2 authentication provider documentation](https://keda.sh/docs/2.21/authentication-providers/oauth2/) for the full `TriggerAuthentication.spec.oauth2` schema. In this case, the `username:password` part in the host URI should be omitted. Currently, only HTTP protocol is supported.
 
 ### Configuration examples
 


### PR DESCRIPTION
Several documentation links return HTTP 404. This updates each to its current working location:

- `content/docs/2.21/scalers/kubernetes-workload.md` (1 link)
- `content/docs/2.21/scalers/rabbitmq-queue.md` (1 link)
- `content/docs/2.21/scalers/aws-kinesis.md` (1 link)

Docs-only change. Each replacement URL was verified to return HTTP 200.