### PR TITLE
docs: fix broken links in scaler docs across all versions

### DIFF
--- a/content/docs/2.10/scalers/aws-kinesis.md
+++ b/content/docs/2.10/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.10/scalers/kubernetes-workload.md
+++ b/content/docs/2.10/scalers/kubernetes-workload.md
@@ -25,7 +25,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.11/scalers/aws-kinesis.md
+++ b/content/docs/2.11/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.11/scalers/kubernetes-workload.md
+++ b/content/docs/2.11/scalers/kubernetes-workload.md
@@ -25,7 +25,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.12/scalers/aws-kinesis.md
+++ b/content/docs/2.12/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.12/scalers/kubernetes-workload.md
+++ b/content/docs/2.12/scalers/kubernetes-workload.md
@@ -25,7 +25,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.13/scalers/aws-kinesis.md
+++ b/content/docs/2.13/scalers/aws-kinesis.md
@@ -39,7 +39,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.13/scalers/kubernetes-workload.md
+++ b/content/docs/2.13/scalers/kubernetes-workload.md
@@ -25,7 +25,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.14/scalers/aws-kinesis.md
+++ b/content/docs/2.14/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.14/scalers/kubernetes-workload.md
+++ b/content/docs/2.14/scalers/kubernetes-workload.md
@@ -26,7 +26,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.15/scalers/aws-kinesis.md
+++ b/content/docs/2.15/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.15/scalers/kubernetes-workload.md
+++ b/content/docs/2.15/scalers/kubernetes-workload.md
@@ -26,7 +26,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.16/scalers/aws-kinesis.md
+++ b/content/docs/2.16/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.16/scalers/kubernetes-workload.md
+++ b/content/docs/2.16/scalers/kubernetes-workload.md
@@ -26,7 +26,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.17/scalers/aws-kinesis.md
+++ b/content/docs/2.17/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.17/scalers/kubernetes-workload.md
+++ b/content/docs/2.17/scalers/kubernetes-workload.md
@@ -26,7 +26,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.18/scalers/aws-kinesis.md
+++ b/content/docs/2.18/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.18/scalers/kubernetes-workload.md
+++ b/content/docs/2.18/scalers/kubernetes-workload.md
@@ -26,7 +26,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.19/scalers/aws-kinesis.md
+++ b/content/docs/2.19/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.19/scalers/kubernetes-workload.md
+++ b/content/docs/2.19/scalers/kubernetes-workload.md
@@ -26,7 +26,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.20/scalers/aws-kinesis.md
+++ b/content/docs/2.20/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.20/scalers/kubernetes-workload.md
+++ b/content/docs/2.20/scalers/kubernetes-workload.md
@@ -28,7 +28,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 When `groupByNode` is enabled, KEDA groups matching non-terminated pods by node and excludes matching pods without a node assignment. For example, if `7` matching pods are found and `2` of them run on the same node, the scaler reports `6`.
 

--- a/content/docs/2.20/scalers/rabbitmq-queue.md
+++ b/content/docs/2.20/scalers/rabbitmq-queue.md
@@ -117,7 +117,7 @@ For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD
 
 #### OAuth2 authentication
 
-For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD with the `oauth2` spec. See the [OAuth2 authentication provider documentation](https://keda.sh/docs/2.20/authentication-providers/oauth/) for the full `TriggerAuthentication.spec.oauth2` schema. In this case, the `username:password` part in the host URI should be omitted. Currently, only HTTP protocol is supported.
+For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD with the `oauth2` spec. See the [OAuth2 authentication provider documentation](https://keda.sh/docs/latest/authentication-providers/oauth2/) for the full `TriggerAuthentication.spec.oauth2` schema. In this case, the `username:password` part in the host URI should be omitted. Currently, only HTTP protocol is supported.
 
 ### Configuration examples
 

--- a/content/docs/2.21/scalers/aws-kinesis.md
+++ b/content/docs/2.21/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 ### Authentication Parameters
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.21/scalers/kubernetes-workload.md
+++ b/content/docs/2.21/scalers/kubernetes-workload.md
@@ -28,7 +28,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 When `groupByNode` is enabled, KEDA groups matching non-terminated pods by node and excludes matching pods without a node assignment. For example, if `7` matching pods are found and `2` of them run on the same node, the scaler reports `6`.
 

--- a/content/docs/2.21/scalers/rabbitmq-queue.md
+++ b/content/docs/2.21/scalers/rabbitmq-queue.md
@@ -115,7 +115,7 @@ For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD
 
 #### OAuth2 authentication
 
-For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD with the `oauth2` spec. See the [OAuth2 authentication provider documentation](https://keda.sh/docs/2.21/authentication-providers/oauth/) for the full `TriggerAuthentication.spec.oauth2` schema. In this case, the `username:password` part in the host URI should be omitted. Currently, only HTTP protocol is supported.
+For RabbitMQ with OIDC support (>= 3.11) you can use `TriggerAuthentication` CRD with the `oauth2` spec. See the [OAuth2 authentication provider documentation](https://keda.sh/docs/latest/authentication-providers/oauth2/) for the full `TriggerAuthentication.spec.oauth2` schema. In this case, the `username:password` part in the host URI should be omitted. Currently, only HTTP protocol is supported.
 
 ### Configuration examples
 

--- a/content/docs/2.4/scalers/aws-kinesis.md
+++ b/content/docs/2.4/scalers/aws-kinesis.md
@@ -36,7 +36,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.5/scalers/aws-kinesis.md
+++ b/content/docs/2.5/scalers/aws-kinesis.md
@@ -36,7 +36,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.6/scalers/aws-kinesis.md
+++ b/content/docs/2.6/scalers/aws-kinesis.md
@@ -36,7 +36,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.6/scalers/kubernetes-workload.md
+++ b/content/docs/2.6/scalers/kubernetes-workload.md
@@ -23,7 +23,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.7/scalers/aws-kinesis.md
+++ b/content/docs/2.7/scalers/aws-kinesis.md
@@ -36,7 +36,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.7/scalers/kubernetes-workload.md
+++ b/content/docs/2.7/scalers/kubernetes-workload.md
@@ -23,7 +23,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.8/scalers/aws-kinesis.md
+++ b/content/docs/2.8/scalers/aws-kinesis.md
@@ -37,7 +37,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.8/scalers/kubernetes-workload.md
+++ b/content/docs/2.8/scalers/kubernetes-workload.md
@@ -25,7 +25,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 

--- a/content/docs/2.9/scalers/aws-kinesis.md
+++ b/content/docs/2.9/scalers/aws-kinesis.md
@@ -40,7 +40,7 @@ triggers:
 
 > These parameters are relevant only when `identityOwner` is set to `pod`.
 
-You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/concepts/authentication).
+You can use `TriggerAuthentication` CRD to configure the authenticate by providing either a role ARN or a set of IAM credentials, or use other [KEDA supported authentication methods](https://keda.sh/docs/latest/concepts/authentication).
 
 #### Delegate auth with TriggerAuthentication
 

--- a/content/docs/2.9/scalers/kubernetes-workload.md
+++ b/content/docs/2.9/scalers/kubernetes-workload.md
@@ -25,7 +25,7 @@ triggers:
 
 > 💡 **Note:** The search scope is limited to the namespace where the `ScaledObject` is deployed.
 
-The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podstatus-v1-core) `phase` equals `Succeeded` or `Failed`.
+The count excludes terminated pods, i.e. [pod status](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus) `phase` equals `Succeeded` or `Failed`.
 
 ### Authentication Parameters
 


### PR DESCRIPTION
### Problem

Several scaler docs contain dead links. This fixes them using version-agnostic targets so they will not go stale, applied across all doc versions that contain each broken link:

- `keda.sh` links now point at `/docs/latest/` (and the `oauth` -> `oauth2` slug is corrected)
- the Kubernetes `PodStatus` reference now uses the stable `kubernetes-api/workload-resources/pod-v1/#PodStatus` page instead of a pinned API version

Affected: `aws-kinesis` (2.4-2.21), `rabbitmq-queue` (2.20-2.21), `kubernetes-workload` (2.6-2.21).

> This supersedes #1809, which I accidentally closed while updating the branch. It incorporates @rickbrouwer's review feedback there (use `latest`, and cover all versions, not just 2.21).