### PR TITLE
docs(azure-pipelines): document service principal authentication

### DIFF
--- a/content/docs/2.21/authentication-providers/azure-service-principal.md
+++ b/content/docs/2.21/authentication-providers/azure-service-principal.md
@@ -1,0 +1,121 @@
++++
+title = "Azure Service Principal"
++++
+
+The `azureServicePrincipal` authentication provider creates a Microsoft Entra service principal credential for supported Azure scalers to use when acquiring access tokens. It can be configured in a `TriggerAuthentication` or `ClusterTriggerAuthentication` and reused by multiple scaling triggers.
+
+The Azure Pipelines scaler supports this provider starting with KEDA 2.21.
+
+## Parameters
+
+- `tenantId` - Microsoft Entra tenant ID. (Required)
+- `clientId` - Application (client) ID of the service principal. (Required)
+- `clientSecret` - Reference to a Kubernetes Secret containing the client secret. (Optional, mutually exclusive with `clientCertificate`)
+- `clientCertificate` - Reference to a Kubernetes Secret containing the client certificate and private key. (Optional, mutually exclusive with `clientSecret`)
+- `clientCertificatePassword` - Reference to a Kubernetes Secret containing the password for a PKCS#12 certificate. (Optional, requires `clientCertificate`)
+- `cloud` - Azure cloud environment. Built-in KEDA cloud names and environments loaded through `AZURE_ENVIRONMENT_FILEPATH` are supported. (Default: `AzurePublicCloud`, Optional)
+- `activeDirectoryEndpoint` - Microsoft Entra authority endpoint. (Optional, required when `cloud` is `Private`; it must not be set for any other cloud)
+
+Exactly one of `clientSecret` or `clientCertificate` must be configured.
+
+## Client secret authentication
+
+Create a Kubernetes Secret containing the service principal client secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-service-principal
+  namespace: default
+type: Opaque
+data:
+  clientSecret: <base64-encoded-client-secret>
+```
+
+Reference it from the authentication provider:
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: azure-service-principal
+  namespace: default
+spec:
+  azureServicePrincipal:
+    tenantId: <tenant-id>
+    clientId: <client-id>
+    clientSecret:
+      valueFrom:
+        secretKeyRef:
+          name: azure-service-principal
+          key: clientSecret
+```
+
+## Client certificate authentication
+
+The certificate Secret must contain either:
+
+- An unencrypted PEM bundle containing the certificate and private key.
+- A PKCS#12/PFX certificate, with `clientCertificatePassword` configured when it is password protected.
+
+Encrypted PEM private keys are not supported. For certificate authentication that requires a password, use PKCS#12/PFX.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-service-principal-certificate
+  namespace: default
+type: Opaque
+data:
+  clientCertificate: <base64-encoded-PEM-or-PFX>
+  clientCertificatePassword: <base64-encoded-password>
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: azure-service-principal-certificate
+  namespace: default
+spec:
+  azureServicePrincipal:
+    tenantId: <tenant-id>
+    clientId: <client-id>
+    clientCertificate:
+      valueFrom:
+        secretKeyRef:
+          name: azure-service-principal-certificate
+          key: clientCertificate
+    clientCertificatePassword:
+      valueFrom:
+        secretKeyRef:
+          name: azure-service-principal-certificate
+          key: clientCertificatePassword
+```
+
+For an unencrypted PEM certificate, omit both `clientCertificatePassword` and its Secret key.
+
+## Azure cloud environments
+
+Azure Public Cloud is used when `cloud` is omitted. Built-in environments include `AzurePublicCloud`, `AzureUSGovernmentCloud`, and `AzureChinaCloud`.
+
+`AzureGermanCloud` remains accepted for compatibility with legacy configurations, but [Microsoft Cloud Germany closed on October 29, 2021](https://learn.microsoft.com/entra/identity-platform/msal-national-cloud#azure-germany-microsoft-cloud-deutschland) and should not be used for new deployments.
+
+`AzureStackCloud` can be used when `AZURE_ENVIRONMENT_FILEPATH` points to an Azure environment file that defines an environment with that name.
+
+For a private cloud, set `cloud` to `Private` and provide its Microsoft Entra authority endpoint:
+
+```yaml
+azureServicePrincipal:
+  tenantId: <tenant-id>
+  clientId: <client-id>
+  cloud: Private
+  activeDirectoryEndpoint: https://login.private.example.com/
+  clientSecret:
+    valueFrom:
+      secretKeyRef:
+        name: azure-service-principal
+        key: clientSecret
+```
+
+KEDA disables Microsoft Entra instance discovery for private-cloud service principal credentials. The consuming scaler remains responsible for selecting its Azure service endpoint and token scope.

--- a/content/docs/2.21/concepts/authentication.md
+++ b/content/docs/2.21/concepts/authentication.md
@@ -141,6 +141,26 @@ spec:
     - parameter: {param-name-used-for-auth}                               # Required.
       name: {key-vault-secret-name}                                       # Required.
       version: {key-vault-secret-version}                                 # Optional.
+  azureServicePrincipal:                                                  # Optional.
+    tenantId: {azure-tenant-id}                                           # Required.
+    clientId: {azure-client-id}                                           # Required.
+    cloud: AzurePublicCloud | AzureUSGovernmentCloud | AzureChinaCloud | AzureGermanCloud | AzureStackCloud | Private # Optional. Default: AzurePublicCloud. AzureGermanCloud is legacy; AzureStackCloud requires AZURE_ENVIRONMENT_FILEPATH.
+    activeDirectoryEndpoint: {active-directory-endpoint-for-cloud}        # Required when cloud = Private; not allowed for other clouds.
+    clientSecret:                                                         # Optional. Mutually exclusive with clientCertificate.
+      valueFrom:                                                          # Required.
+        secretKeyRef:                                                     # Required.
+          name: {k8s-secret-with-azure-client-secret}                     # Required.
+          key: {key-within-the-secret}                                    # Required.
+    clientCertificate:                                                    # Optional. Mutually exclusive with clientSecret.
+      valueFrom:                                                          # Required.
+        secretKeyRef:                                                     # Required.
+          name: {k8s-secret-with-azure-client-certificate}                # Required.
+          key: {key-within-the-secret}                                    # Required.
+    clientCertificatePassword:                                            # Optional. Requires clientCertificate.
+      valueFrom:                                                          # Required.
+        secretKeyRef:                                                     # Required.
+          name: {k8s-secret-with-azure-client-certificate-password}       # Required.
+          key: {key-within-the-secret}                                    # Required.
   awsSecretManager:
     podIdentity:                                                          # Optional.
       provider: aws                                                       # Required.

--- a/content/docs/2.21/scalers/azure-pipelines.md
+++ b/content/docs/2.21/scalers/azure-pipelines.md
@@ -69,7 +69,7 @@ The Azure Pipelines scaler supports the following Azure DevOps authentication me
 - [Azure AD Workload Identity](../authentication-providers/azure-ad-workload-identity/)
 - [Microsoft Entra service principal](../authentication-providers/azure-service-principal/) using a client secret or certificate
 
-The Azure DevOps organization URL must be provided through `organizationURL`, `organizationURLFromEnv`, or an authentication parameter. Authentication credentials can be supplied through environment variables or an `authenticationRef`.
+The Azure DevOps organization URL can be supplied directly through `organizationURL`, from the scale target through `organizationURLFromEnv`, or as an authentication parameter. A PAT can be supplied through `personalAccessTokenFromEnv` or an `authenticationRef`. Workload identity and service principal authentication must be configured through an `authenticationRef`.
 
 When more than one authentication method is configured, KEDA uses the following precedence:
 

--- a/content/docs/2.21/scalers/azure-pipelines.md
+++ b/content/docs/2.21/scalers/azure-pipelines.md
@@ -63,16 +63,34 @@ triggers:
 
 ### Authentication Parameters
 
-As an alternative to using environment variables, you can authenticate with Azure Devops using a Personal Access Token or Managed identity via `TriggerAuthentication` configuration. If `personalAccessTokenFromEnv` or `personalAccessTokenFrom` is empty `TriggerAuthentication` must be configured using podIdentity.
+The Azure Pipelines scaler supports the following Azure DevOps authentication methods:
 
-**Personal Access Token Authentication:**
+- Personal Access Token (PAT)
+- [Azure AD Workload Identity](../authentication-providers/azure-ad-workload-identity/)
+- [Microsoft Entra service principal](../authentication-providers/azure-service-principal/) using a client secret or certificate
 
-- `organizationURL` - The URL of the Azure DevOps organization.
-- `personalAccessToken` - The Personal Access Token (PAT) for Azure DevOps.
+The Azure DevOps organization URL must be provided through `organizationURL`, `organizationURLFromEnv`, or an authentication parameter. Authentication credentials can be supplied through environment variables or an `authenticationRef`.
 
-**Pod Identity Authentication**
+When more than one authentication method is configured, KEDA uses the following precedence:
 
-[Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/) provider can be used.
+1. Personal Access Token
+2. Azure AD Workload Identity
+3. Microsoft Entra service principal
+
+#### Personal Access Token authentication
+
+- `organizationURL` - URL of the Azure DevOps organization.
+- `personalAccessToken` - Personal Access Token for Azure DevOps.
+
+#### Azure AD Workload Identity authentication
+
+Configure a `TriggerAuthentication` or `ClusterTriggerAuthentication` with `podIdentity.provider` set to `azure-workload`.
+
+#### Microsoft Entra service principal authentication
+
+Configure the reusable `azureServicePrincipal` authentication provider with either a client secret or client certificate. The Azure Pipelines scaler acquires a Microsoft Entra token for Azure DevOps and sends it as a bearer token.
+
+Before using the scaler, add the service principal to the Azure DevOps organization and grant it permission to read the required agent pool and its job requests. When adding it to Azure DevOps, use the service principal object ID from **Enterprise applications**, not the application registration object ID. For detailed setup instructions, see the [Azure DevOps service principal documentation](https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/service-principal-managed-identity?view=azure-devops).
 
 ### How to determine your pool ID
 
@@ -180,7 +198,7 @@ chmod +x ./run-docker.sh
 ./run-docker.sh "$@" --once & wait $!
 ```
 
-### Example for ScaledObject
+### Example using Personal Access Token authentication
 
 ```yaml
 apiVersion: v1
@@ -220,7 +238,55 @@ spec:
       parent: "example-keda-template"
       demands: "maven,docker"
     authenticationRef:
-     name: pipeline-trigger-auth
+      name: pipeline-trigger-auth
+```
+
+### Example using service principal authentication
+
+The following example uses a client secret. Certificate credentials can be configured using the same [`azureServicePrincipal` authentication provider](../authentication-providers/azure-service-principal/).
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-pipelines-service-principal
+  namespace: default
+type: Opaque
+data:
+  clientSecret: <base64-encoded-client-secret>
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: azure-pipelines-service-principal
+  namespace: default
+spec:
+  azureServicePrincipal:
+    tenantId: <tenant-id>
+    clientId: <client-id>
+    clientSecret:
+      valueFrom:
+        secretKeyRef:
+          name: azure-pipelines-service-principal
+          key: clientSecret
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: azure-pipelines-scaledobject
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: azdevops-deployment
+  minReplicaCount: 1
+  maxReplicaCount: 5
+  triggers:
+  - type: azure-pipelines
+    metadata:
+      poolID: "1"
+      organizationURL: "https://dev.azure.com/<organization>"
+    authenticationRef:
+      name: azure-pipelines-service-principal
 ```
 
 ### Example for Parent Deployment or StatefulSet
@@ -277,5 +343,5 @@ spec:
       parent: "example-keda-template"
       demands: "maven,docker"
     authenticationRef:
-     name: pipeline-trigger-auth
+      name: pipeline-trigger-auth
 ```


### PR DESCRIPTION
_Provide a description of what has been changed_

Documents the new **Azure service principal** authentication provider and its use by the Azure Pipelines scaler, targeting the 2.21 docs.

- **New** `authentication-providers/azure-service-principal.md` — parameters, client
  secret and certificate examples, and Azure cloud environment guidance
  (sovereign clouds, `Private`, `AzureStackCloud` via `AZURE_ENVIRONMENT_FILEPATH`,
  and a legacy note for `AzureGermanCloud`).
- **Updated** `concepts/authentication.md` — adds `azureServicePrincipal` to the
  TriggerAuthentication spec reference, including the rule that
  `activeDirectoryEndpoint` is required for `Private` and not allowed for other clouds.
- **Updated** `scalers/azure-pipelines.md` — documents the supported auth methods
  (PAT, Azure AD Workload Identity, Microsoft Entra service principal), their
  precedence, the Azure DevOps org-access prerequisite, and a service principal
  `ScaledObject` example.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

## Related Issue
Relates to kedacore/keda#4853
Relates to kedacore/keda#7581

Relates to kedacore/keda#7931
Relates to kedacore/charts#888

