### PR TITLE
docs: fix outdated GitHub App Organization permissions for github-runner scaler

### DIFF
--- a/content/docs/2.11/scalers/github-runner.md
+++ b/content/docs/2.11/scalers/github-runner.md
@@ -29,7 +29,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -47,7 +47,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -81,8 +81,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -109,7 +107,7 @@ The scaler will query the GitHub API in the following order:
 
 GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
 
-Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows, 
+Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows,
 and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout can help reduce the number of API calls. Usage of the `repos` parameter is recommended to reduce the number of API calls to the GitHub API.

--- a/content/docs/2.12/scalers/github-runner.md
+++ b/content/docs/2.12/scalers/github-runner.md
@@ -29,7 +29,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -47,7 +47,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -81,8 +81,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -109,7 +107,7 @@ The scaler will query the GitHub API in the following order:
 
 GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
 
-Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows, 
+Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows,
 and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout can help reduce the number of API calls. Usage of the `repos` parameter is recommended to reduce the number of API calls to the GitHub API.

--- a/content/docs/2.13/scalers/github-runner.md
+++ b/content/docs/2.13/scalers/github-runner.md
@@ -29,7 +29,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -47,7 +47,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -81,8 +81,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -109,7 +107,7 @@ The scaler will query the GitHub API in the following order:
 
 GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
 
-Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows, 
+Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows,
 and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout can help reduce the number of API calls. Usage of the `repos` parameter is recommended to reduce the number of API calls to the GitHub API.

--- a/content/docs/2.14/scalers/github-runner.md
+++ b/content/docs/2.14/scalers/github-runner.md
@@ -30,7 +30,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -48,7 +48,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -82,8 +82,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -110,7 +108,7 @@ The scaler will query the GitHub API in the following order:
 
 GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
 
-Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows, 
+Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows,
 and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout can help reduce the number of API calls. Usage of the `repos` parameter is recommended to reduce the number of API calls to the GitHub API.

--- a/content/docs/2.15/scalers/github-runner.md
+++ b/content/docs/2.15/scalers/github-runner.md
@@ -30,7 +30,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -48,7 +48,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -82,8 +82,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -110,7 +108,7 @@ The scaler will query the GitHub API in the following order:
 
 GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
 
-Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows, 
+Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows,
 and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout can help reduce the number of API calls. Usage of the `repos` parameter is recommended to reduce the number of API calls to the GitHub API.

--- a/content/docs/2.16/scalers/github-runner.md
+++ b/content/docs/2.16/scalers/github-runner.md
@@ -32,7 +32,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -51,7 +51,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -86,8 +86,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -114,7 +112,7 @@ The scaler will query the GitHub API in the following order:
 
 GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)
 
-Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows, 
+Example: The GitHub API has a rate limit of standard 5000 requests per hour. The scaler will make 1 request per repository to get the list of workflows,
 and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout can help reduce the number of API calls. Usage of the `repos` parameter is recommended to reduce the number of API calls to the GitHub API.

--- a/content/docs/2.17/scalers/github-runner.md
+++ b/content/docs/2.17/scalers/github-runner.md
@@ -34,7 +34,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -54,7 +54,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -89,8 +89,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))

--- a/content/docs/2.18/scalers/github-runner.md
+++ b/content/docs/2.18/scalers/github-runner.md
@@ -36,7 +36,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -57,7 +57,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -93,8 +93,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))

--- a/content/docs/2.19/scalers/github-runner.md
+++ b/content/docs/2.19/scalers/github-runner.md
@@ -36,7 +36,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -57,7 +57,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -93,8 +93,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))

--- a/content/docs/2.20/scalers/github-runner.md
+++ b/content/docs/2.20/scalers/github-runner.md
@@ -36,7 +36,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -57,7 +57,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -93,8 +93,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -135,7 +133,7 @@ Careful design of how you design your repository request layout and configure th
 - Using the `repos` parameter as opposed to just `owner` means that the Github API isn't queried to get a list of repositories.
 - Setting `enableEtags` to `true` can reduce the rate limit consumption, as this makes [conditional requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate) against the Github API by passing the Etag of the last request to the URL, if a `304: Not modified` response is returned, this will not count against the rate limit. In this case the scaler will use the results from the last query to the URL where the response was `200: Success`.
 
-The github scaler [handles rate limit errors appropriately](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2026-03-10#handle-rate-limit-errors-appropriately) by waiting until X-RateLimit-Reset or Retry-After times until the github API is queried when rate limited. During this time it will return the cached queue length which is updated with each successful request. 
+The github scaler [handles rate limit errors appropriately](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2026-03-10#handle-rate-limit-errors-appropriately) by waiting until X-RateLimit-Reset or Retry-After times until the github API is queried when rate limited. During this time it will return the cached queue length which is updated with each successful request.
 
 **Fine-Tuning**
 

--- a/content/docs/2.21/scalers/github-runner.md
+++ b/content/docs/2.21/scalers/github-runner.md
@@ -36,7 +36,7 @@ triggers:
       # Optional: The name of the application ID from the GitHub App
       applicationID: "{applicatonID}"
       # Optional: The name of the installation ID from the GitHub App once installed into Org or repo.
-      installationID: "{installationID}"      
+      installationID: "{installationID}"
     authenticationRef:
       name: personalAccessToken or appKey triggerAuthentication Reference
 ```
@@ -57,7 +57,7 @@ triggers:
 
 *Parameters from Environment Variables*
 
-You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`, 
+You can access each parameter from above using environment variables. When you specify the parameter in metadata with a suffix of `FromEnv`,
 the scaler will use the value from the environment variable. The environment variable must be available to the manifest. e.g. `labelsFromEnv: "RUNNER_LABELS"` will use the environment variable `RUNNER_LABELS` as the source fo the `labels` parameter.
 
 - `githubApiURLFromEnv` - The URL of the GitHub API, defaults to https://api.github.com. You should only need to modify this if you have your own GitHub Appliance. (Optional)
@@ -93,8 +93,6 @@ You can use the GitHub App to authenticate with GitHub. This is useful if you wa
         - Administration - Read & Write
         - Metadata - Read-only
     - **Organization permissions**
-        - Actions - Read-only
-        - Metadata - Read-only
         - Self-hosted Runners - Read & write
 5. Download the private key for the GitHub App. ([docs](https://docs.github.com/en/developers/apps/authenticating-with-github-apps#generating-a-private-key))
 6. Install the GitHub App on your organization or repository. ([docs](https://docs.github.com/en/developers/apps/installing-github-apps))
@@ -135,7 +133,7 @@ Careful design of how you design your repository request layout and configure th
 - Using the `repos` parameter as opposed to just `owner` means that the Github API isn't queried to get a list of repositories.
 - Setting `enableEtags` to `true` can reduce the rate limit consumption, as this makes [conditional requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate) against the Github API by passing the Etag of the last request to the URL, if a `304: Not modified` response is returned, this will not count against the rate limit. In this case the scaler will use the results from the last query to the URL where the response was `200: Success`.
 
-The github scaler [handles rate limit errors appropriately](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2026-03-10#handle-rate-limit-errors-appropriately) by waiting until X-RateLimit-Reset or Retry-After times until the github API is queried when rate limited. During this time it will return the cached queue length which is updated with each successful request. 
+The github scaler [handles rate limit errors appropriately](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2026-03-10#handle-rate-limit-errors-appropriately) by waiting until X-RateLimit-Reset or Retry-After times until the github API is queried when rate limited. During this time it will return the cached queue length which is updated with each successful request.
 
 **Fine-Tuning**
 


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #

## Description

Fixes the "Organization permissions" list for the GitHub App required by
the `github-runner` scaler, which no longer matches the current GitHub
App permission editor UI.

However, the current GitHub App permission editor does **not** expose
"Actions" or "Metadata" at the Organization level at all. The only
relevant Organization-level permission is **Self-hosted runners**.

Verified directly against the current GitHub App permission editor UI
(screenshot below).

## Changes

- Removed "Actions" and "Metadata" from the Organization permissions list
- Corrected "Self-hosted Runners" casing to match the UI ("Self-hosted runners")
- Applied the fix to both `2.20` and `2.21` (unreleased) docs

## Screenshot

<img width="1303" height="218" alt="image" src="https://github.com/user-attachments/assets/306d8238-2900-445c-9865-68b3d4a285e9" />

Fixes #1805 