### PR TITLE
docs(http-add-on): note queue tick duration also bounds /queue fetches

### DIFF
--- a/content/http-add-on/0.16/reference/environment-variables.md
+++ b/content/http-add-on/0.16/reference/environment-variables.md
@@ -95,7 +95,7 @@ When set, they take precedence over their replacements.
 | `KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT`          | _(required)_ | Name of the interceptor Deployment to issue metrics RPC requests to.                |
 | `KEDA_HTTP_SCALER_TARGET_ADMIN_PORT`                | _(required)_ | Port on the interceptor admin Service for metrics RPC requests.                     |
 | `KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD` | `60m`        | Resync interval for the controller-runtime cache.                                   |
-| `KEDA_HTTP_QUEUE_TICK_DURATION`                     | `500ms`      | Duration between queue polling ticks.                                               |
+| `KEDA_HTTP_QUEUE_TICK_DURATION`                     | `500ms`      | Duration between queue polling ticks. Also bounds each request to an interceptor pod's `/queue` endpoint (clamped to a minimum of `250ms`), so one unresponsive interceptor cannot stall metric collection. |
 | `KEDA_HTTP_SCALER_STREAM_INTERVAL_MS`               | `200`        | Interval in milliseconds between stream ticks for `IsActive` communication to KEDA. |
 
 ### Metrics


### PR DESCRIPTION
## Summary
- Document that `KEDA_HTTP_QUEUE_TICK_DURATION` also bounds each scaler request to an interceptor pod's `/queue` endpoint (clamped to a minimum of `250ms`), matching [kedacore/http-add-on#1729](https://github.com/kedacore/http-add-on/pull/1729).
- Scoped to the unreleased `0.16` docs; this behavior is not in v0.15.0.

## Test plan
- [x] Confirm the updated description in [Environment Variables](https://keda.sh/docs/http-add-on/0.16/reference/environment-variables/) renders correctly in the table.
- [x] Spot-check that `0.14`/`0.15` entries are unchanged.