### PR TITLE
docs(http-add-on): document direct pod routing default

### DIFF
--- a/content/http-add-on/0.16/concepts/architecture.md
+++ b/content/http-add-on/0.16/concepts/architecture.md
@@ -38,7 +38,9 @@ The interceptor supports HTTP/1.1, HTTP/2 (both h2c and h2 over TLS), gRPC, and 
 For cleartext backends, the interceptor defaults to HTTP/1.1 unless the target Service port sets `appProtocol: kubernetes.io/h2c`, which switches the backend connection to HTTP/2 cleartext (required for gRPC).
 For TLS backends, the protocol is negotiated automatically via ALPN.
 
-The interceptor forwards requests to the backend's Kubernetes Service, relying on standard Kubernetes service load balancing for distribution across pods.
+By default, the interceptor routes each request directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features such as Service-level NetworkPolicy, session affinity, and topology-aware routing.
+Set `KEDA_HTTP_DIRECT_POD_ROUTING=false` to forward through the Service and use standard Kubernetes service load balancing instead.
+See [Configure the Interceptor](../../operations/configure-interceptor/#direct-pod-routing).
 
 The interceptor deployment is itself auto-scaled by KEDA via a ScaledObject created by the Helm chart.
 

--- a/content/http-add-on/0.16/operations/configure-interceptor.md
+++ b/content/http-add-on/0.16/operations/configure-interceptor.md
@@ -40,6 +40,24 @@ helm upgrade http-add-on kedacore/keda-add-ons-http \
   --set interceptor.extraEnvs.KEDA_HTTP_ENABLE_COLD_START_HEADER=false
 ```
 
+## Direct pod routing
+
+By default, the interceptor forwards each request to a ready backend pod IP rather than the Service ClusterIP.
+This avoids kube-proxy and other Service-layer features, which improves cold-start latency when EndpointSlice updates have not yet propagated to every node.
+
+Direct pod routing is enabled by default.
+Disable it if you rely on Service-level NetworkPolicy, session affinity, or topology-aware routing:
+
+```shell
+helm upgrade http-add-on kedacore/keda-add-ons-http \
+  --namespace keda \
+  --set interceptor.extraEnvs.KEDA_HTTP_DIRECT_POD_ROUTING=false
+```
+
+| Helm value | Env var                        | Default | Description                                                                                                                                      |
+| ---------- | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| —          | `KEDA_HTTP_DIRECT_POD_ROUTING` | `true`  | Route to a ready pod IP when `true`; forward through the Service ClusterIP when `false`.                                                         |
+
 ## Connection tuning
 
 Configure the interceptor's connection pool for backend services:

--- a/content/http-add-on/0.16/reference/environment-variables.md
+++ b/content/http-add-on/0.16/reference/environment-variables.md
@@ -18,6 +18,7 @@ These are set via the `extraEnvs` Helm value for each component or directly in t
 | `KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD` | `60m`        | Resync interval for the controller-runtime cache.                                             |
 | `KEDA_HTTP_ENABLE_COLD_START_HEADER`                | `true`       | When enabled, the interceptor adds the `X-KEDA-HTTP-Cold-Start` response header.              |
 | `KEDA_HTTP_LOG_REQUESTS`                            | `false`      | Enable logging of incoming requests.                                                          |
+| `KEDA_HTTP_DIRECT_POD_ROUTING`                      | `true`       | When enabled, route requests to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (Service-level NetworkPolicy, session affinity, topology-aware routing). |
 
 ### Graceful shutdown
 


### PR DESCRIPTION
## Summary
- Document `KEDA_HTTP_DIRECT_POD_ROUTING` (default `true`) in the 0.16 environment variables reference and Configure Interceptor guide, matching [kedacore/http-add-on#1697](https://github.com/kedacore/http-add-on/pull/1697) / [#1585](https://github.com/kedacore/http-add-on/pull/1585).
- Correct architecture text that still described forwarding only through the Service ClusterIP.
- Scoped to the unreleased `0.16` docs; this feature is not in v0.15.0.

## Test plan
- [x] Confirm the new env var row renders in [Environment Variables](https://keda.sh/docs/http-add-on/0.16/reference/environment-variables/).
- [x] Confirm the Direct pod routing section and helm example in [Configure the Interceptor](https://keda.sh/docs/http-add-on/0.16/operations/configure-interceptor/).
- [x] Confirm the architecture interceptor section no longer claims ClusterIP-only forwarding.
- [x] Spot-check that `0.14`/`0.15` pages are unchanged.