### PR TITLE
docs(http-add-on): document cold-start pending request limit

### DIFF
--- a/content/http-add-on/0.16/operations/configure-interceptor.md
+++ b/content/http-add-on/0.16/operations/configure-interceptor.md
@@ -40,6 +40,19 @@ helm upgrade http-add-on kedacore/keda-add-ons-http \
   --set interceptor.extraEnvs.KEDA_HTTP_ENABLE_COLD_START_HEADER=false
 ```
 
+## Cold-start pending request limit
+
+While a backend has no ready endpoints (e.g. during scale-from-zero), the interceptor holds incoming requests until an endpoint becomes ready.
+By default, the number of held requests per route is unlimited, so a request burst against a scaled-to-zero app can exhaust an interceptor pod's memory and file descriptors.
+Set a cluster-wide default limit to protect the interceptor:
+
+| Helm value                                | Env var                                     | Default | Description                                                                                      |
+| ------------------------------------------ | ------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `interceptor.coldStart.maxPendingRequests` | `KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS` | `0`     | Maximum requests held per route while the backend is not ready. `0` means unlimited.             |
+
+The limit applies per interceptor replica, so the effective cluster-wide capacity scales with the replica count.
+Application developers can override it per route with `coldStart.maxPendingRequests` — see [Configure Cold-Start Behavior](../../user-guide/configure-cold-start/).
+
 ## Direct pod routing
 
 By default, the interceptor forwards each request to a ready backend pod IP rather than the Service ClusterIP.

--- a/content/http-add-on/0.16/reference/environment-variables.md
+++ b/content/http-add-on/0.16/reference/environment-variables.md
@@ -17,6 +17,7 @@ These are set via the `extraEnvs` Helm value for each component or directly in t
 | `KEDA_HTTP_WATCH_NAMESPACE`                         | `""`         | Namespace to watch for HTTPScaledObjects and InterceptorRoutes. Empty watches all namespaces. |
 | `KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD` | `60m`        | Resync interval for the controller-runtime cache.                                             |
 | `KEDA_HTTP_ENABLE_COLD_START_HEADER`                | `true`       | When enabled, the interceptor adds the `X-KEDA-HTTP-Cold-Start` response header.              |
+| `KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS`         | `0`          | Default limit on requests held per route while the backend has no ready endpoints (e.g. during scale-from-zero). `0` means unlimited. Routes override it via `coldStart.maxPendingRequests`. Applies per interceptor replica. |
 | `KEDA_HTTP_LOG_REQUESTS`                            | `false`      | Enable logging of incoming requests.                                                          |
 | `KEDA_HTTP_DIRECT_POD_ROUTING`                      | `true`       | When enabled, route requests to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (Service-level NetworkPolicy, session affinity, topology-aware routing). |
 

--- a/content/http-add-on/0.16/reference/interceptorroute.md
+++ b/content/http-add-on/0.16/reference/interceptorroute.md
@@ -151,15 +151,29 @@ For usage guidance, see [Configure Static Routes](../../user-guide/configure-sta
 
 Configures behavior while the target is not ready (scaling from zero).
 
-| Field         | Type                                             | Required | Default | Description                                                                                          |
-| ------------- | ------------------------------------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `fallback`    | [`*ColdStartFallback`](#coldstartfallback)       | No       |         | Fallback service to route to when the target is scaling from zero and the readiness timeout expires. |
-| `placeholder` | [`*ColdStartPlaceholder`](#coldstartplaceholder) | No       |         | Placeholder response to serve while the target has no ready endpoints.                               |
+| Field                | Type                                             | Required | Default                                        | Description                                                                                                          |
+| -------------------- | ------------------------------------------------ | -------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `fallback`           | [`*ColdStartFallback`](#coldstartfallback)       | No       |                                                | Fallback service to route to when the target is scaling from zero and the readiness timeout expires.                 |
+| `placeholder`        | [`*ColdStartPlaceholder`](#coldstartplaceholder) | No       |                                                | Placeholder response to serve while the target has no ready endpoints.                                               |
+| `maxPendingRequests` | `*int32`                                         | No       | Global `KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS` | Maximum pending requests held while the backend is not ready. Minimum: 1. See [pending request limit](#pending-request-limit). |
+| `overflow`           | `string`                                         | No       | `Reject`                                       | How to handle requests arriving when the pending request limit is reached: `Reject` or `Placeholder`.                |
 
-**Validation:** At least one of `fallback` or `placeholder` must be set.
+**Validation:** At least one of `fallback`, `placeholder`, or `maxPendingRequests` must be set.
+When `overflow` is `Placeholder`, `placeholder` must be set.
 
 When both are configured, the placeholder response is returned immediately while the backend scales up.
 If the backend does not become ready within the readiness timeout, the fallback service is used.
+
+#### Pending request limit
+
+`maxPendingRequests` bounds how many requests the interceptor holds for a route while the backend has no ready endpoints.
+Requests arriving when the limit is reached are handled according to `overflow`: `Reject` returns HTTP 503, while `Placeholder` serves the configured placeholder response.
+
+The limit applies per interceptor replica: the effective cluster-wide capacity is `maxPendingRequests` multiplied by the number of interceptor replicas.
+
+Setting `maxPendingRequests` together with a placeholder and `overflow: Placeholder` holds requests up to the limit instead of serving the placeholder immediately; only overflowing requests receive it.
+
+For usage guidance, see [Configure Cold-Start Behavior](../../user-guide/configure-cold-start/).
 
 ### `ColdStartFallback`
 

--- a/content/http-add-on/0.16/reference/metrics.md
+++ b/content/http-add-on/0.16/reference/metrics.md
@@ -73,6 +73,22 @@ See [Environment Variables](../environment-variables/#metrics) for configuration
 | `route_name`      | Name of the matched InterceptorRoute or HTTPScaledObject.                                                                 |
 | `route_namespace` | Namespace of the matched route resource.                                                                                  |
 
+### Cold-start rejections
+
+|                          |                                                                             |
+| ------------------------ | --------------------------------------------------------------------------- |
+| **Prometheus name**      | `interceptor_cold_start_rejections_total`                                   |
+| **OTel instrument name** | `interceptor.cold_start.rejections`                                         |
+| **Type**                 | Counter                                                                     |
+| **Description**          | Requests rejected because the cold-start pending request limit was reached. |
+
+**Labels:**
+
+| Label             | Description                                               |
+| ----------------- | --------------------------------------------------------- |
+| `route_name`      | Name of the matched InterceptorRoute or HTTPScaledObject. |
+| `route_namespace` | Namespace of the matched route resource.                  |
+
 ### Method normalization
 
 The `method` label accepts the following standard HTTP methods without modification:

--- a/content/http-add-on/0.16/user-guide/configure-cold-start.md
+++ b/content/http-add-on/0.16/user-guide/configure-cold-start.md
@@ -1,10 +1,11 @@
 +++
 title = "Configure Cold-Start Behavior"
-description = "Placeholder responses, fallback services, and response headers for cold-start scenarios"
+description = "Placeholder responses, fallback services, pending request limits, and response headers for cold-start scenarios"
 +++
 
 When a request arrives for a backend that has been scaled to zero, the interceptor holds the request until the backend becomes ready.
 You can configure a placeholder response, a fallback service, or both to control what happens during a cold start.
+You can also limit how many requests are held while the backend scales up.
 
 ## Placeholder response
 
@@ -136,6 +137,41 @@ coldStart:
       name: fallback-svc
       port: 8080
 ```
+
+## Limiting pending requests
+
+While a backend has no ready endpoints, the interceptor holds incoming requests until an endpoint becomes ready.
+Each held request keeps a connection and its buffers open, so a request burst against a scaled-to-zero app can exhaust an interceptor pod's memory.
+Use `coldStart.maxPendingRequests` to bound how many requests a route holds:
+
+```yaml
+coldStart:
+  maxPendingRequests: 500
+  overflow: Reject
+```
+
+Requests arriving when the limit is reached are rejected with HTTP `503`.
+Rejections are tracked by the `interceptor_cold_start_rejections_total` metric (see [Metrics Reference](../../reference/metrics/)).
+
+Set `overflow` to `Placeholder` to serve the configured placeholder response instead of an error:
+
+```yaml
+coldStart:
+  maxPendingRequests: 500
+  overflow: Placeholder
+  placeholder:
+    response:
+      body: "<h1>Loading...</h1>"
+      headers:
+        Refresh: "5"
+      statusCode: 503
+```
+
+With this combination, the first 500 requests are held until the backend becomes ready, and only overflowing requests receive the placeholder.
+A placeholder without `maxPendingRequests` keeps its default behavior: every request receives the placeholder immediately and no requests are held.
+
+The limit applies per interceptor replica: with 3 interceptor replicas, up to 1,500 requests can be held cluster-wide.
+When unset, the global `KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS` default applies (`0` — unlimited, see [Configure the Interceptor](../../operations/configure-interceptor/#cold-start-pending-request-limit)).
 
 ## Cold-start response header
 


### PR DESCRIPTION
Document the new `coldStart.maxPendingRequests` and `coldStart.overflow` InterceptorRoute fields and the `KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS` interceptor default (kedacore/http-add-on#1732, kedacore/http-add-on#1733), in the unreleased 0.16 version:

- **interceptorroute reference**: new `ColdStartSpec` fields, updated validation rules, and a "Pending request limit" section covering the per-replica semantics
- **configure-cold-start user guide**: "Limiting pending requests" section with `Reject` and `Placeholder` overflow examples
- **environment-variables reference**: new interceptor variable
- **metrics reference**: `interceptor_cold_start_rejections_total` counter
- **configure-interceptor operations page**: global default via the new `interceptor.coldStartMaxPendingRequests` Helm value (kedacore/charts#896)

Depends on kedacore/http-add-on#1733 (approved, not yet merged — 0.16 docs are unpublished until release).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to kedacore/http-add-on#1732