### PR TITLE
Revert "chore: update zoom link"

### DIFF
--- a/includes/get-involved.md
+++ b/includes/get-involved.md
@@ -1,7 +1,7 @@
 If you're interested in contributing to or participating in the direction of KEDA, you can join our community meetings.
 
 * Meeting time: Bi-weekly Tues 17:00 (European time - CEST/CET). | [Convert to your timezone](https://dateful.com/time-zone-converter?t=04:00%20pm&tz=UTC))
-* Link: https://zoom-lfx.platform.linuxfoundation.org/meeting/99013592011?password=ae029ce9-52a1-49d5-8e2c-e40287910161
+* Link: https://zoom-lfx.platform.linuxfoundation.org/meeting/95172147716?password=e10a898f-1dab-47cb-84df-6b94e8572d48
 * Meeting agenda: [Google Docs](https://docs.google.com/document/d/1zdwD6j86GxcCe5S5ay9suCO77WPrEDnKSfuaI24EwM4/edit?usp=sharing)
 
 Just want to learn or chat about KEDA? Feel free to join the conversation in the [#keda](https://kubernetes.slack.com/messages/CKZJ36A5D) (general), [#keda-dev](https://kubernetes.slack.com/archives/C01JGDP8MB8) & [#keda-docs](https://kubernetes.slack.com/archives/C03M2DKCS3H) channel(s) on the [Kubernetes Slack](https://slack.k8s.io)!


### PR DESCRIPTION
The link in docs was wrongly updated to a non-recurrent link created just for 28th of Jul. The recurrent link was the other one replaced. This PR restores it


https://zoom-lfx.platform.linuxfoundation.org/meeting/95172147716?password=e10a898f-1dab-47cb-84df-6b94e8572d48