### PR TITLE
feat: Explain when pollingInterval is not relevant for scaling

### DIFF
--- a/content/docs/2.21/reference/scaledobject-spec.md
+++ b/content/docs/2.21/reference/scaledobject-spec.md
@@ -71,15 +71,15 @@ To scale Kubernetes Deployments only `name` need be specified. To scale a differ
 ```yaml
   pollingInterval: 30  # Optional. Default: 30 seconds
 ```
-This is the interval to check each trigger on. By default, KEDA will check each trigger source on every ScaledObject every 30 seconds, unless the interval is not relevant for scaling (see below).
+This is the interval to check each trigger on. By default, KEDA will check each trigger source on every ScaledObject every 30 seconds, unless the interval is not relevant for scaling (see the note below).
 
 When scaling from 0 to 1, the polling interval is controlled by KEDA. For example, if this parameter is set to `60`, KEDA will poll for a metric value every 60 seconds while the number of replicas is 0.
 
 While scaling from 1 to N, on top of KEDA, the HPA will also poll regularly for metrics, based on the [`--horizontal-pod-autoscaler-sync-period`](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options) parameter to the `kube-controller-manager`, which by default is 15 seconds. For example, if the `kube-controller-manager` was started with `--horizontal-pod-autoscaler-sync-period=30`, the HPA will poll for a metric value every 30 seconds while the number of replicas is between 1 and N.
 
-When `minReplicaCount` is greater than 0 and neither `idleReplicaCount`, `useCachedMetrics` nor `scalingModifiers` are used, the workload can never scale to zero and the HPA drives all scaling on its own. In that case KEDA no longer queries the trigger sources on `pollingInterval`; it reuses the metric values from the HPA's own queries instead. `pollingInterval` then only controls how often the `ScaledObject` status is refreshed.
+> 💡 **NOTE:** When `minReplicaCount` is greater than 0 and neither `idleReplicaCount`, `useCachedMetrics` nor `scalingModifiers` are used, the workload can never scale to zero and the HPA drives all scaling on its own. In that case KEDA no longer queries the trigger sources on `pollingInterval`; it reuses the metric values from the HPA's own queries instead. KEDA still queries the trigger sources itself whenever such a value is not available, for example before the HPA's first query or while the HPA is not actively scaling. `pollingInterval` then only controls how often KEDA refreshes the `ScaledObject` status conditions and events, so removing it means those are refreshed on the default of 30 seconds.
 
-If you want respect the polling interval, the feature [`caching metrics`](../concepts/scaling-deployments/#caching-metrics) enables caching of metric values during polling interval.
+If you want to respect the polling interval, the feature [`caching metrics`](../concepts/scaling-deployments/#caching-metrics) enables caching of metric values during polling interval.
 
 **Example:** in a queue scenario, KEDA will check the queueLength every `pollingInterval` while the number of replicas is 0, and scale the resource up an down accordingly.
 

--- a/content/docs/2.21/reference/scaledobject-spec.md
+++ b/content/docs/2.21/reference/scaledobject-spec.md
@@ -71,11 +71,13 @@ To scale Kubernetes Deployments only `name` need be specified. To scale a differ
 ```yaml
   pollingInterval: 30  # Optional. Default: 30 seconds
 ```
-This is the interval to check each trigger on. By default, KEDA will check each trigger source on every ScaledObject every 30 seconds.
+This is the interval to check each trigger on. By default, KEDA will check each trigger source on every ScaledObject every 30 seconds, unless the interval is not relevant for scaling (see below).
 
 When scaling from 0 to 1, the polling interval is controlled by KEDA. For example, if this parameter is set to `60`, KEDA will poll for a metric value every 60 seconds while the number of replicas is 0.
 
 While scaling from 1 to N, on top of KEDA, the HPA will also poll regularly for metrics, based on the [`--horizontal-pod-autoscaler-sync-period`](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options) parameter to the `kube-controller-manager`, which by default is 15 seconds. For example, if the `kube-controller-manager` was started with `--horizontal-pod-autoscaler-sync-period=30`, the HPA will poll for a metric value every 30 seconds while the number of replicas is between 1 and N.
+
+When `minReplicaCount` is greater than 0 and neither `idleReplicaCount`, `useCachedMetrics` nor `scalingModifiers` are used, the workload can never scale to zero and the HPA drives all scaling on its own. In that case KEDA no longer queries the trigger sources on `pollingInterval`; it reuses the metric values from the HPA's own queries instead. `pollingInterval` then only controls how often the `ScaledObject` status is refreshed.
 
 If you want respect the polling interval, the feature [`caching metrics`](../concepts/scaling-deployments/#caching-metrics) enables caching of metric values during polling interval.
 


### PR DESCRIPTION
Update the `pollingInterval` documentation for kedacore/keda#8031.
When `minReplicaCount` is greater than 0 and neither `idleReplicaCount`, `useCachedMetrics` nor `scalingModifiers` are used, KEDA no longer queries the trigger sources on `pollingInterval` but reuses the metric values from the HPA's own queries. `pollingInterval` then only controls how often the `ScaledObject` status is refreshed.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates: https://github.com/kedacore/keda/pull/8031