### PR TITLE
enforce light theme

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html {{- with site.Language.Locale }} lang="{{ . }}" {{- end }}>
+<html data-theme="light" {{- with site.Language.Locale }} lang="{{ . }}" {{- end }}>
   <head>
     {{ partial "meta.html" . }}
     <title>


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The recent updates (https://github.com/kedacore/keda-docs/pull/1839) broke the website design on devices with dark mode. The page is rendered with dark background but the rest of the site design is not ready for it, this results in unpleasant page, see the screenshot below.

This PR enforces light mode.

<img width="1270" height="1099" alt="Screenshot 2026-08-20 at 12 03 38" src="https://github.com/user-attachments/assets/930bfee2-81cf-422a-b51a-3a3ddedfb7c3" />

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

