### PR TITLE
docs(kafka): Add Azure Workload Identity SASL OAUTHBEARER token provider

### DIFF
--- a/content/docs/2.21/scalers/apache-kafka.md
+++ b/content/docs/2.21/scalers/apache-kafka.md
@@ -63,7 +63,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 - `fullMetadata` - When set to `false`, the Kafka client fetches metadata only for the configured `topic` instead of the full cluster. Requires `topic` to be set. Reduces memory significantly on large clusters. (Values: `true`, `false`, Default: `true`, Optional)
 - `partitionLimitation` - Comma separated list of partition ids to scope the scaling on. Allowed patterns are "x,y" and/or ranges "x-y". If set, the calculation of the lag will only take these ids into account.  (Default: All partitions, Optional)
 - `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `oauthbearer`, or `none`, Default: `none`, Optional). This parameter could also be specified in `sasl` in TriggerAuthentication. If specified in both ScaledObject and TriggerAuthentication, the value in ScaledObject takes precedence.
-- `saslTokenProvider` - Kafka SASL token provider when `sasl` is `oauthbearer`. (Values: `bearer`, `aws_msk_iam`, Default: `bearer`, Optional). This parameter could also be specified in `saslTokenProvider` in TriggerAuthentication. If specified in both ScaledObject and TriggerAuthentication, the value in ScaledObject takes precedence.
+- `saslTokenProvider` - Kafka SASL token provider when `sasl` is `oauthbearer`. (Values: `bearer`, `aws_msk_iam`, `azure_workload_identity`, Default: `bearer`, Optional). This parameter could also be specified in `saslTokenProvider` in TriggerAuthentication. If specified in both ScaledObject and TriggerAuthentication, the value in ScaledObject takes precedence.
 - `tls` - To enable SSL auth for Kafka, set this to `enable`. If not set, TLS for Kafka is not used. (Values: `enable`, `disable`, Default: `disable`, Optional). This parameter could also be specified in `tls` in TriggerAuthentication. If specified in both ScaledObject and TriggerAuthentication, the value in ScaledObject takes precedence.
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Values: `true`, `false`, Default: `false`, Optional)
 - `awsRegion` - AWS region of your MSK cluster. (Optional, required for AWS MSK IAM authentication)
@@ -89,7 +89,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 
  You can use `TriggerAuthentication` CRD to configure the authentication by providing `sasl`, `username` and `password`, in case your Kafka cluster has SASL authentication turned on.  If you are using SASL/GSSAPI, you will need to provide Kerberos user, password or keytab, realm and krb5.conf file. If you are using SASL/OAuthbearer you will need to provide `oauthTokenEndpointUri` and `scopes` as required by your OAuth2 provider. You can also add custom SASL extension for OAuthbearer (see [KIP-342](https://cwiki.apache.org/confluence/display/KAFKA/KIP-342%3A+Add+support+for+Custom+SASL+extensions+in+OAuthBearer+authentication)) using `oauthExtensions`.
  If TLS is required you should set `tls` to `enable`. If required for your Kafka configuration, you may also provide a `ca`, `cert`, `key` and `keyPassword`. `cert` and `key` must be specified together.
- Another alternative is to specify `tls` and `sasl` in ScaledObject instead of `tls` and `sasl` in TriggerAuthentication, respectively. If specified in both ScaledObject and TriggerAuthentication, the value in ScaledObject takes precedence. For AWS MSK IAM authentication, you only need to set `awsRegion` in ScaledObject and you also need to enable TLS by setting `tls` to enable.
+ Another alternative is to specify `tls` and `sasl` in ScaledObject instead of `tls` and `sasl` in TriggerAuthentication, respectively. If specified in both ScaledObject and TriggerAuthentication, the value in ScaledObject takes precedence. For AWS MSK IAM authentication, you only need to set `awsRegion` in ScaledObject and you also need to enable TLS by setting `tls` to enable. For Azure AD Workload Identity authentication, you need to set `podIdentity.provider` to `azure-workload` in TriggerAuthentication.
 
 
 **Credential based authentication:**
@@ -97,7 +97,7 @@ partition will be scaled to zero. See the [discussion](https://github.com/kedaco
 **SASL:**
 
 - `sasl` - Kafka SASL auth mode. (Values: `plaintext`, `scram_sha256`, `scram_sha512`, `gssapi`, `oauthbearer` or `none`, Default: `none`, Optional)
-- `saslTokenProvider` - Kafka SASL token provider. (Values: `bearer`, `aws_msk_iam`, Default: `bearer`, Optional).
+- `saslTokenProvider` - Kafka SASL token provider. (Values: `bearer`, `aws_msk_iam`, `azure_workload_identity`, Default: `bearer`, Optional).
 - `username` - Username used for sasl authentication. (Optional)
 - `password` - Password used for sasl authentication. (Optional)
 - `keytab` - Kerberos keytab.  Either `password` or `keytab` is required in case of `gssapi`.  (Optional)
@@ -129,6 +129,10 @@ For authentication, you must use `TriggerAuthentication` CRD to configure the au
 
 - `awsAccessKeyID` - Id of the user.
 - `awsSecretAccessKey` - Access key for the user to authenticate with.
+
+**Azure AD Workload Identity Specific Configuration:**
+
+For authentication, you must use `TriggerAuthentication` CRD to configure [Azure AD Workload Identity](../authentication-providers/azure-ad-workload-identity.md) by setting `podIdentity.provider` to `azure-workload`. You also need to set `scopes` to the OAuth scope requested from your identity provider, and `oauthExtensions` if your broker requires them (for example, Confluent Cloud OAuth/OIDC identity pools require a `logicalCluster` and `identityPoolId` extension).
 
 ### New Consumers and Offset Reset Policy
 
@@ -621,3 +625,67 @@ spec:
     authenticationRef:
       name: keda-trigger-auth-kafka-credential
 ```
+
+#### Your Kafka cluster (e.g. Confluent Cloud) uses Azure AD Workload Identity:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-kafka-secrets
+  namespace: default
+data:
+  sasl: "oauthbearer"
+  saslTokenProvider: "azure_workload_identity"
+  scopes: "api://my-app-id/.default"
+  oauthExtensions: "logicalCluster=lkc-example,identityPoolId=pool-example"
+  tls: "enable"
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-kafka-credential
+  namespace: default
+spec:
+  secretTargetRef:
+  - parameter: sasl
+    name: keda-kafka-secrets
+    key: sasl
+  - parameter: saslTokenProvider
+    name: keda-kafka-secrets
+    key: saslTokenProvider
+  - parameter: scopes
+    name: keda-kafka-secrets
+    key: scopes
+  - parameter: oauthExtensions
+    name: keda-kafka-secrets
+    key: oauthExtensions
+  - parameter: tls
+    name: keda-kafka-secrets
+    key: tls
+  podIdentity:
+    provider: azure-workload
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: kafka-scaledobject
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: azure-functions-deployment
+  pollingInterval: 30
+  triggers:
+  - type: kafka
+    metadata:
+      bootstrapServers: localhost:9092
+      consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
+      topic: test-topic
+      # Optional
+      lagThreshold: "50"
+      offsetResetPolicy: latest
+    authenticationRef:
+      name: keda-trigger-auth-kafka-credential
+```
+
+No client secret is needed here. KEDA gets the OAuth token using the pod's federated identity, the same way described in [Azure AD Workload Identity](../authentication-providers/azure-ad-workload-identity.md).


### PR DESCRIPTION
## What this PR does

This documents a new option for the kafka scaler: `saslTokenProvider: azure_workload_identity`.

This option is added by kedacore/keda#8070 (currently a draft PR, code review in progress). It lets pods authenticate to a Kafka broker (for example Confluent Cloud) using Azure AD Workload Identity, instead of a plain OAuth2 client secret.

## Changes

In `content/docs/2.21/scalers/apache-kafka.md`:

- Added `azure_workload_identity` to the `saslTokenProvider` values list, in both places it is listed (top parameter list and the Authentication Parameters section).
- Added a short note in the Authentication Parameters intro about setting `podIdentity.provider` to `azure-workload`.
- Added an "Azure AD Workload Identity Specific Configuration" section, next to the existing "AWS MSK IAM Specific Configuration" one, explaining `scopes` and `oauthExtensions`.
- Added a full example at the end of the page, showing a `TriggerAuthentication` with `podIdentity.provider: azure-workload` plus `scopes` and `oauthExtensions`, and a `ScaledObject` using it.

I kept the same wording style and parameter format used by the rest of the page (for example the existing AWS MSK IAM section), and linked to the existing [Azure AD Workload Identity](https://keda.sh/docs/2.21/authentication-providers/azure-ad-workload-identity/) provider page instead of repeating its content.

## Why draft

Opening as draft because the code PR (kedacore/keda#8070) is still in review. I will mark this ready once that PR is closer to merging, in case the parameter names or behavior change during review.
