### PR TITLE
fix(docs): fix go_file link for forgejo

### DIFF
--- a/content/docs/2.18/scalers/forgejo.md
+++ b/content/docs/2.18/scalers/forgejo.md
@@ -4,7 +4,7 @@ availability = "v2.18+"
 maintainer = "Community"
 category = "CI/CD"
 description = "Scale applications based on pending jobs on Forgejo repository."
-go_file = "forgejo_scaler"
+go_file = "forgejo_runner_scaler"
 +++
 
 ### Trigger Specification

--- a/content/docs/2.19/scalers/forgejo.md
+++ b/content/docs/2.19/scalers/forgejo.md
@@ -4,7 +4,7 @@ availability = "v2.18+"
 maintainer = "Community"
 category = "CI/CD"
 description = "Scale applications based on pending jobs on Forgejo repository."
-go_file = "forgejo_scaler"
+go_file = "forgejo_runner_scaler"
 +++
 
 ### Trigger Specification

--- a/content/docs/2.20/scalers/forgejo.md
+++ b/content/docs/2.20/scalers/forgejo.md
@@ -4,7 +4,7 @@ availability = "v2.18+"
 maintainer = "Community"
 category = "CI/CD"
 description = "Scale applications based on pending jobs on Forgejo repository."
-go_file = "forgejo_scaler"
+go_file = "forgejo_runner_scaler"
 +++
 
 ### Trigger Specification

--- a/content/docs/2.21/scalers/forgejo.md
+++ b/content/docs/2.21/scalers/forgejo.md
@@ -4,7 +4,7 @@ availability = "v2.18+"
 maintainer = "Community"
 category = "CI/CD"
 description = "Scale applications based on pending jobs on Forgejo repository."
-go_file = "forgejo_scaler"
+go_file = "forgejo_runner_scaler"
 +++
 
 ### Trigger Specification


### PR DESCRIPTION
Reading through the documentation I noticed one of the links was broken.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
