### PR TITLE
GitHub Runner Scaler: Respect paging for jobs

### DIFF
--- a/content/docs/2.21/scalers/github-runner.md
+++ b/content/docs/2.21/scalers/github-runner.md
@@ -126,7 +126,7 @@ GitHub Documentation on Rate Limiting [https://docs.github.com/en/rest/overview/
 | Hosted Appliance | Unlimited | No rate limits apply |
 
 Example: The GitHub API has a rate limit of standard 5000 requests per hour. By default the scaler will make 1 request per repository to get the list of workflows,
-and 1 request per queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
+and 1 request per 100 jobs or fraction thereof in queued workflow to get the list of jobs. If you have 100 repositories, and 10 queued workflows (across all those repos), the scaler will make 110 requests per scaler check (default: 30 secs). This is 3.6% of the hourly rate limit per 30 seconds.
 
 Careful design of how you design your repository request layout and configure the scaler can help reduce the number of API calls. Here are some recommendations:
 
@@ -134,6 +134,8 @@ Careful design of how you design your repository request layout and configure th
 - Setting `enableEtags` to `true` can reduce the rate limit consumption, as this makes [conditional requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate) against the Github API by passing the Etag of the last request to the URL, if a `304: Not modified` response is returned, this will not count against the rate limit. In this case the scaler will use the results from the last query to the URL where the response was `200: Success`.
 
 The github scaler [handles rate limit errors appropriately](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2026-03-10#handle-rate-limit-errors-appropriately) by waiting until X-RateLimit-Reset or Retry-After times until the github API is queried when rate limited. During this time it will return the cached queue length which is updated with each successful request.
+
+To prevent excessive requests to the GitHub API, a hardlimit of 50 pages is hard-coded for both of repositories and jobs, resulting in a maximum of 5000 each.
 
 **Fine-Tuning**
 


### PR DESCRIPTION
…keda/pull/7973 for https://github.com/kedacore/keda/issues/7969.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add documentation for the changes done in https://github.com/kedacore/keda/pull/7973: 

* Multiple GH-API-requests for jobs possible
* Added Hard-Limit for pages

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
