### PR TITLE
ActiveMQ Scaler: Document managementEndpoint from TriggerAuthentication

### DIFF
--- a/content/docs/2.21/scalers/activemq.md
+++ b/content/docs/2.21/scalers/activemq.md
@@ -24,7 +24,7 @@ triggers:
 
 **Parameter list:**
 
-- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`. Can also be set via `TriggerAuthentication` or a resolved environment variable, see [Authentication Parameters](#authentication-parameters) below.
+- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`.
 - `destinationName` - Name of the queue to check for the message count.
 - `brokerName` - Name of the broker as defined in ActiveMQ.
 - `targetQueueSize` - Target value for queue length passed to the scaler. The scaler will cause the replicas to increase if the queue message count is greater than the target value per active replica. (Default: `10`, Optional)
@@ -48,7 +48,7 @@ You can authenticate by using username and password via `TriggerAuthentication` 
 
 **Management Endpoint:**
 
-- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`. (Optional, takes precedence when set in the trigger metadata)
+- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`.
 
 This is useful when the broker address is managed as infrastructure data alongside the credentials, for example synced into a `Secret` by an external secret store, rather than written into each `ScaledObject`.
 

--- a/content/docs/2.21/scalers/activemq.md
+++ b/content/docs/2.21/scalers/activemq.md
@@ -24,7 +24,7 @@ triggers:
 
 **Parameter list:**
 
-- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`.
+- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`. Can also be set via `TriggerAuthentication` or a resolved environment variable, see [Authentication Parameters](#authentication-parameters) below.
 - `destinationName` - Name of the queue to check for the message count.
 - `brokerName` - Name of the broker as defined in ActiveMQ.
 - `targetQueueSize` - Target value for queue length passed to the scaler. The scaler will cause the replicas to increase if the queue message count is greater than the target value per active replica. (Default: `10`, Optional)
@@ -45,6 +45,12 @@ You can authenticate by using username and password via `TriggerAuthentication` 
 
 - `username` - Username for connect to the management endpoint of ActiveMQ.
 - `password` - Password for connect to the management endpoint of ActiveMQ.
+
+**Management Endpoint:**
+
+- `managementEndpoint` - ActiveMQ management endpoint in format: `<hostname>:<port>`. (Optional, takes precedence when set in the trigger metadata)
+
+This is useful when the broker address is managed as infrastructure data alongside the credentials, for example synced into a `Secret` by an external secret store, rather than written into each `ScaledObject`.
 
 ### Example
 


### PR DESCRIPTION
Docs for kedacore/keda#8129, as requested in review there.

That PR gives the ActiveMQ scaler's `managementEndpoint` the parsing order RabbitMQ's `host` already has — `triggerMetadata;authParams;resolvedEnv` — so the broker console address can come from the same Secret as `username`/`password` instead of being written into every `ScaledObject`. Trigger metadata keeps precedence, so existing configurations are unaffected.

Changes to `content/docs/2.21/scalers/activemq.md`:

- the `managementEndpoint` entry in the parameter list now points at the authentication section;
- a **Management Endpoint** block under *Authentication Parameters*, noting it is optional there and that trigger metadata wins when both are set.

Only 2.21 is touched, since that is where the code change lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)