### PR TITLE
docs: fix broken scaler schema links on the Schema page

### DIFF
--- a/content/docs/2.18/operate/schema.md
+++ b/content/docs/2.18/operate/schema.md
@@ -6,7 +6,7 @@ weight = 100
 
 ## Scaler Schema
 
-KEDA provides a separate scaler's schema for third-party usage ([scalers-metadata-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.yaml)/[scalers-metadata-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.json)). The schema file will keep updating according to the scaler's refactor.
+KEDA provides a separate scaler's schema for third-party usage ([scalers-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.yaml)/[scalers-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.json)). The schema file will keep updating according to the scaler's refactor.
 
 *Notice: The schema file still lacks some of the scalers. It will be completed once all scalers are refactored to use the new declarative scaler config.
 

--- a/content/docs/2.19/operate/schema.md
+++ b/content/docs/2.19/operate/schema.md
@@ -6,7 +6,7 @@ weight = 100
 
 ## Scaler Schema
 
-KEDA provides a separate scaler's schema for third-party usage ([scalers-metadata-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.yaml)/[scalers-metadata-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.json)). The schema file will keep updating according to the scaler's refactor.
+KEDA provides a separate scaler's schema for third-party usage ([scalers-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.yaml)/[scalers-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.json)). The schema file will keep updating according to the scaler's refactor.
 
 *Notice: The schema file still lacks some of the scalers. It will be completed once all scalers are refactored to use the new declarative scaler config.
 

--- a/content/docs/2.20/operate/schema.md
+++ b/content/docs/2.20/operate/schema.md
@@ -6,7 +6,7 @@ weight = 100
 
 ## Scaler Schema
 
-KEDA provides a separate scaler's schema for third-party usage ([scalers-metadata-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.yaml)/[scalers-metadata-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.json)). The schema file will keep updating according to the scaler's refactor.
+KEDA provides a separate scaler's schema for third-party usage ([scalers-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.yaml)/[scalers-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.json)). The schema file will keep updating according to the scaler's refactor.
 
 *Notice: The schema file still lacks some of the scalers. It will be completed once all scalers are refactored to use the new declarative scaler config.
 

--- a/content/docs/2.21/operate/schema.md
+++ b/content/docs/2.21/operate/schema.md
@@ -6,7 +6,7 @@ weight = 100
 
 ## Scaler Schema
 
-KEDA provides a separate scaler's schema for third-party usage ([scalers-metadata-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.yaml)/[scalers-metadata-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.json)). The schema file will keep updating according to the scaler's refactor.
+KEDA provides a separate scaler's schema for third-party usage ([scalers-schema.yaml](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.yaml)/[scalers-schema.json](https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.json)). The schema file will keep updating according to the scaler's refactor.
 
 *Notice: The schema file still lacks some of the scalers. It will be completed once all scalers are refactored to use the new declarative scaler config.
 


### PR DESCRIPTION
The Schema page points at two files in the keda repository that do not exist. Both links 404 today:

```
$ curl -sIL -o /dev/null -w '%{http_code}\n' https://github.com/kedacore/keda/blob/main/schema/generated/scalers-metadata-schema.yaml
404
$ curl -sIL -o /dev/null -w '%{http_code}\n' https://github.com/kedacore/keda/blob/main/schema/generated/scalers-schema.yaml
200
```

The generated schema directory contains exactly two files:

```
$ ls schema/generated/
scalers-schema.json
scalers-schema.yaml
```

This corrects both the URL and the link text. Applied across 2.18, 2.19, 2.20 and 2.21, which are all the versions whose Schema page carries the stale name. The four files are byte-identical, so it is the same one-line change in each.

`.htmltest.yml` sets `CheckExternal: false`, so the link-check workflow never resolved these URLs, which is why they went stale unnoticed.

Live today at https://keda.sh/docs/2.20/operate/schema/
