### PR TITLE
Docs: Clarify ScaledObject activation and idle replica behavior

### DIFF
--- a/content/docs/2.19/concepts/scaling-deployments.md
+++ b/content/docs/2.19/concepts/scaling-deployments.md
@@ -162,15 +162,15 @@ Complete language definition of `expr` package can be found [here](https://expr.
 
 KEDA has 2 different phases during the autoscaling process.
 
-- **Activation phase:** The activating (or deactivating) phase is the moment when KEDA (operator) has to decide if the workload should be scaled from/to zero. KEDA takes responsibility for this action based on the result of the scaler `IsActive` function and only applies to 0<->1 scaling. There are use-cases where the activating value (0-1 and 1-0) is totally different than 0, such as workloads scaled with the Prometheus scaler where the values go from -X to X.
-- **Scaling phase:** The scaling phase is the moment when KEDA has decided to scale out to 1 instance and now it is the HPA controller who takes the scaling decisions based on the configuration defined in the generated HPA (from ScaledObject data) and the metrics exposed by KEDA (metrics server). This phase applies the to 1<->N scaling.
+- **Activation phase:** KEDA (operator) decides whether to scale the workload from or to zero based on trigger activity. When activating a workload from zero, KEDA sets the replica count to [`minReplicaCount`](../reference/scaledobject-spec.md#minreplicacount) if it is greater than 0, or to 1 otherwise. This initial replica count does not depend on the metric value that caused activation. Activation thresholds can differ from zero, such as with Prometheus metrics whose values range from -X to X.
+- **Scaling phase:** Once the workload has replicas, the HPA controller makes scaling decisions based on the configuration in the generated HPA and the metrics exposed by KEDA (metrics server). The HPA scales within its configured minimum and maximum replica counts.
 
 KEDA allows you to specify different values for each scenario:
 
 - **Activation:** Defines when the scaler is active or not and scales from/to 0 based on it.
-- **Scaling:** Defines the target value to scale the workload from 1 to _n_ instances and vice versa. To achieve this, KEDA passes the target value to the Horizontal Pod Autoscaler (HPA) and the built-in HPA controller will handle all the autoscaling.
+- **Scaling:** Defines the target metric value used by the HPA to calculate the desired replica count.
 
-> ⚠️ **NOTE:** If the minimum replicas is >= 1, the scaler is always active and the activation value will be ignored.
+> ⚠️ **NOTE:** If `minReplicaCount` is greater than 0 and `idleReplicaCount` is not set, inactive triggers do not cause the workload to scale to zero. With [`idleReplicaCount: 0`](../reference/scaledobject-spec.md#idlereplicacount), KEDA can scale the workload to zero after the [`cooldownPeriod`](../reference/scaledobject-spec.md#cooldownperiod) and back to `minReplicaCount` when a trigger becomes active.
 
 Each scaler defines parameters for their use-cases, but the activation will always be the same as the scaling value, appended by the prefix `activation` (ie: `threshold` for scaling and `activationThreshold` for activation).
 

--- a/content/docs/2.19/reference/scaledobject-spec.md
+++ b/content/docs/2.19/reference/scaledobject-spec.md
@@ -129,6 +129,8 @@ If this property is set, KEDA will scale the resource down to this number of rep
 
 Minimum number of replicas KEDA will scale the resource down to. By default, it's scale to zero, but you can use it with some other value as well.
 
+When `minReplicaCount` is greater than 0, KEDA uses that value as `minReplicas` in the generated HPA. If `minReplicaCount` is omitted or set to 0, the HPA's `minReplicas` is 1. KEDA manages scaling to zero separately, as described in [Activating and Scaling thresholds](../concepts/scaling-deployments.md#activating-and-scaling-thresholds).
+
 ## maxReplicaCount
 
 ```yaml

--- a/content/docs/2.20/concepts/scaling-deployments.md
+++ b/content/docs/2.20/concepts/scaling-deployments.md
@@ -192,15 +192,15 @@ Complete language definition of `expr` package can be found [here](https://expr.
 
 KEDA has 2 different phases during the autoscaling process.
 
-- **Activation phase:** The activating (or deactivating) phase is the moment when KEDA (operator) has to decide if the workload should be scaled from/to zero. KEDA takes responsibility for this action based on the result of the scaler `IsActive` function and only applies to 0<->1 scaling. There are use-cases where the activating value (0-1 and 1-0) is totally different than 0, such as workloads scaled with the Prometheus scaler where the values go from -X to X.
-- **Scaling phase:** The scaling phase is the moment when KEDA has decided to scale out to 1 instance and now it is the HPA controller who takes the scaling decisions based on the configuration defined in the generated HPA (from ScaledObject data) and the metrics exposed by KEDA (metrics server). This phase applies the to 1<->N scaling.
+- **Activation phase:** KEDA (operator) decides whether to scale the workload from or to zero based on trigger activity. When activating a workload from zero, KEDA sets the replica count to [`minReplicaCount`](../reference/scaledobject-spec.md#minreplicacount) if it is greater than 0, or to 1 otherwise. This initial replica count does not depend on the metric value that caused activation. Activation thresholds can differ from zero, such as with Prometheus metrics whose values range from -X to X.
+- **Scaling phase:** Once the workload has replicas, the HPA controller makes scaling decisions based on the configuration in the generated HPA and the metrics exposed by KEDA (metrics server). The HPA scales within its configured minimum and maximum replica counts.
 
 KEDA allows you to specify different values for each scenario:
 
 - **Activation:** Defines when the scaler is active or not and scales from/to 0 based on it.
-- **Scaling:** Defines the target value to scale the workload from 1 to _n_ instances and vice versa. To achieve this, KEDA passes the target value to the Horizontal Pod Autoscaler (HPA) and the built-in HPA controller will handle all the autoscaling.
+- **Scaling:** Defines the target metric value used by the HPA to calculate the desired replica count.
 
-> ⚠️ **NOTE:** If the minimum replicas is >= 1, the scaler is always active and the activation value will be ignored.
+> ⚠️ **NOTE:** If `minReplicaCount` is greater than 0 and `idleReplicaCount` is not set, inactive triggers do not cause the workload to scale to zero. With [`idleReplicaCount: 0`](../reference/scaledobject-spec.md#idlereplicacount), KEDA can scale the workload to zero after the [`cooldownPeriod`](../reference/scaledobject-spec.md#cooldownperiod) and back to `minReplicaCount` when a trigger becomes active.
 
 Each scaler defines parameters for their use-cases, but the activation will always be the same as the scaling value, appended by the prefix `activation` (ie: `threshold` for scaling and `activationThreshold` for activation).
 

--- a/content/docs/2.20/reference/scaledobject-spec.md
+++ b/content/docs/2.20/reference/scaledobject-spec.md
@@ -129,6 +129,8 @@ If this property is set, KEDA will scale the resource down to this number of rep
 
 Minimum number of replicas KEDA will scale the resource down to. By default, it's scale to zero, but you can use it with some other value as well.
 
+When `minReplicaCount` is greater than 0, KEDA uses that value as `minReplicas` in the generated HPA. If `minReplicaCount` is omitted or set to 0, the HPA's `minReplicas` is 1. KEDA manages scaling to zero separately, as described in [Activating and Scaling thresholds](../concepts/scaling-deployments.md#activating-and-scaling-thresholds).
+
 ## maxReplicaCount
 
 ```yaml

--- a/content/docs/2.21/concepts/scaling-deployments.md
+++ b/content/docs/2.21/concepts/scaling-deployments.md
@@ -192,15 +192,15 @@ Complete language definition of `expr` package can be found [here](https://expr.
 
 KEDA has 2 different phases during the autoscaling process.
 
-- **Activation phase:** The activating (or deactivating) phase is the moment when KEDA (operator) has to decide if the workload should be scaled from/to zero. KEDA takes responsibility for this action based on the result of the scaler `IsActive` function and only applies to 0<->1 scaling. There are use-cases where the activating value (0-1 and 1-0) is totally different than 0, such as workloads scaled with the Prometheus scaler where the values go from -X to X.
-- **Scaling phase:** The scaling phase is the moment when KEDA has decided to scale out to 1 instance and now it is the HPA controller who takes the scaling decisions based on the configuration defined in the generated HPA (from ScaledObject data) and the metrics exposed by KEDA (metrics server). This phase applies the to 1<->N scaling.
+- **Activation phase:** KEDA (operator) decides whether to scale the workload from or to zero based on trigger activity. When activating a workload from zero, KEDA sets the replica count to [`minReplicaCount`](../reference/scaledobject-spec.md#minreplicacount) if it is greater than 0, or to 1 otherwise. This initial replica count does not depend on the metric value that caused activation. Activation thresholds can differ from zero, such as with Prometheus metrics whose values range from -X to X.
+- **Scaling phase:** Once the workload has replicas, the HPA controller makes scaling decisions based on the configuration in the generated HPA and the metrics exposed by KEDA (metrics server). The HPA scales within its configured minimum and maximum replica counts.
 
 KEDA allows you to specify different values for each scenario:
 
 - **Activation:** Defines when the scaler is active or not and scales from/to 0 based on it.
-- **Scaling:** Defines the target value to scale the workload from 1 to _n_ instances and vice versa. To achieve this, KEDA passes the target value to the Horizontal Pod Autoscaler (HPA) and the built-in HPA controller will handle all the autoscaling.
+- **Scaling:** Defines the target metric value used by the HPA to calculate the desired replica count.
 
-> ⚠️ **NOTE:** If the minimum replicas is >= 1, the scaler is always active and the activation value will be ignored.
+> ⚠️ **NOTE:** If `minReplicaCount` is greater than 0 and `idleReplicaCount` is not set, inactive triggers do not cause the workload to scale to zero. With [`idleReplicaCount: 0`](../reference/scaledobject-spec.md#idlereplicacount), KEDA can scale the workload to zero after the [`cooldownPeriod`](../reference/scaledobject-spec.md#cooldownperiod) and back to `minReplicaCount` when a trigger becomes active.
 
 Each scaler defines parameters for their use-cases, but the activation will always be the same as the scaling value, appended by the prefix `activation` (ie: `threshold` for scaling and `activationThreshold` for activation).
 

--- a/content/docs/2.21/reference/scaledobject-spec.md
+++ b/content/docs/2.21/reference/scaledobject-spec.md
@@ -131,6 +131,8 @@ If this property is set, KEDA will scale the resource down to this number of rep
 
 Minimum number of replicas KEDA will scale the resource down to. By default, it's scale to zero, but you can use it with some other value as well.
 
+When `minReplicaCount` is greater than 0, KEDA uses that value as `minReplicas` in the generated HPA. If `minReplicaCount` is omitted or set to 0, the HPA's `minReplicas` is 1. KEDA manages scaling to zero separately, as described in [Activating and Scaling thresholds](../concepts/scaling-deployments.md#activating-and-scaling-thresholds).
+
 ## maxReplicaCount
 
 ```yaml


### PR DESCRIPTION
The activation section describes only `0 <-> 1` scaling and says that a positive `minReplicaCount` makes the scaler always active. This overlooks `idleReplicaCount: 0`: a workload with `minReplicaCount: 2` can scale to zero when inactive and reactivate directly at 2 replicas.

Clarify how KEDA chooses the initial replica count independently of the metric value, distinguish activation from subsequent HPA scaling, and qualify the note about positive minimum replicas with the idle-replica exception. Link to the existing field references instead of adding another configuration example. Apply the same clarification to versions 2.19, 2.20, and 2.21.

The explanation follows the existing [`scaleFromZeroOrIdle` implementation](https://github.com/kedacore/keda/blob/v2.20.0/pkg/scaling/executor/scale_scaledobjects.go#L228-L240) and the [`TestScaleToIdleReplicasWhenNotActive` / `TestScaleFromIdleToMinReplicasWhenActive` test cases](https://github.com/kedacore/keda/blob/v2.20.0/pkg/scaling/executor/scale_scaledobjects_test.go#L212-L329).

Validation:

- `npm run check:links` passed, including the Hugo build and internal link checks across 2,174 documents.
- `git diff --check` passed.
- Confirmed the corrected section and reference anchors in all three generated pages.
- Cross-checked the behavior against KEDA v2.19.0, v2.20.0, and main. KEDA unit and end-to-end tests were not run for this documentation-only change.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
